### PR TITLE
Add itm params to widget links

### DIFF
--- a/class-parsely-recommended-widget.php
+++ b/class-parsely-recommended-widget.php
@@ -90,6 +90,9 @@ class Parsely_Recommended_Widget extends WP_Widget {
 
 					var display_author = "<?php echo ( isset( $instance['display_author'] ) ? wp_json_encode( boolval( $instance['display_author'] ) ) : false ); ?>";
 
+					var itm_medium = "site_widget";
+					var itm_source = "parsely_recommended_widget";
+
 					var personalized = "<?php echo wp_json_encode( boolval( $instance['personalize_results'] ) ); ?>";
 					if ( personalized && uuid ) {
 						full_url += '&uuid=';
@@ -131,8 +134,14 @@ class Parsely_Recommended_Widget extends WP_Widget {
 								jQuery('<img>').attr('src', value['image_url']).appendTo(widgetEntry);
 							}
 
+							var cmp_cmp = '?itm_campaign=<?php echo esc_attr( $this->id ); ?>';
+							var cmp_med = '&itm_medium=' + itm_medium;
+							var cmp_src = '&itm_source=' + itm_source;
+							var cmp_con = '&itm_content=widget_item-' + key;
+							var itm_link = value['url'] + cmp_cmp + cmp_med + cmp_src + cmp_con;
+
 							var postTitle = jQuery('<div>').attr('class', 'parsely-recommended-widget-title');
-							var postLink = jQuery('<a>').attr('href', value['url']).text(value['title']);
+							var postLink = jQuery('<a>').attr('href', itm_link).text(value['title']);
 							postTitle.append(postLink);
 							textDiv.append(postTitle);
 


### PR DESCRIPTION
Fixes https://github.com/Parsely/wp-parsely/issues/126.

I made some judgement calls about what exactly these params should be, and settled on:

- itm_campaign: the specific widget instance by number (e.g. `parsely_recommended_widget-2`)
- itm_medium: `site_widget`
- itm_source: to differentiate from other non-Parse.ly widgets: `parsely_recommended_widget`
- itm_content: link/story number, to help optimize widget length (e.g. `widget_item-2`)

Tested/verified it worked on https://beta.parsely.com/elevatedtoday.com/campaigns/?start=2019-01-03&end=2019-01-03

![image](https://user-images.githubusercontent.com/1679762/50651729-e32e4380-0f49-11e9-9b73-5b13dbc6f8f9.png)
