### PR TITLE
Bugfix: smarter detection for multisite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,21 @@ branches:
     - master
 
 php:
-  - 5.3
   - 5.6
+  - 7.0
+  - 7.1
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
-  - WP_VERSION=4.0 WP_MULTISITE=0
+  - WP_VERSION=4.5 WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=1
+  - WP_VERSION=4.5 WP_MULTISITE=1
 
 matrix:
   include:
-    - php: 5.3
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,19 @@ branches:
 
 php:
   - 5.6
+  - 7.0
   - 7.1
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
-  - WP_VERSION=4.5 WP_MULTISITE=0
+  - WP_VERSION=4.7 WP_MULTISITE=0
   - WP_VERSION=latest WP_MULTISITE=1
-  - WP_VERSION=4.5 WP_MULTISITE=1
+  - WP_VERSION=4.7 WP_MULTISITE=1
 
 matrix:
   include:
     - php: 5.6
+    - php: 7.0
     - php: 7.1
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ branches:
 
 php:
   - 5.6
-  - 7.0
   - 7.1
 
 env:
@@ -23,7 +22,6 @@ env:
 matrix:
   include:
     - php: 5.6
-    - php: 7.0
     - php: 7.1
 
 before_script:

--- a/parsely-javascript.php
+++ b/parsely-javascript.php
@@ -1,5 +1,4 @@
 <?php if(!isset($parselyOptions['apikey']) || empty($parselyOptions['apikey'])) { return; } ?>
-<?php if(!$parselyOptions['track_authenticated_users'] && is_user_logged_in()) { return; } ?>
 
 <!-- START Parse.ly Include: Standard -->
 <div id="parsely-root" style="display: none">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
 	<php>
 		<server name="SERVER_PORT" value="80"/>
         <server name="HTTP_HOST" value="localhost"/>
+        <server name="REMOTE_ADDR" value="127.0.0.1"/>
 	</php>
 	<testsuites>
 		<testsuite>

