### PR TITLE
insert_parsely_page() should not run on a 404 because of queries

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -706,7 +706,7 @@ class Parsely {
 		$parsely_options = $this->get_options();
 
 		// If we don't have an API key or if we aren't supposed to show to logged in users, there's no need to proceed.
-		if ( empty( $parsely_options['apikey'] ) || ( ! $parsely_options['track_authenticated_users'] && $this->parsely_is_user_logged_in() ) ) {
+		if ( empty( $parsely_options['apikey'] ) || ( ! $parsely_options['track_authenticated_users'] && $this->parsely_is_user_logged_in() ) || is_404() ) {
 			return '';
 		}
 


### PR DESCRIPTION
When 404s are not cached, we'd like them to be as fast as possible.  We've noticed that `insert_parsely_page()` runs on a 404 and results in two possible queries:

```
SELECT t.*, tt.* FROM wp_terms AS t INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('post_tag') AND tr.object_id IN (x) ORDER BY t.name ASC /* 

require, require_once, include, get_header, locate_template, load_template, require_once, wp_head, do_action, WP_Hook->do_action, WP_Hook->apply_filters, Parsely->insert_parsely_page, Parsely->get_tags, wp_get_post_tags, wp_get_post_terms, wp_get_object_terms, get_terms, WP_Term_Query->query, WP_Term_Query->get_terms, wpdb->get_results
```

```
SELECT * FROM wp_posts WHERE ID = 1 LIMIT 1

require, require_once, include, get_header, locate_template, load_template, require_once, wp_head, do_action, WP_Hook->do_action, WP_Hook->apply_filters, Parsely->insert_parsely_page, get_the_modified_date, get_post, WP_Post->get_instance, wpdb->get_row
```