### PR TITLE
Simple JS WP build env + prettier & eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,4 @@
+{
+	"env": { "browser": true },
+	"extends": [ "plugin:@wordpress/eslint-plugin/recommended-with-formatting" ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor
 .DS_Store
 .idea
+node_modules

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+useTabs: true
+tabWidth: 2
+printWidth: 100
+singleQuote: true
+bracketSpacing: true
+parenSpacing: true
+jsxBracketSameLine: false
+semi: true

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "wp-parsely",
+  "version": "2.4.0",
+  "description": "The official WordPress plugin for Parse.ly - makes it a snap to add the required tracking code to enable Parse.ly on your WordPress site.",
+  "main": "build/index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "wp-scripts build",
+    "start": "wp-scripts start",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Parsely/wp-parsely.git"
+  },
+  "author": "",
+  "license": "GPL-2.0-only",
+  "bugs": {
+    "url": "https://github.com/Parsely/wp-parsely/issues"
+  },
+  "homepage": "https://github.com/Parsely/wp-parsely#readme",
+  "devDependencies": {
+    "@wordpress/eslint-plugin": "^9.0.1",
+    "@wordpress/scripts": "14.0.1",
+    "prettier": "^2.2.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git+https://github.com/Parsely/wp-parsely.git"
   },
   "author": "",
-  "license": "GPL-2.0-only",
+  "license": "GPL-2.0-or-later",
   "bugs": {
     "url": "https://github.com/Parsely/wp-parsely/issues"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,1 @@
+console.log( 'hello from the entry file!' );


### PR DESCRIPTION
This is a step toward a more robust JS environment for the front end and admin (ES6+ syntax, importing npm packages, etc.).

It leverages the [`wp-scripts` package](https://www.npmjs.com/package/@wordpress/scripts) so we don't need a custom webpack config (yet).

Additionally, this includes prettier and eslint configurations to enable IDE auto-formatters.

Right now, the src/index.js file is only a placeholder for the entrypoint. We'll want to replace it with an actual implementation prior to sourcing the built file in the plugin :)

## To Test

`npm i` to install dev dependencies.

### Development

* `npm run start`
* Make changes to `src/index.js`, add and link other source files (using `import _ from '__'` format, etc.)
* Source changes should automatically generate a new development `build/index.js`

### Release

* `npm run build`
* It should generate a new "production" `build/index.js`