--- a/tests/test-wp-parsely.php
+++ b/tests/test-wp-parsely.php
@@ -292,7 +292,7 @@ class SampleTest extends WP_UnitTestCase {
         $options['track_authenticated_users'] = FALSE;
         update_option('parsely', $options);
         $new_user = $this->create_test_user('bill_brasky');
-        wp_set_current_user($new_user->id);
+        wp_set_current_user($new_user);
         ob_start();
         echo self::$parsely->insert_parsely_javascript();
         $output = ob_get_clean();

--- a/tests/test-wp-parsely.php
+++ b/tests/test-wp-parsely.php
@@ -58,6 +58,7 @@ class SampleTest extends WP_UnitTestCase {
     protected static $parsely;
     protected static $custom_taxonomy;
     protected static $taxonomy_factory;
+    protected static $parsely_html;
 
     public static function setUpBeforeClass() {
     }
@@ -74,14 +75,7 @@ class SampleTest extends WP_UnitTestCase {
             'custom_taxonomy_section' => 'category',
             'lowercase_tags' => true);
         update_option('parsely', $optionDefaults);
-    }
-
-
-    function test_parsely_tag() {
-        ob_start();
-        echo self::$parsely->insert_parsely_javascript();
-        $output = ob_get_clean();
-        $html = "<div id=\"parsely-root\" style=\"display: none\">
+        self::$parsely_html = "<div id=\"parsely-root\" style=\"display: none\">
   <div id=\"parsely-cfg\" data-parsely-site=\"blog.parsely.com\"></div>
 </div>
 <script data-cfasync=\"false\">
@@ -94,7 +88,14 @@ class SampleTest extends WP_UnitTestCase {
   e = d.createElement(s); e.id = i; e.async = true;
   e.setAttribute('data-cfasync', 'false'); e.src = h+\"//\"+u+\"/p.js\"; r.appendChild(e);
 })(\"script\", \"parsely\", document);";
-        $this->assertTrue(strpos($output, $html) > 0);
+    }
+
+
+    function test_parsely_tag() {
+        ob_start();
+        echo self::$parsely->insert_parsely_javascript();
+        $output = ob_get_clean();
+        $this->assertTrue(strpos($output, self::$parsely_html) > 0);
     }
 
 
@@ -296,19 +297,6 @@ class SampleTest extends WP_UnitTestCase {
         ob_start();
         echo self::$parsely->insert_parsely_javascript();
         $output = ob_get_clean();
-        $html = "<div id=\"parsely-root\" style=\"display: none\">
-          <div id=\"parsely-cfg\" data-parsely-site=\"blog.parsely.com\"></div>
-        </div>
-        <script data-cfasync=\"false\">
-        (function(s, p, d) {
-          var h=d.location.protocol, i=p+\"-\"+s,
-              e=d.getElementById(i), r=d.getElementById(p+\"-root\"),
-              u=h===\"https:\"?\"d1z2jf7jlzjs58.cloudfront.net\"
-              :\"static.\"+p+\".com\";
-          if (e) return;
-          e = d.createElement(s); e.id = i; e.async = true;
-          e.setAttribute('data-cfasync', 'false'); e.src = h+\"//\"+u+\"/p.js\"; r.appendChild(e);
-        })(\"script\", \"parsely\", document);";
-                $this->assertTrue(strpos($output, $html) == false);
+        $this->assertFalse(strpos($output, self::$parsely_html) > 0);
     }
 }

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -954,9 +954,9 @@ class Parsely {
 
     public function parsely_is_user_logged_in() {
         // can't use $blog_id here because it futzes with the global $blog_id
-        $blog = get_current_blog_id();
-        $user = get_current_user_id();
-        return is_user_member_of_blog($user, $blog);
+        $current_blog_id = get_current_blog_id();
+        $current_user_id = get_current_user_id();
+        return is_user_member_of_blog($current_user_id, $current_blog_id);
     }
 }
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -367,7 +367,7 @@ class Parsely {
         $parselyOptions = $this->get_options();
 
         // If we don't have an API key or if we aren't supposed to show to logged in users, there's no need to proceed.
-        if ( empty($parselyOptions['apikey']) || (!$parselyOptions['track_authenticated_users'] && is_user_logged_in()) ) {
+        if ( empty($parselyOptions['apikey']) || (!$parselyOptions['track_authenticated_users'] && $this->parsely_is_user_logged_in()) ) {
             return '';
         }
 
@@ -499,6 +499,9 @@ class Parsely {
         $display = TRUE;
 
         if ( is_single() && $post->post_status != 'publish' ) {
+            $display = FALSE;
+        }
+        if (!$parselyOptions['track_authenticated_users'] && $this->parsely_is_user_logged_in()) {
             $display = FALSE;
         }
         if ( $display ) {

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -949,8 +949,11 @@ class Parsely {
         return $analytics;
     }
 
-    public function parsely_is_user_logged_in($user) {
-
+    public function parsely_is_user_logged_in() {
+        // can't use $blog_id here because it futzes with the global $blog_id
+        $blog = get_current_blog_id();
+        $user = get_current_user_id();
+        return is_user_member_of_blog($user, $blog);
     }
 }
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -948,6 +948,10 @@ class Parsely {
 
         return $analytics;
     }
+
+    public function parsely_is_user_logged_in($user) {
+
+    }
 }
 
 


### PR DESCRIPTION
There was an issue people were running into where is_user_logged_in() would give a false positive for users who were logged into other wordpress.com domains (for example, is_user_logged_in() would return true for someone visiting a.wordpress.com if they were logged in to b.wordpress.com).

Not sure if this is a bug on WP's end or ours (this doesn't seem like expected behavior) but we can go ahead and make that check a little smarter: this checks to see if the user is actually a member of the current blog they're on instead of just a generic is_user_logged_in() call. 