### PR TITLE
Fix category metadata

### DIFF
--- a/tests/structured-data/archive-post-test.php
+++ b/tests/structured-data/archive-post-test.php
@@ -99,9 +99,40 @@ final class Archive_Post_Test extends TestCase {
 		self::assertEquals( get_permalink( $page_id ) . 'page/2', $structured_data['url'] );
 	}
 
+	public function test_term_archive() {
+		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
+		// See https://github.com/Parsely/wp-parsely/issues/151
+		$this->set_permalink_structure( '/%postname%/' );
+
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Insert a single category term, and a Post with that category.
+		$category = self::factory()->category->create( [ 'name' => 'Test Category' ] );
+		self::factory()->post->create( [ 'post_category' => [ $category ] ] );
+
+		// Make a request to that page to set the global $wp_query object.
+		$cat_link = get_category_link( $category );
+		$this->go_to( $cat_link );
+
+		// Reset permalinks to default.
+		$this->set_permalink_structure( '' );
+
+		// Create the structured data for that category.
+		// The category metadata doesn't use the post data, but the construction method requires it for now.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, get_post() );
+
+		// Check the required properties exist.
+		$this->assert_data_has_required_properties( $structured_data );
+
+		// The headline should be the category name.
+		self::assertEquals( 'Test Category', $structured_data['headline'] );
+		self::assertEquals( $cat_link, $structured_data['url'] );
+	}
+
 	public function assert_data_has_required_properties( $structured_data ) {
 		$required_properties = $this->get_required_properties();
-
 		array_walk(
 			$required_properties,
 			static function( $property, $index ) use ( $structured_data ) {
@@ -109,7 +140,6 @@ final class Archive_Post_Test extends TestCase {
 			}
 		);
 	}
-
 	private function get_required_properties() {
 		return array(
 			'@context',

--- a/tests/structured-data/archive-post-test.php
+++ b/tests/structured-data/archive-post-test.php
@@ -99,6 +99,38 @@ final class Archive_Post_Test extends TestCase {
 		self::assertEquals( get_permalink( $page_id ) . 'page/2', $structured_data['url'] );
 	}
 
+	public function test_author_archive() {
+		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
+		// See https://github.com/Parsely/wp-parsely/issues/151
+		$this->set_permalink_structure( '/%postname%/' );
+
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Insert a single user, and a Post assigned to them.
+		$user = self::factory()->user->create( [ 'user_login' => 'parsely' ] );
+		$this->factory()->post->create( [ 'post_author' => $user ] );
+
+		// Make a request to that page to set the global $wp_query object.
+		$author_posts_url = get_author_posts_url( $user );
+		$this->go_to( $author_posts_url );
+
+		// Reset permalinks to default.
+		$this->set_permalink_structure( '' );
+
+		// Create the structured data for that category.
+		// The author archive metadata doesn't use the post data, but the construction method requires it for now.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, get_post() );
+
+		// Check the required properties exist.
+		$this->assert_data_has_required_properties( $structured_data );
+
+		// The headline should be the category name.
+		self::assertEquals( 'Author - parsely', $structured_data['headline'] );
+		self::assertEquals( $author_posts_url, $structured_data['url'] );
+	}
+
 	public function test_term_archive() {
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
 		// See https://github.com/Parsely/wp-parsely/issues/151

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -820,6 +820,7 @@ class Parsely {
 			'@type'    => 'WebPage',
 		);
 		$current_url  = $this->get_current_url();
+
 		if ( is_front_page() && ! is_paged() || ( 'page' === get_option( 'show_on_front' ) && ! get_option( 'page_on_front' ) ) ) {
 			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_bloginfo( 'name', 'raw' ) );
 			$parsely_page['url']      = home_url();
@@ -828,6 +829,34 @@ class Parsely {
 			$parsely_page['url']      = $current_url;
 		} elseif ( is_home() ) {
 			$parsely_page['headline'] = get_the_title( get_option('page_for_posts', true) );
+			$parsely_page['url']      = $current_url;
+		} elseif ( is_author() ) {
+			// TODO: why can't we have something like a WP_User object for all the other cases? Much nicer to deal with than functions.
+			$author                   = ( get_query_var( 'author_name' ) ) ? get_user_by( 'slug', get_query_var( 'author_name' ) ) : get_userdata( get_query_var( 'author' ) );
+			$parsely_page['headline'] = $this->get_clean_parsely_page_value( 'Author - ' . $author->data->display_name );
+			$parsely_page['url']      = $current_url;
+		} elseif ( is_category() ) {
+			$category                 = get_the_category();
+			$category                 = $category[0];
+			$parsely_page['headline'] = $this->get_clean_parsely_page_value( $category->name );
+			$parsely_page['url']      = $current_url;
+		} elseif ( is_date() ) {
+			if ( is_year() ) {
+				$parsely_page['headline'] = 'Yearly Archive - ' . get_the_time( 'Y' );
+			} elseif ( is_month() ) {
+				$parsely_page['headline'] = 'Monthly Archive - ' . get_the_time( 'F, Y' );
+			} elseif ( is_day() ) {
+				$parsely_page['headline'] = 'Daily Archive - ' . get_the_time( 'F jS, Y' );
+			} elseif ( is_time() ) {
+				$parsely_page['headline'] = 'Hourly, Minutely, or Secondly Archive - ' . get_the_time( 'F jS g:i:s A' );
+			}
+			$parsely_page['url'] = $current_url;
+		} elseif ( is_tag() ) {
+			$tag = single_tag_title( '', false );
+			if ( empty( $tag ) ) {
+				$tag = single_term_title( '', false );
+			}
+			$parsely_page['headline'] = $this->get_clean_parsely_page_value( 'Tagged - ' . $tag );
 			$parsely_page['url']      = $current_url;
 		} elseif ( in_array( get_post_type( $post ), $parsely_options['track_post_types'], true ) && 'publish' === $post->post_status ) {
 			$authors  = $this->get_author_names( $post );
@@ -911,34 +940,6 @@ class Parsely {
 		} elseif ( in_array( get_post_type(), $parsely_options['track_page_types'], true ) && 'publish' === $post->post_status ) {
 			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_the_title( $post ) );
 			$parsely_page['url']      = $this->get_current_url( 'post' );
-		} elseif ( is_author() ) {
-			// TODO: why can't we have something like a WP_User object for all the other cases? Much nicer to deal with than functions.
-			$author                   = ( get_query_var( 'author_name' ) ) ? get_user_by( 'slug', get_query_var( 'author_name' ) ) : get_userdata( get_query_var( 'author' ) );
-			$parsely_page['headline'] = $this->get_clean_parsely_page_value( 'Author - ' . $author->data->display_name );
-			$parsely_page['url']      = $current_url;
-		} elseif ( is_category() ) {
-			$category                 = get_the_category();
-			$category                 = $category[0];
-			$parsely_page['headline'] = $this->get_clean_parsely_page_value( $category->name );
-			$parsely_page['url']      = $current_url;
-		} elseif ( is_date() ) {
-			if ( is_year() ) {
-				$parsely_page['headline'] = 'Yearly Archive - ' . get_the_time( 'Y' );
-			} elseif ( is_month() ) {
-				$parsely_page['headline'] = 'Monthly Archive - ' . get_the_time( 'F, Y' );
-			} elseif ( is_day() ) {
-				$parsely_page['headline'] = 'Daily Archive - ' . get_the_time( 'F jS, Y' );
-			} elseif ( is_time() ) {
-				$parsely_page['headline'] = 'Hourly, Minutely, or Secondly Archive - ' . get_the_time( 'F jS g:i:s A' );
-			}
-			$parsely_page['url'] = $current_url;
-		} elseif ( is_tag() ) {
-			$tag = single_tag_title( '', false );
-			if ( empty( $tag ) ) {
-				$tag = single_term_title( '', false );
-			}
-			$parsely_page['headline'] = $this->get_clean_parsely_page_value( 'Tagged - ' . $tag );
-			$parsely_page['url']      = $current_url;
 		}
 
 		/**


### PR DESCRIPTION
This is branched off of #152 and that should be merged first before this one is merged. WIP because it has no tests yet!

Similar situation to #152, but for index pages instead of the home page: this swaps the order of conditionals to make sure that we check to see if a page is any of the index types first (author, tag, category, etc.) before outputting metadata. 