### PR TITLE
Widget: Replace form and hide front-end output when API settings are missing

### DIFF
--- a/class-parsely-recommended-widget.php
+++ b/class-parsely-recommended-widget.php
@@ -222,6 +222,19 @@ class Parsely_Recommended_Widget extends WP_Widget {
 	public function form( $instance ) {
 		$this->migrate_old_fields( $instance );
 
+		if ( ! $this->api_key_and_secret_are_populated() ) {
+			$settings_page_url = add_query_arg( 'page', 'parsely', get_admin_url() . 'options-general.php' );
+
+			$message = sprintf(
+				__( 'The <i>Parse.ly Site ID</i> and <i>Parse.ly API Secret</i> fields need to be populated on the <a href="%s">Parse.ly settings page</a> for this widget to work.', 'wp-parsely' ),
+				esc_url( $settings_page_url )
+			);
+
+			echo '<p>', wp_kses_post( $message ), '</p>';
+
+			return;
+		}
+
 		// editable fields: title.
 		$title               = ! empty( $instance['title'] ) ? $instance['title'] : '';
 		$return_limit        = ! empty( $instance['return_limit'] ) ? $instance['return_limit'] : 5;
@@ -358,5 +371,26 @@ class Parsely_Recommended_Widget extends WP_Widget {
 			'li_referrals'          => __( 'Page views where the referrer was linkedin.com', 'wp-parsely' ),
 			'pi_referrals'          => __( 'Page views where the referrer was pinterest.com', 'wp-parsely' ),
 		);
+	}
+
+	private function api_key_and_secret_are_populated() {
+		$options = get_option( 'parsely' );
+
+		// No options are saved, so API key is not available.
+		if ( ! is_array( $options ) ) {
+			return false;
+		}
+
+		// Parse.ly Site ID settings field is not populated.
+		if ( ! array_key_exists( 'apikey', $options ) || $options['apikey'] === '' ) {
+			return false;
+		}
+
+		// Parse.ly API Secret settings field is not populated.
+		if ( ! array_key_exists( 'api_secret', $options ) || $options['api_secret'] === '' ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/class-parsely-recommended-widget.php
+++ b/class-parsely-recommended-widget.php
@@ -44,6 +44,10 @@ class Parsely_Recommended_Widget extends WP_Widget {
 	 * @param array $instance Values saved to the db.
 	 */
 	public function widget( $args, $instance ) {
+		if ( ! $this->api_key_and_secret_are_populated() ) {
+			return;
+		}
+
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $instance['title'] );
 
@@ -53,140 +57,129 @@ class Parsely_Recommended_Widget extends WP_Widget {
 
 		// Set up the variables.
 		$options = get_option( 'parsely' );
-		if ( is_array( $options ) && array_key_exists( 'apikey', $options ) && array_key_exists( 'api_secret', $options ) && ! empty( $options['api_secret'] ) ) {
-			$root_url       = 'https://api.parsely.com/v2/related?apikey=' . esc_attr( $options['apikey'] );
-			$pub_date_start = '&pub_date_start=' . $instance['published_within'] . 'd';
-			$sort           = '&sort=' . trim( $instance['sort'] );
-			// No idea why boost is coming back with a space prepended: I've trimmed it everywhere I possibly could.
-			// Trimming here too to avoid it ruining the query.
-			$boost    = '&boost=' . trim( $instance['boost'] );
-			$limit    = '&limit=' . $instance['return_limit'];
-			$full_url = $root_url . $sort . $boost . $limit;
 
-			if ( 0 !== (int) $instance['published_within'] ) {
-				$full_url .= $pub_date_start;
-			}
-			?>
-			<script data-cfasync="false">
-				// adapted from https://stackoverflow.com/questions/7486309/how-to-make-script-execution-wait-until-jquery-is-loaded
+		$root_url       = 'https://api.parsely.com/v2/related?apikey=' . esc_attr( $options['apikey'] );
+		$pub_date_start = '&pub_date_start=' . $instance['published_within'] . 'd';
+		$sort           = '&sort=' . trim( $instance['sort'] );
+		// No idea why boost is coming back with a space prepended: I've trimmed it everywhere I possibly could.
+		// Trimming here too to avoid it ruining the query.
+		$boost    = '&boost=' . trim( $instance['boost'] );
+		$limit    = '&limit=' . $instance['return_limit'];
+		$full_url = $root_url . $sort . $boost . $limit;
 
-				function defer(method) {
-					if (window.jQuery) {
-						method();
-					} else {
-						setTimeout(function() { defer(method); }, 50);
-					}
-				}
-
-				function widgetLoad() {
-					var parsely_results = [];
-
-					uuid = false;
-					// regex stolen from Mozilla's docs
-					var cookieVal = document.cookie.replace(/(?:(?:^|.*;\s*)_parsely_visitor\s*\=\s*([^;]*).*$)|^.*$/, "$1");
-					if ( cookieVal ) {
-						var uuid = JSON.parse(unescape(cookieVal))['id'];
-					}
-
-					var full_url = '<?php echo esc_js( esc_url_raw( $full_url ) ); ?>';
-
-					var img_src = "<?php echo ( isset( $instance['img_src'] ) ? esc_js( $instance['img_src'] ) : null ); ?>";
-
-					var display_author = "<?php echo ( isset( $instance['display_author'] ) ? wp_json_encode( boolval( $instance['display_author'] ) ) : false ); ?>";
-
-					var display_direction = "<?php echo ( isset( $instance['display_direction'] ) ? esc_js( $instance['display_direction'] ) : null ); ?>";
-
-					var itm_medium = "site_widget";
-					var itm_source = "parsely_recommended_widget";
-
-					var personalized = "<?php echo wp_json_encode( boolval( $instance['personalize_results'] ) ); ?>";
-					if ( personalized && uuid ) {
-						full_url += '&uuid=';
-						full_url += uuid;
-
-					}
-					else {
-						full_url += '&url=';
-						full_url += '<?php echo wp_json_encode( esc_url_raw( get_permalink() ) ); ?>';
-
-					}
-					var parentDiv = jQuery.find('#<?php echo esc_attr( $this->id ); ?>');
-					if (parentDiv.length === 0) {
-						parentDiv = jQuery.find('.Parsely_Recommended_Widget');
-					}
-					// make sure page is not attempting to load widget twice in the same spot
-					if (jQuery(parentDiv).find("div.parsely-recommendation-widget").length != 0) {
-						return;
-					}
-
-					var outerDiv = jQuery('<div>').addClass('parsely-recommendation-widget').appendTo(parentDiv);
-					if (img_src !== 'none') {
-						outerDiv.addClass('display-thumbnail');
-					}
-					if (display_direction) {
-						outerDiv.addClass('list-' + display_direction);
-					}
-
-					var outerList = jQuery('<ul>').addClass('parsely-recommended-widget').appendTo(outerDiv);
-					jQuery.getJSON( full_url, function (data) {
-						jQuery.each(data.data, function(key, value) {
-							var widgetEntry = jQuery('<li>')
-								.addClass('parsely-recommended-widget-entry')
-								.attr('id', 'parsely-recommended-widget-item' + key);
-
-							var textDiv = jQuery('<div>').addClass('parsely-text-wrapper');
-
-							if (img_src === 'parsely_thumb') {
-								jQuery('<img>').attr('src', value['thumb_url_medium']).appendTo(widgetEntry);
-							}
-							else if (img_src === 'original') {
-								jQuery('<img>').attr('src', value['image_url']).appendTo(widgetEntry);
-							}
-
-							var cmp_cmp = '?itm_campaign=<?php echo esc_attr( $this->id ); ?>';
-							var cmp_med = '&itm_medium=' + itm_medium;
-							var cmp_src = '&itm_source=' + itm_source;
-							var cmp_con = '&itm_content=widget_item-' + key;
-							var itm_link = value['url'] + cmp_cmp + cmp_med + cmp_src + cmp_con;
-
-							var postTitle = jQuery('<div>').attr('class', 'parsely-recommended-widget-title');
-							var postLink = jQuery('<a>').attr('href', itm_link).text(value['title']);
-							postTitle.append(postLink);
-							textDiv.append(postTitle);
-
-							if ( display_author ) {
-								var authorLink = jQuery('<div>').attr('class', 'parsely-recommended-widget-author').text(value['author']);
-								textDiv.append(authorLink);
-							}
-
-							widgetEntry.append(textDiv);
-
-
-
-							// set up the rest of entry
-							outerList.append(widgetEntry);
-						});
-						outerDiv.append(outerList);
-					});
-
-				}
-				defer(widgetLoad);
-
-
-			</script>
-			<?php
-		} else {
-			?>
-			<p>
-			you must set the Parsely API Secret for this widget to work!
-			</p>
-			<?php
+		if ( 0 !== (int) $instance['published_within'] ) {
+			$full_url .= $pub_date_start;
 		}
-
 		?>
+		<script data-cfasync="false">
+			// adapted from https://stackoverflow.com/questions/7486309/how-to-make-script-execution-wait-until-jquery-is-loaded
+
+			function defer(method) {
+				if (window.jQuery) {
+					method();
+				} else {
+					setTimeout(function() { defer(method); }, 50);
+				}
+			}
+
+			function widgetLoad() {
+				var parsely_results = [];
+
+				uuid = false;
+				// regex stolen from Mozilla's docs
+				var cookieVal = document.cookie.replace(/(?:(?:^|.*;\s*)_parsely_visitor\s*\=\s*([^;]*).*$)|^.*$/, "$1");
+				if ( cookieVal ) {
+					var uuid = JSON.parse(unescape(cookieVal))['id'];
+				}
+
+				var full_url = '<?php echo esc_js( esc_url_raw( $full_url ) ); ?>';
+
+				var img_src = "<?php echo ( isset( $instance['img_src'] ) ? esc_js( $instance['img_src'] ) : null ); ?>";
+
+				var display_author = "<?php echo ( isset( $instance['display_author'] ) ? wp_json_encode( boolval( $instance['display_author'] ) ) : false ); ?>";
+
+				var display_direction = "<?php echo ( isset( $instance['display_direction'] ) ? esc_js( $instance['display_direction'] ) : null ); ?>";
+
+				var itm_medium = "site_widget";
+				var itm_source = "parsely_recommended_widget";
+
+				var personalized = "<?php echo wp_json_encode( boolval( $instance['personalize_results'] ) ); ?>";
+				if ( personalized && uuid ) {
+					full_url += '&uuid=';
+					full_url += uuid;
+
+				}
+				else {
+					full_url += '&url=';
+					full_url += '<?php echo wp_json_encode( esc_url_raw( get_permalink() ) ); ?>';
+
+				}
+				var parentDiv = jQuery.find('#<?php echo esc_attr( $this->id ); ?>');
+				if (parentDiv.length === 0) {
+					parentDiv = jQuery.find('.Parsely_Recommended_Widget');
+				}
+				// make sure page is not attempting to load widget twice in the same spot
+				if (jQuery(parentDiv).find("div.parsely-recommendation-widget").length != 0) {
+					return;
+				}
+
+				var outerDiv = jQuery('<div>').addClass('parsely-recommendation-widget').appendTo(parentDiv);
+				if (img_src !== 'none') {
+					outerDiv.addClass('display-thumbnail');
+				}
+				if (display_direction) {
+					outerDiv.addClass('list-' + display_direction);
+				}
+
+				var outerList = jQuery('<ul>').addClass('parsely-recommended-widget').appendTo(outerDiv);
+				jQuery.getJSON( full_url, function (data) {
+					jQuery.each(data.data, function(key, value) {
+						var widgetEntry = jQuery('<li>')
+							.addClass('parsely-recommended-widget-entry')
+							.attr('id', 'parsely-recommended-widget-item' + key);
+
+						var textDiv = jQuery('<div>').addClass('parsely-text-wrapper');
+
+						if (img_src === 'parsely_thumb') {
+							jQuery('<img>').attr('src', value['thumb_url_medium']).appendTo(widgetEntry);
+						}
+						else if (img_src === 'original') {
+							jQuery('<img>').attr('src', value['image_url']).appendTo(widgetEntry);
+						}
+
+						var cmp_cmp = '?itm_campaign=<?php echo esc_attr( $this->id ); ?>';
+						var cmp_med = '&itm_medium=' + itm_medium;
+						var cmp_src = '&itm_source=' + itm_source;
+						var cmp_con = '&itm_content=widget_item-' + key;
+						var itm_link = value['url'] + cmp_cmp + cmp_med + cmp_src + cmp_con;
+
+						var postTitle = jQuery('<div>').attr('class', 'parsely-recommended-widget-title');
+						var postLink = jQuery('<a>').attr('href', itm_link).text(value['title']);
+						postTitle.append(postLink);
+						textDiv.append(postTitle);
+
+						if ( display_author ) {
+							var authorLink = jQuery('<div>').attr('class', 'parsely-recommended-widget-author').text(value['author']);
+							textDiv.append(authorLink);
+						}
+
+						widgetEntry.append(textDiv);
 
 
+
+						// set up the rest of entry
+						outerList.append(widgetEntry);
+					});
+					outerDiv.append(outerList);
+				});
+
+			}
+			defer(widgetLoad);
+
+
+		</script>
 		<?php
+
 		echo wp_kses( $args['after_widget'], $allowed_tags );
 	}
 


### PR DESCRIPTION
The widget requires the "Parse.ly Site ID" (API key) and "Parse.ly API Secret" to be populated.

This PR contains two commits - one that replaces the widget form in the back-end, and one that removes the content in the front-end - when the settings are not populated.

_The second commit unwraps a large block of code from a conditional, so it is advisable to ignore whitespace changes when reviewing (ensure `?w=1` is added to the files view URL)._

## Hide form when settings are missing

If either field were not populated, the widget form would still display the regular widget settings, even though there was zero chance of the widget working correctly.

This has now switched to checking for the settings, and giving a message to the user with a link to the settings page.

Here's what it now looks like when the API key or secret setting is missing:

<img width="472" alt="Screenshot of new widget with replaced form" src="https://user-images.githubusercontent.com/88371/114323388-daf7e200-9b1c-11eb-985f-2d36315e5898.png">

This draws the user's attention to the fact they need to populate the two settings.

## Hide front-end when settings are missing.

Prior to this PR, the widget would still display the `before_widget`, `before_title`, `title`, `after_title`, and `after_widget` content, even though the widget body would never show any content.

This has now switched to checking for the settings, and displaying nothing at all if the settings are missing.

The prior art here is the WP core RSS Widget, which [returns early](https://github.com/WordPress/WordPress/blob/270f2011f8ec7265c3f4ddce39c77ef5b496ed1c/wp-includes/widgets/class-wp-widget-rss.php#L55-L57) if the URL setting is not populated.

With no output, it technically does change the front-end of the website - previously the partial widget output acted as a placeholder:

<img width="1248" alt="Screenshot 2021-04-11 at 23 30 39" src="https://user-images.githubusercontent.com/88371/114323659-1b0b9480-9b1e-11eb-8bac-b9d6da280893.png">

Now, it doesn't, so subsequent widgets get shifted.

<img width="1248" alt="Screenshot 2021-04-11 at 23 30 51" src="https://user-images.githubusercontent.com/88371/114323671-28c11a00-9b1e-11eb-9f14-06ecff425a09.png">

Given the rarity of this, since it's only likely to be when setting the plugin up, and the widget form draws attention to the fact that required settings are missing, I think this lack of placeholder is an acceptable situation; a completely missing output hints at a different situation (not set up correctly), than having no data showing in the widget body (is my key correct? is Parse.ly API broken?) (which will be handled by #193).

This second commit is optional though, and could be adapted to leave a HTML comment in the output, or even a similar visible message to what the form shows, though this would show up as soon as someone added the widget to the widget area, before they then had a chance to see the form message and populate the settings.

Closes #156.