### PR TITLE
Add a parsely_post_authors filter Add a parsely_post_authors filter

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -686,7 +686,6 @@ class Parsely {
             $authors = array(get_user_by('id', $post->post_author));
         }
         $authors = array_map(array($this, 'get_author_name'), $authors);
-        $authors = array_map(array($this, 'get_author_name'), $authors);
         $authors = apply_filters( 'wp_parsely_post_authors', $authors, $post );
         $authors = array_map(array($this, 'get_clean_parsely_page_value'), $authors);
         return $authors;

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -686,8 +686,10 @@ class Parsely {
             $authors = array(get_user_by('id', $post->post_author));
         }
         $authors = array_map(array($this, 'get_author_name'), $authors);
+        $authors = array_map(array($this, 'get_author_name'), $authors);
+        $authors = apply_filters( 'wp_parsely_post_authors', $authors, $post );
         $authors = array_map(array($this, 'get_clean_parsely_page_value'), $authors);
-        return apply_filters( 'wp_parsely_post_authors', $authors, $post );
+        return $authors;
     }
 
     /* sanitize content

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -687,7 +687,7 @@ class Parsely {
         }
         $authors = array_map(array($this, 'get_author_name'), $authors);
         $authors = array_map(array($this, 'get_clean_parsely_page_value'), $authors);
-        return apply_filters( 'parsely_post_authors', $authors, $post );
+        return apply_filters( 'wp_parsely_post_authors', $authors, $post );
     }
 
     /* sanitize content

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -687,7 +687,7 @@ class Parsely {
         }
         $authors = array_map(array($this, 'get_author_name'), $authors);
         $authors = array_map(array($this, 'get_clean_parsely_page_value'), $authors);
-        return $authors;
+        return apply_filters( 'parsely_post_authors', $authors, $post );
     }
 
     /* sanitize content


### PR DESCRIPTION
Allows themes to extend the reported authors, for example adding authors from a custom taxonomy.