### PR TITLE
CI: Allow Composer validation to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate
       - name: Validate Composer installation
-        continue-on-error: true
         run: composer validate --no-check-all --strict
 
       # Install dependencies and handle caching in one go.


### PR DESCRIPTION
It was previously allowed to fail because there were some missing required fields. See annotation at https://github.com/Parsely/wp-parsely/actions/runs/698922725

These fields have since been added.

See #172.
See #165.