### PR TITLE
Don't give metadata output for is_search()

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -776,8 +776,19 @@ class Parsely {
 	public function insert_parsely_page() {
 		$parsely_options = $this->get_options();
 
-		// If we don't have an API key or if we aren't supposed to show to logged in users, there's no need to proceed.
-		if ( empty( $parsely_options['apikey'] ) || ( ! $parsely_options['track_authenticated_users'] && $this->parsely_is_user_logged_in() ) || is_404() ) {
+		if (
+			// No API key.
+			empty( $parsely_options['apikey'] ) ||
+
+			// Chosen not to track logged in users.
+			( ! $parsely_options['track_authenticated_users'] && $this->parsely_is_user_logged_in() ) ||
+
+			// 404 pages are not tracked.
+			is_404() ||
+
+			// Search pages are not tracked.
+			is_search()
+		) {
 			return '';
 		}
 


### PR DESCRIPTION
There is logic on the Parse.ly end to exclude search results pages when crawling, so it doesn't make sense to have the request for those pages going through the logic of potentially constructing meta data only to output a redundant meta tag and some HTML comments.
Only for posts and pages.

Closes #201.