### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# This file is for unifying the coding style for different editors and IDEs.
+# It is based on https://core.trac.wordpress.org/browser/trunk/.editorconfig.
+# See https://editorconfig.org for more information about the standard.
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.txt]
+end_of_line = crlf


### PR DESCRIPTION
This file is for unifying the coding style for different editors and IDEs. See https://editorconfig.org for more information about the standard.