### PR TITLE
Enhancement: track custom post types

### DIFF
--- a/tests/test-wp-parsely.php
+++ b/tests/test-wp-parsely.php
@@ -80,7 +80,9 @@ class SampleTest extends WP_UnitTestCase {
             'cats_as_tags' => false,
             'track_authenticated_users' => true,
             'custom_taxonomy_section' => 'category',
-            'lowercase_tags' => true);
+            'lowercase_tags' => true,
+            'track_post_types' => array('post'),
+            'track_page_types' => array('page'));
         update_option('parsely', $optionDefaults);
         self::$parsely_html = <<<PARSELYJS
 <div id="parsely-root" style="display: none">

--- a/tests/test-wp-parsely.php
+++ b/tests/test-wp-parsely.php
@@ -11,12 +11,13 @@
  */
 class SampleTest extends WP_UnitTestCase {
 
-    function create_test_post_array() {
+    function create_test_post_array($post_type = 'post') {
         $post_array = array(
             'post_title' => 'Sample Parsely Post',
             'post_author' => 1,
             'post_content' => 'Some sample content just to have here',
-            'post_status' => 'publish');
+            'post_status' => 'publish',
+            'post_type' => $post_type);
         return $post_array;
     }
 
@@ -102,6 +103,9 @@ PARSELYJS;
 
     function test_parsely_tag() {
         ob_start();
+        $post_array = $this->create_test_post_array();
+        $post = $this->factory->post->create($post_array);
+        $this->go_to('/?p=' . $post);
         echo self::$parsely->insert_parsely_javascript();
         $output = ob_get_clean();
         $this->assertContains(self::$parsely_html, $output);

--- a/tests/test-wp-parsely.php
+++ b/tests/test-wp-parsely.php
@@ -72,6 +72,7 @@ class SampleTest extends WP_UnitTestCase {
 
     public function setUp() {
         parent::setUp();
+        register_post_type('thinkpiece');
         self::$parsely = new Parsely();
         $optionDefaults = array(
             'apikey' => 'blog.parsely.com',
@@ -123,6 +124,19 @@ PARSELYJS;
         $this->go_to('/?p=' . $post);
         $ppage = self::$parsely->insert_parsely_page();
         $this->assertTrue($ppage['@type'] == 'NewsArticle');
+    }
+
+    function test_parsely_tag_custom_post() {
+        $post_array = $this->create_test_post_array('thinkpiece');
+        $post = $this->factory->post->create($post_array);
+        $options = get_option('parsely');
+        $options['track_post_types'] = array('thinkpiece');
+        $this->go_to('/?p=' . $post);
+        ob_start();
+        echo self::$parsely->insert_parsely_javascript();
+        $output = ob_get_clean();
+        $this->assertContains(self::$parsely_html, $output);
+
     }
 
     function test_parsely_categories()

--- a/tests/test-wp-parsely.php
+++ b/tests/test-wp-parsely.php
@@ -334,6 +334,9 @@ PARSELYJS;
         // update both blog options
         update_option('parsely', $options);
         update_blog_option($second_blog, 'parsely', $options);
+        $post_array = $this->create_test_post_array();
+        $post = $this->factory->post->create($post_array);
+        $this->go_to('/?p=' . $post);
 
         $this->assertEquals(get_current_blog_id(), $first_blog);
         $this->assertTrue(is_user_member_of_blog($new_user, $first_blog));

--- a/tests/test-wp-parsely.php
+++ b/tests/test-wp-parsely.php
@@ -72,7 +72,6 @@ class SampleTest extends WP_UnitTestCase {
 
     public function setUp() {
         parent::setUp();
-        register_post_type('thinkpiece');
         self::$parsely = new Parsely();
         $optionDefaults = array(
             'apikey' => 'blog.parsely.com',
@@ -124,19 +123,6 @@ PARSELYJS;
         $this->go_to('/?p=' . $post);
         $ppage = self::$parsely->insert_parsely_page();
         $this->assertTrue($ppage['@type'] == 'NewsArticle');
-    }
-
-    function test_parsely_tag_custom_post() {
-        $post_array = $this->create_test_post_array('thinkpiece');
-        $post = $this->factory->post->create($post_array);
-        $options = get_option('parsely');
-        $options['track_post_types'] = array('thinkpiece');
-        $this->go_to('/?p=' . $post);
-        ob_start();
-        echo self::$parsely->insert_parsely_javascript();
-        $output = ob_get_clean();
-        $this->assertContains(self::$parsely_html, $output);
-
     }
 
     function test_parsely_categories()

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -52,7 +52,8 @@ class Parsely {
                                         'cats_as_tags' => false,
                                         'track_authenticated_users' => true,
                                         'lowercase_tags' => true,
-                                        'force_https_canonicals' => false);
+                                        'force_https_canonicals' => false,
+                                        'track_types' => ['post']);
     private $implementationOpts = array('standard' => 'Standard',
                                         'dom_free' => 'DOM-Free');
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -621,7 +621,7 @@ class Parsely {
 
             if ($multiple) {
                 $selected = in_array($val, $options[$args['option_key']]);
-                $tag .= selected($selected) . '>';
+                $tag .= selected($selected, true, false) . '>';
             }
             else {
                 $tag .= selected($selected, $key, false) . '>';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -326,6 +326,12 @@ class Parsely {
                                    'Your Parse.ly Site ID looks incorrect, it should look like "example.com".');  
 
         }
+        // these can't be null, if somebody accidentally deselected them just reset to default
+        if (!isset( $input['track_post_types']) || !isset($input['track_page_types'])) {
+            $input['track_post_types'] = array('post');
+            $input['track_page_types'] = array('page');
+
+        }
         $input['track_post_types'] = $this->validate_option_array($input['track_post_types'], 'track_post_types');
         $input['track_page_types'] = $this->validate_option_array($input['track_page_types'], 'track_page_types');
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -570,6 +570,7 @@ class Parsely {
 
         global $post;
         $display = TRUE;
+        echo var_dump($post);
         if ( in_array(get_post_type(), $parselyOptions['track_post_types']) && $post->post_status != 'publish' ) {
             $display = FALSE;
         }

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -54,7 +54,7 @@ class Parsely {
                                         'lowercase_tags' => true,
                                         'force_https_canonicals' => false,
                                         'track_post_types' => array('post'),
-                                        'track_page_types' => array('page'));
+                                        'track_page_types' => array('page'),
                                         'disable_javascript' => false);
 
     private $implementationOpts = array('standard' => 'Standard',

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -453,7 +453,7 @@ class Parsely {
             "@type" => "WebPage"
         );
         $currentURL = $this->get_current_url();
-        if ( is_single() && $post->post_status == 'publish' ) {
+        if ( in_array(get_post_type(), $parselyOptions['track_post_types']) && $post->post_status == 'publish') {
             $authors    = $this->get_author_names($post);
             $category   = $this->get_category_name($post, $parselyOptions);
             $postId     = $parselyOptions['content_id_prefix'] . (string)get_the_ID();
@@ -518,7 +518,7 @@ class Parsely {
                 'name' => get_bloginfo('name')
             ); 
             $parselyPage['keywords']       = $tags;
-        } elseif ( is_page() && $post->post_status == 'publish' ) {
+        } elseif ( in_array(get_post_type(), $parselyOptions['track_page_types']) && $post->post_status == 'publish' ) {
             $parselyPage['headline']       = $this->get_clean_parsely_page_value(get_the_title());
             $parselyPage['url']            = $this->get_current_url('post');
         } elseif ( is_author() ) {
@@ -571,7 +571,7 @@ class Parsely {
         global $post;
         $display = TRUE;
 
-        if ( is_single() && $post->post_status != 'publish' ) {
+        if ( in_array(get_post_type(), $parselyOptions['track_post_types']) && $post->post_status != 'publish' ) {
             $display = FALSE;
         }
         if (!$parselyOptions['track_authenticated_users'] && $this->parsely_is_user_logged_in()) {

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -570,14 +570,13 @@ class Parsely {
 
         global $post;
         $display = TRUE;
-
         if ( in_array(get_post_type(), $parselyOptions['track_post_types']) && $post->post_status != 'publish' ) {
             $display = FALSE;
         }
         if (!$parselyOptions['track_authenticated_users'] && $this->parsely_is_user_logged_in()) {
             $display = FALSE;
         }
-        if (!in_array(get_post_type(), $parselyOptions['track_post_types']) || !in_array(get_post_type(), $parselyOptions['track_page_types'])) {
+        if (!in_array(get_post_type(), $parselyOptions['track_post_types']) && !in_array(get_post_type(), $parselyOptions['track_page_types'])) {
             $display = FALSE;
         }
         if ( $display ) {

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -569,6 +569,9 @@ class Parsely {
         if (!$parselyOptions['track_authenticated_users'] && $this->parsely_is_user_logged_in()) {
             $display = FALSE;
         }
+        if (!in_array(get_post_type(), $parselyOptions['track_post_types']) || !in_array(get_post_type(), $parselyOptions['track_page_types'])) {
+            $display = FALSE;
+        }
         if ( $display ) {
             include('parsely-javascript.php');
         }

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -53,7 +53,8 @@ class Parsely {
                                         'track_authenticated_users' => true,
                                         'lowercase_tags' => true,
                                         'force_https_canonicals' => false,
-                                        'track_types' => ['post']);
+                                        'track_post_types' => ['post'],
+                                        'track_page_types' => ['page']);
     private $implementationOpts = array('standard' => 'Standard',
                                         'dom_free' => 'DOM-Free');
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -327,10 +327,12 @@ class Parsely {
 
         }
         // these can't be null, if somebody accidentally deselected them just reset to default
-        if (!isset( $input['track_post_types']) || !isset($input['track_page_types'])) {
+        if (!isset( $input['track_post_types'])) {
             $input['track_post_types'] = array('post');
-            $input['track_page_types'] = array('page');
 
+        }
+        if (!isset( $input['track_page_types'])){
+            $input['track_page_types'] = array('page');
         }
         $input['track_post_types'] = $this->validate_option_array($input['track_post_types'], 'track_post_types');
         $input['track_page_types'] = $this->validate_option_array($input['track_page_types'], 'track_page_types');

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -270,6 +270,32 @@ class Parsely {
                 'help_text' => $h,
                 'requires_recrawl' => true));
 
+        // Allow use of custom taxonomy to populate articleSection in parselyPage; defaults to category
+        $h = 'By default, Parsely only tracks the default post type as a post page. ' .
+                'If you want to track custom post types, select them here!<br>';
+        add_settings_field('track_post_types',
+            'Post Types To Track  <div class="help-icons"></div>',
+            array($this, 'print_select_tag'),
+            Parsely::MENU_SLUG, 'optional_settings',
+            array('option_key' => 'track_post_types',
+                'help_text' => $h,
+                // filter Wordpress taxonomies under the hood that should not appear in dropdown
+                'select_options' => get_post_types(),
+                'requires_recrawl' => true));
+
+        // Allow use of custom taxonomy to populate articleSection in parselyPage; defaults to category
+        $h = 'By default, Parsely only tracks the default page type as a non-post page. ' .
+            'If you want to track custom post types as non-post pages, select them here!<br>';
+        add_settings_field('track_page_types',
+            'Post Types To Track  <div class="help-icons"></div>',
+            array($this, 'print_select_tag'),
+            Parsely::MENU_SLUG, 'optional_settings',
+            array('option_key' => 'track_page_types',
+                'help_text' => $h,
+                // filter Wordpress taxonomies under the hood that should not appear in dropdown
+                'select_options' => get_post_types(),
+                'requires_recrawl' => true));
+
         // Dynamic tracking note
         add_settings_field('dynamic_tracking_note', 'Note: ',
                             array($this, 'print_dynamic_tracking_note'),

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -288,7 +288,7 @@ class Parsely {
         $h = 'By default, Parsely only tracks the default page type as a non-post page. ' .
             'If you want to track custom post types as non-post pages, select them here!<br>';
         add_settings_field('track_page_types',
-            'Post Types To Track  <div class="help-icons"></div>',
+            'Page Types To Track  <div class="help-icons"></div>',
             array($this, 'print_select_tag'),
             Parsely::MENU_SLUG, 'optional_settings',
             array('option_key' => 'track_page_types',


### PR DESCRIPTION
Many publishers use custom post types to differentiate between different types of content. This PR enables publishers to select which kinds of posts and pages they want to track as posts vs. non-posts, giving them greater flexibility in their data collection!

Note that there are no new tests for this functionality: I am painfully aware there should be, but I can't figure out how to get register_post_type to work in tests. Given the timing of 1.11, I figured it was better to get the functionality out (I tested it manually) rather than be held up by a couple of minor tests for a few more days. If anybody wants to implement those as a separate PR that would be excellent!