### PR TITLE
Add a 'wp_parsely_post_category' filter

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -599,8 +599,9 @@ class Parsely {
             $category = 'Uncategorized';
         }
 
+        $category = apply_filters( 'wp_parsely_post_category', $category, $postObj, $parselyOptions );
         $category = $this->get_clean_parsely_page_value( $category );
-        return apply_filters( 'wp_parsely_post_category', $category, $postObj, $parselyOptions );
+        return $category;
     }
 
     /**

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -600,7 +600,7 @@ class Parsely {
         }
 
         $category = $this->get_clean_parsely_page_value( $category );
-        return apply_filter( 'wp_parsely_post_category', $category, $postObj, $parselyOptions );
+        return apply_filters( 'wp_parsely_post_category', $category, $postObj, $parselyOptions );
     }
 
     /**

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -599,7 +599,8 @@ class Parsely {
             $category = 'Uncategorized';
         }
 
-        return $this->get_clean_parsely_page_value($category);
+        $category = $this->get_clean_parsely_page_value( $category );
+        return apply_filter( 'wp_parsely_post_category', $category, $postObj, $parselyOptions );
     }
 
     /**


### PR DESCRIPTION
Allows developers to customize the category reported for a post.