### PR TITLE
Changelog for 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2021-04-06
+- Fix metadata for home pages, including pages of older posts.
+- Fix metadata for category archives, and 404 pages.
+
 ## [2.3.0] - 2021-03-24
 - Fix and improve Travis configuration.
 - Small maintenance items: merge isset() calls, remove unnecessary typecasting, remove is_null() in favour of null comparison, un-nest nested functions, simplify ternary operators, remove unnecessary local variable, etc.
@@ -165,6 +169,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial version.
 - Add sSupport for parsely-page and JavaScript on home page and published pages and posts as well as archive pages (date/author/category/tag).
 
+[2.3.1]: https://github.com/Parsely/wp-parsely/compare/2.3.0...2.3.1
 [2.3.0]: https://github.com/Parsely/wp-parsely/compare/2.2.1...2.3.0
 [2.2.1]: https://github.com/Parsely/wp-parsely/compare/2.2...2.2.1
 [2.2]: https://github.com/Parsely/wp-parsely/compare/2.1.3...2.2


### PR DESCRIPTION
Pre-emptive change log for https://github.com/Parsely/wp-parsely/pull/152 and https://github.com/Parsely/wp-parsely/pull/192 which are planned to go out as a patch release.

As the `CHANGELOG.md` didn't exist in the 2.3.0 tag, then we can't point this PR to the `release/2.3.1` branch without adding the whole file, which doesn't seem quite right. So left pointing to `develop`, and it can be merged after the `release/2.3.1` branch is merged into `master`.

It means that the 2.3.1 release won't contain a `CHANGELOG.md`, but then neither did any version before, and the details can be added to the GitHub Release anyway. 

This is only an oddity because we're doing a hotfix release immediately after the `CHANGELOG.md` file was added; in future releases (2.4.0 and beyond), then a separate PR like this can be based on the `release/x.y.z` branch.