### PR TITLE
Fix for infinite loop

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -1113,7 +1113,7 @@ class Parsely {
 		$parent = get_term_by( 'id', $term_id, $taxonomy_name );
 		while ( 0 !== $parent->parent ) {
 			if ( false === $parent ) {
-				break;
+				return false;
 			}
 			$parent = get_term_by( 'id', $parent->parent, $taxonomy_name );
 		}

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -1112,6 +1112,9 @@ class Parsely {
 	private function get_top_level_term( $term_id, $taxonomy_name ) {
 		$parent = get_term_by( 'id', $term_id, $taxonomy_name );
 		while ( 0 !== $parent->parent ) {
+			if ( false === $parent ) {
+				break;
+			}
 			$parent = get_term_by( 'id', $parent->parent, $taxonomy_name );
 		}
 		return $parent->name;


### PR DESCRIPTION
`get_term_by()` can return `false` if the term does not exist, causing an infinite loop.