### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,9 +17,11 @@
 
 # Files
 /.editorconfig       export-ignore
+/.eslintrc           export-ignore
 /.gitattributes      export-ignore
 /.gitignore          export-ignore
 /.phpcs.xml.dist     export-ignore
+/.prettierrc         export-ignore
 /.travis.yml         export-ignore
 /CHANGELOG.md        export-ignore
 /CODE_OF_CONDUCT.md  export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Exclude these files from release archives.
+
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+
+# If you develop for this package using Composer, use `--prefer-source`.
+# https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
+# https://blog.madewithlove.be/post/gitattributes/
+
+# They are also used when pushing to WordPress.org SVN using the
+# https://github.com/10up/action-wordpress-plugin-deploy GitHub Action.
+
+# Directories
+/.github             export-ignore
+/.wordpress-org      export-ignore
+/bin                 export-ignore
+/tests               export-ignore
+
+# Files
+/.editorconfig       export-ignore
+/.gitattributes      export-ignore
+/.gitignore          export-ignore
+/.phpcs.xml.dist     export-ignore
+/.travis.yml         export-ignore
+/CHANGELOG.md        export-ignore
+/CODE_OF_CONDUCT.md  export-ignore
+/CONTRIBUTING.md     export-ignore
+/composer.json       export-ignore
+/composer.lock       export-ignore
+/phpunit.xml.dist    export-ignore


### PR DESCRIPTION
This reduces the files that are included in exports for Composer, or when using a GitHub action to push to WordPress.org SVN.

There is no need to include tests and other development files and directories in production releases.

(There are a few files included here that do not yet exist in the repo, but they will do shortly.)