### PR TITLE
Tests: Split utility methods into custom test case

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Base unit test case
+ *
+ * @package Parsely\Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace Parsely\Tests;
+
+/**
+ * Abstract base class for all test case implementations.
+ *
+ * @package Parsely\Tests
+ */
+abstract class TestCase extends \WP_UnitTestCase {
+
+	/**
+	 * Create a test post.
+	 *
+	 * @param string $post_type Optional. Post type. Default is 'post'.
+	 * @return array An array of WP_Post fields.
+	 */
+	public function create_test_post_array( $post_type = 'post' ) {
+		return array(
+			'post_title'   => 'Sample Parsely Post',
+			'post_author'  => 1,
+			'post_content' => 'Some sample content just to have here',
+			'post_status'  => 'publish',
+			'post_type'    => $post_type,
+		);
+	}
+
+	/**
+	 * Create a test category.
+	 *
+	 * @param string $name Category name.
+	 * @return array|WP_Error An array containing the term_id and term_taxonomy_id, WP_Error otherwise.
+	 */
+	public function create_test_category( $name ) {
+		return $this->factory->category->create(
+			array(
+				'name'                 => $name,
+				'category_description' => $name,
+				'category_nicename'    => 'category-' . $name,
+				'taxonomy'             => 'category',
+			)
+		);
+	}
+
+	/**
+	 * Create a test user.
+	 *
+	 * @param string $user_login The user's login username.
+	 * @return int|WP_Error The newly created user's ID or a WP_Error object if the user could not be created.
+	 */
+	public function create_test_user( $user_login ) {
+		return $this->factory->user->create( array( 'user_login' => $user_login ) );
+	}
+
+	/**
+	 * Create a test blog.
+	 *
+	 * @param string $domain  Site second-level domain without a .com TLD e.g. 'example' will
+	 *                        result in a new subsite of 'http://example.com'.
+	 * @param string $user_id User ID for the site administrator.
+	 * @return int|WP_Error The site ID on success, WP_Error object on failure.
+	 */
+	public function create_test_blog( $domain, $user_id ) {
+		return $this->factory->blog->create(
+			array(
+				'domain'  => 'http://' . $domain . 'com',
+				'user_id' => $user_id,
+			)
+		);
+	}
+
+	/**
+	 * Create a test taxonomy with a single term.
+	 *
+	 * @param string $taxonomy_key Taxonomy key, must not exceed 32 characters.
+	 * @param string $term_name    The term name to add.
+	 * @return array|WP_Error An array containing the term_id and term_taxonomy_id, WP_Error otherwise.
+	 */
+	public function create_test_taxonomy( $taxonomy_key, $term_name ) {
+		register_taxonomy(
+			$taxonomy_key,
+			'post',
+			array(
+				'label'        => $taxonomy_key,
+				'hierarchical' => true,
+			)
+		);
+
+		return $this->factory->term->create(
+			array(
+				'name'     => $term_name,
+				'taxonomy' => $taxonomy_key,
+			)
+		);
+	}
+}

--- a/tests/all-test.php
+++ b/tests/all-test.php
@@ -5,102 +5,17 @@
  * @package WordPress
  */
 
+namespace Parsely\Tests;
+
+use Parsely\Tests\TestCase as ParselyTestCase;
+
 /**
  * Sample test case.
  *
  * @category   Class
  * @package    SampleTest
  */
