### PR TITLE
PHP: Specify minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Stable tag: trunk  
 Requires at least: 4.0  
 Tested up to: 5.6  
+Requires PHP: 5.6  
 License: GPLv2 or later  
 Tags: analytics, post, page  
 Contributors: parsely_mike

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
       "role": "Developer"
     }
   ],
+  "require": {
+    "php": ">=5.6"
+  },
   "require-dev": {
     "automattic/vipwpcs": "^2.2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",


### PR DESCRIPTION
Can be used for highlighting incompatible syntax from newer versions of PHP, and let's users know what versions of PHP the plugin works on.