### PR TITLE
Bugfix/archive page canonicals

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -189,7 +189,10 @@ class Parsely {
 				'option_key'       => 'meta_type',
 				'help_text'        => $h,
 				// filter Wordpress taxonomies under the hood that should not appear in dropdown
-				'select_options'   => array( 'json_ld' => 'json_ld', 'repeated_metas' => 'repeated_metas' ),
+				'select_options'   => array(
+					'json_ld'        => 'json_ld',
+					'repeated_metas' => 'repeated_metas',
+				),
 				'requires_recrawl' => true,
 				'multiple'         => false,
 			)

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -4,7 +4,7 @@ Plugin Name: Parse.ly
 Plugin URI: http://www.parsely.com/
 Description: This plugin makes it a snap to add Parse.ly tracking code to your WordPress blog.
 Author: Mike Sukmanowsky ( mike@parsely.com )
-Version: 1.12
+Version: 1.12.1
 Requires at least: 4.0.0
 Author URI: http://www.parsely.com/
 License: GPL2
@@ -37,7 +37,7 @@ class Parsely {
 	/**
 	 * @codeCoverageIgnoreStart
 	 */
-	const VERSION         = '1.12';
+	const VERSION         = '1.12.1';
 	const MENU_SLUG       = 'parsely';             // Defines the page param passed to options-general.php
 	const MENU_TITLE      = 'Parse.ly';            // Text to be used for the menu as seen in Settings sub-menu
 	const MENU_PAGE_TITLE = 'Parse.ly > Settings'; // Text shown in <title></title> when the settings screen is viewed


### PR DESCRIPTION
Some themes are somehow setting the frontpage's 2nd post as the canonical: this adds an explicit is_archive and is_frontpage check to prevent this from happening (and simplifies a lot of the parsely page generation as a result, which is a nice little win). 