### PR TITLE
Add a `wp_parsely_post_tags` filter for tags

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -523,6 +523,7 @@ class Parsely {
     */
     private function get_tags_as_string($postId, $parselyOptions) {
         $wpTags = wp_get_post_tags($postId);
+        $wpTags = apply_filters( 'wp_parsely_post_tags', $wpTags, $postId );
         $tags = array();
         foreach ( $wpTags as $wpTag ) {
             if ( $parselyOptions['lowercase_tags'] === true ) {


### PR DESCRIPTION
Allows developers to adjust the tag list, for example adding all terms from custom taxonomies.

Example usage:

```php
function add_all_tags_to_parsely( $wpTags, $postId ){
	$taxonomies = get_object_taxonomies( 'post' );
	// Remove the default taxonomies which are already accounted for
	$taxonomies = array_diff( $taxonomies, array( 'category', 'post_tag' ) );
	$terms      = wp_get_post_terms( $postId, $taxonomies );

	return array_merge( $terms, $wpTags );
}
add_filter( 'wp_parsely_post_tags', 'add_all_tags_to_parsely', 10, 2 );
```