### PR TITLE
Tests: Fix multisite tests not running

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -1,4 +1,4 @@
-name: CS & Tests
+name: CS & Lint
 
 on:
   # Run on all pushes and on all pull requests.
@@ -68,62 +68,3 @@ jobs:
 
 #      - name: Show PHPCS results in PR
 #        run: cs2pr ./phpcs-report.xml
-
-  test:
-    name: Integration tests
-    runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allowed_failure }}
-
-    env:
-      WP_VERSION: latest
-      WP_MULTISITE: ${{ matrix.wp_multisite }}
-
-    strategy:
-      matrix:
-        php: [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6' ]
-        allowed_failure: [ false ]
-        wp_multisite: [ 0, 1 ]
-        include:
-          # PHP nightly.
-          - php: '8.1'
-            allowed_failure: true
-            wp_multisite: 0
-          - php: '8.1'
-            allowed_failure: true
-            wp_multisite: 1
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@master
-
-      - name: Setup PHP 7.4
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          coverage: pcov
-          # https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions
-          extensions: curl, dom, exif, fileinfo, hash, json, mbstring, mysqli, libsodium, openssl, pcre, imagick, xml, zip
-
-      - name: Install Composer dependencies (PHP < 8.0 )
-        if: ${{ matrix.php < 8.0 }}
-        uses: ramsey/composer-install@v1
-
-      - name: Install Composer dependencies (PHP >= 8.0)
-        if: ${{ matrix.php >= 8.0 }}
-        uses: ramsey/composer-install@v1
-        with:
-          composer-options: --ignore-platform-reqs
-
-      - name: Setup Problem Matchers for PHPUnit
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-#      - name: Run unit tests
-#        run: composer unit
-
-      - name: Start MySQL Service
-        run: sudo systemctl start mysql.service
-
-      - name: Prepare environment for integration tests
-        run: composer prepare
-
-      - name: Run integration tests
-        run: composer integration

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,67 @@
+name: Integration Tests
+
+on:
+  # Run on all pushes and on all pull requests.
+  # Prevent the "push" build from running when there are only irrelevant changes.
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allowed_failure }}
+
+    env:
+      WP_VERSION: latest
+
+    strategy:
+      matrix:
+        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0' ]
+        allowed_failure: [ false ]
+        include:
+          # PHP nightly.
+          - php: '8.1'
+            allowed_failure: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: Setup PHP 7.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: pcov
+          # https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions
+          extensions: curl, dom, exif, fileinfo, hash, json, mbstring, mysqli, libsodium, openssl, pcre, imagick, xml, zip
+
+      - name: Install Composer dependencies (PHP < 8.0 )
+        if: ${{ matrix.php < 8.0 }}
+        uses: ramsey/composer-install@v1
+
+      - name: Install Composer dependencies (PHP >= 8.0)
+        if: ${{ matrix.php >= 8.0 }}
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: --ignore-platform-reqs
+
+      - name: Setup Problem Matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+#      - name: Run unit tests
+#        run: composer unit
+
+      - name: Start MySQL Service
+        run: sudo systemctl start mysql.service
+
+      - name: Prepare environment for integration tests
+        run: composer prepare
+
+      - name: Run integration tests (single site)
+        run: composer integration
+      - name: Run integration tests (multisite)
+        run: composer integration-ms

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,10 @@
     ],
     "integration": [
       "@php ./vendor/bin/phpunit --testsuite WP_Tests"
+    ],
+    "integration-ms": [
+      "@putenv WP_MULTISITE=1",
+      "@composer integration"
     ]
   }
 }


### PR DESCRIPTION
Remove the specific jobs from CI, and just make the integration tests run twice when using the Composer script - once as single site install, then once as multisite.