-class SampleTest extends WP_UnitTestCase {
-
-	/**
-	 * Create a sample post.
-	 *
-	 * @category   Function
-	 * @package    SampleTest
-	 * @param string $post_type You can pass in a post type.
-	 */
-	public function create_test_post_array( $post_type = 'post' ) {
-		return array(
-			'post_title'   => 'Sample Parsely Post',
-			'post_author'  => 1,
-			'post_content' => 'Some sample content just to have here',
-			'post_status'  => 'publish',
-			'post_type'    => $post_type,
-		);
-	}
-
-	/**
-	 * Create a sample category.
-	 *
-	 * @category   Function
-	 * @package    SampleTest
-	 * @param string $name You can pass in a category name.
-	 */
-	public function create_test_category( $name ) {
-		return $this->factory->category->create(
-			array(
-				'name'                 => $name,
-				'category_description' => $name,
-				'category_nicename'    => 'category-' . $name,
-				'taxonomy'             => 'category',
-			)
-		);
-	}
-
-	/**
-	 * Create a sample user
-	 *
-	 * @category   Function
-	 * @package    SampleTest
-	 * @param string $name You can pass in a user name.
-	 */
-	public function create_test_user( $name ) {
-		return $this->factory->user->create( array( 'user_login' => $name ) );
-	}
-
-	/**
-	 * Create a test blog.
-	 *
-	 * @category   Function
-	 * @package    SampleTest
-	 * @param string $name You can pass in a user name.
-	 * @param string $user_id You can pass in a user id.
-	 */
-	public function create_test_blog( $name, $user_id ) {
-		return $this->factory->blog->create(
-			array(
-				'domain'  => 'http://' . $name . 'com',
-				'user_id' => $user_id,
-			)
-		);
-	}
-
-	/**
-	 * Create a sample taxonomy.
-	 *
-	 * @category   Function
-	 * @package    SampleTest
-	 * @param string $taxonomy You can pass in a taxonomy.
-	 * @param string $taxonomy_value The name of the taxonomy.
-	 */
-	public function create_test_taxonomy( $taxonomy, $taxonomy_value ) {
-		register_taxonomy(
-			$taxonomy,
-			'post',
-			array(
-				'label'        => $taxonomy,
-				'hierarchical' => true,
-			)
-		);
-
-		return $this->factory->term->create(
-			array(
-				'name'     => $taxonomy_value,
-				'taxonomy' => $taxonomy,
-			)
-		);
-	}
+class SampleTest extends ParselyTestCase {
 
 	/**
 	 * Internal variables
@@ -175,7 +90,7 @@ class SampleTest extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-		self::$parsely   = new Parsely();
+		self::$parsely   = new \Parsely();
 		$option_defaults = array(
 			'apikey'                    => 'blog.parsely.com',
 			'content_id_prefix'         => '',

--- a/tests/all-test.php
+++ b/tests/all-test.php
@@ -388,25 +388,23 @@ PARSELYJS;
 		$options    = get_option( 'parsely' );
 		$post_array = $this->create_test_post_array();
 		$post       = $this->factory->post->create( $post_array );
+		$headline   = 'Completely New And Original Filtered Headline';
 		$this->go_to( '/?p=' . $post );
-		/**
-		 * Check out page filtering.
-		 *
-		 * @category   Function
-		 * @package    SampleTest
-		 * @param string $original_ppage The original parsely page.
-		 * @param string $ppage_post The parsely post.
-		 * @param string $p_options Any options.
-		 */
-		function filter_ppage( $original_ppage, $ppage_post, $p_options ) {
-			$new_vals             = $original_ppage;
-			$new_vals['headline'] = 'Completely New And Original Filtered Headline';
-			return $new_vals;
-		}
+		
+		// Apply page filtering.
+		add_filter(
+			'after_set_parsely_page',
+			function( $args ) use ( $headline ) {
+				$args['headline'] = $headline;
 
-		add_filter( 'after_set_parsely_page', 'filter_ppage', 10, 3 );
+				return $args;
+			},
+			10,
+			3
+		);
+
 		$ppage = self::$parsely->insert_parsely_page();
-		self::assertSame( strpos( $ppage['headline'], 'Completely New And Original Filtered Headline' ), 0 );
+		self::assertTrue( strpos( $ppage['headline'], $headline ) === 0 );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,3 +23,6 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
+
+// Include the Parsely custom test case.
+require_once __DIR__ . '/TestCase.php';


### PR DESCRIPTION
- New TestCase class for WP unit tests. Single Test class extends this custom TestCase.
- Move the custom wrapper methods for the WP Unit Test factory methods into the new TestCase.
- Update DocBlocks and variables internal to methods to clarify intent.
- Add namespace to test files.
- Remove nested test callback method.

The intent of the PR would be allow the single Test class to then be split up further into multiple test classes that would focus on different areas, and allow for more granularity of these tests, and easier maintenance, by separating the actual tests from the utility methods.