### PR TITLE
Add $post_id to wp_parsely_permalink filter hook

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -1606,11 +1606,14 @@ class Parsely {
 			 * Filters the list of author names for a post.
 			 *
 			 * @since 1.14.0
+			 * @since 2.5.0  Added $post_id.
 			 *
 			 * @param string $permalink The permalink URL or false if post does not exist.
 			 * @param string $post      Post object type group ("post" or "nonpost").
+			 * @param int    $post_id   ID of the post you want to get the URL for. May be 0, so $permalink will be
+			 *                          for the global $post.
 			 */
-			$permalink        = apply_filters( 'wp_parsely_permalink', $permalink, $post );
+			$permalink        = apply_filters( 'wp_parsely_permalink', $permalink, $post, $post_id );
 			$parsed_canonical = wp_parse_url( $permalink );
 			// handle issue if wp_parse_url doesn't return good host & path data, fallback to page url as a last resort.
 			if ( isset( $parsed_canonical['host'], $parsed_canonical['path'] ) ) {


### PR DESCRIPTION
The `wp_parsely_permalink` filter only provided the existing permalink to be filtered, and a $post variable, which is really just a "post" or "nonpost" string.

We now provide the $post_id, which is the ID of the specific post that the `get_current_url()` is working with. If the `$post_id` was not provided to the parent function, then the value will be 0, and the permalink will be for the `global $post`.

Closes #168.