### PR TITLE
Tests: Call the TestCase factory method statically

### DIFF
--- a/tests/structured-data/archive-post-test.php
+++ b/tests/structured-data/archive-post-test.php
@@ -31,8 +31,8 @@ final class Archive_Post_Test extends TestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert 2 posts.
-		$page_id = $this->factory()->post->create();
-		$this->factory()->post->create();
+		$page_id = self::factory()->post->create();
+		self::factory()->post->create();
 		$page = get_post( $page_id );
 
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
@@ -67,11 +67,11 @@ final class Archive_Post_Test extends TestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a page for the blog posts.
-		$page_id = $this->factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Page for Posts', 'post_name' => 'page-for-posts' ] );
+		$page_id = self::factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Page for Posts', 'post_name' => 'page-for-posts' ] );
 
 		// Create 2 posts so that posts page has pagination
-		$this->factory()->post->create();
-		$this->factory()->post->create();
+		self::factory()->post->create();
+		self::factory()->post->create();
 		$page    = get_post( $page_id );
 
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
@@ -110,7 +110,7 @@ final class Archive_Post_Test extends TestCase {
 
 		// Insert a single user, and a Post assigned to them.
 		$user = self::factory()->user->create( [ 'user_login' => 'parsely' ] );
-		$this->factory()->post->create( [ 'post_author' => $user ] );
+		self::factory()->post->create( [ 'post_author' => $user ] );
 
 		// Make a request to that page to set the global $wp_query object.
 		$author_posts_url = get_author_posts_url( $user );

--- a/tests/structured-data/single-non-post-test.php
+++ b/tests/structured-data/single-non-post-test.php
@@ -31,7 +31,7 @@ final class Single_Non_Post_Test extends TestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a single page.
-		$page_id = $this->factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Single Page', 'post_name' => 'foo' ] );
+		$page_id = self::factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Single Page', 'post_name' => 'foo' ] );
 		$page    = get_post( $page_id );
 
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
@@ -66,7 +66,7 @@ final class Single_Non_Post_Test extends TestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a single page.
-		$page_id = $this->factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Page for Posts' ] );
+		$page_id = self::factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Page for Posts' ] );
 		$page    = get_post( $page_id );
 
 		// Make a request to the root of the site to set the global $wp_query object.
@@ -92,8 +92,8 @@ final class Single_Non_Post_Test extends TestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a page for blog posts and insert another post.
-		$page_id = $this->factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Page for Posts', 'post_name' => 'page-for-posts' ] );
-		$this->factory()->post->create();
+		$page_id = self::factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Page for Posts', 'post_name' => 'page-for-posts' ] );
+		self::factory()->post->create();
 		$page    = get_post( $page_id );
 
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
@@ -129,7 +129,7 @@ final class Single_Non_Post_Test extends TestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a single page.
-		$page_id = $this->factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Home' ] );
+		$page_id = self::factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Home' ] );
 		$page    = get_post( $page_id );
 
 		// Set that page as the homepage Page.
@@ -159,7 +159,7 @@ final class Single_Non_Post_Test extends TestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a single page.
-		$page_id = $this->factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Home' ] );
+		$page_id = self::factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Home' ] );
 		$page    = get_post( $page_id );
 
 		// Set that page as the homepage Page.

--- a/tests/structured-data/single-post-test.php
+++ b/tests/structured-data/single-post-test.php
@@ -22,7 +22,7 @@ final class Single_Post_Test extends TestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a single post and set as global post.
-		$post_id = $this->factory()->post->create();
+		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
 		// Make a request to the root of the site to set the global $wp_query object.


### PR DESCRIPTION
As [discussed](https://github.com/Parsely/wp-parsely/pull/192#discussion_r611664371) in #192, the factory method of the `TestCase` utility is declared static, so it makes sense to call it as such:

https://core.trac.wordpress.org/browser/trunk/tests/phpunit/includes/abstract-testcase.php?rev=50697#L41

## To Test

All PHPUnit tests in affected files should continue to pass

Note: This is currently based on ~~the branch in #192~~ `release/2.4.0` to catch the tests added in that branch, so it will have to be rebased against develop once it lands.