### PR TITLE
Release 2.4.0 (#200)

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -1,4 +1,4 @@
-name: CS & Tests
+name: CS & Lint
 
 on:
   # Run on all pushes and on all pull requests.
@@ -68,62 +68,3 @@ jobs:
 
 #      - name: Show PHPCS results in PR
 #        run: cs2pr ./phpcs-report.xml
-
-  test:
-    name: Integration tests
-    runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allowed_failure }}
-
-    env:
-      WP_VERSION: latest
-      WP_MULTISITE: ${{ matrix.wp_multisite }}
-
-    strategy:
-      matrix:
-        php: [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6' ]
-        allowed_failure: [ false ]
-        wp_multisite: [ 0, 1 ]
-        include:
-          # PHP nightly.
-          - php: '8.1'
-            allowed_failure: true
-            wp_multisite: 0
-          - php: '8.1'
-            allowed_failure: true
-            wp_multisite: 1
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@master
-
-      - name: Setup PHP 7.4
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          coverage: pcov
-          # https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions
-          extensions: curl, dom, exif, fileinfo, hash, json, mbstring, mysqli, libsodium, openssl, pcre, imagick, xml, zip
-
-      - name: Install Composer dependencies (PHP < 8.0 )
-        if: ${{ matrix.php < 8.0 }}
-        uses: ramsey/composer-install@v1
-
-      - name: Install Composer dependencies (PHP >= 8.0)
-        if: ${{ matrix.php >= 8.0 }}
-        uses: ramsey/composer-install@v1
-        with:
-          composer-options: --ignore-platform-reqs
-
-      - name: Setup Problem Matchers for PHPUnit
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-#      - name: Run unit tests
-#        run: composer unit
-
-      - name: Start MySQL Service
-        run: sudo systemctl start mysql.service
-
-      - name: Prepare environment for integration tests
-        run: composer prepare
-
-      - name: Run integration tests
-        run: composer integration

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,67 @@
+name: Integration Tests
+
+on:
+  # Run on all pushes and on all pull requests.
+  # Prevent the "push" build from running when there are only irrelevant changes.
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allowed_failure }}
+
+    env:
+      WP_VERSION: latest
+
+    strategy:
+      matrix:
+        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0' ]
+        allowed_failure: [ false ]
+        include:
+          # PHP nightly.
+          - php: '8.1'
+            allowed_failure: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: Setup PHP 7.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: pcov
+          # https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions
+          extensions: curl, dom, exif, fileinfo, hash, json, mbstring, mysqli, libsodium, openssl, pcre, imagick, xml, zip
+
+      - name: Install Composer dependencies (PHP < 8.0 )
+        if: ${{ matrix.php < 8.0 }}
+        uses: ramsey/composer-install@v1
+
+      - name: Install Composer dependencies (PHP >= 8.0)
+        if: ${{ matrix.php >= 8.0 }}
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: --ignore-platform-reqs
+
+      - name: Setup Problem Matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+#      - name: Run unit tests
+#        run: composer unit
+
+      - name: Start MySQL Service
+        run: sudo systemctl start mysql.service
+
+      - name: Prepare environment for integration tests
+        run: composer prepare
+
+      - name: Run integration tests (single site)
+        run: composer integration
+      - name: Run integration tests (multisite)
+        run: composer integration-ms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2021-04-14
+
+### Added
+- Structured data integration tests for posts, pages, category and author archives, and home/front pages.
+- License, `.editorconfig`, `.gitattributes`, `CODEOWNERS`, `CHANGELOG.md`, and other development files.
+- Documentation for hooks.
+- Coding standards and other linting checks.
+- JS Build environment entrypoint.
+
+### Changed
+- Improve WordPress.org assets (screenshots, icons, readme).
+- Switch to using GitHub Actions workflow for CI and WordPress.org deployment.
+- Update scaffolded integration test files.
+- Improve plugin header (support DocBlock format, add textdomain, update information, clarify license, remove to-do's).
+- Separate multisite and single-site tests in CI workflow.
+
+### Fixed
+- Fix metadata for home pages, including pages of older posts.
+- Fix metadata for category archives. 
+
+### Removed
+- Remove Parse.ly metadata from search result pages.
+
 ## [2.3.0] - 2021-03-24
 - Fix and improve Travis configuration.
 - Small maintenance items: merge isset() calls, remove unnecessary typecasting, remove is_null() in favour of null comparison, un-nest nested functions, simplify ternary operators, remove unnecessary local variable, etc.
@@ -165,6 +188,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial version.
 - Add sSupport for parsely-page and JavaScript on home page and published pages and posts as well as archive pages (date/author/category/tag).
 
+[2.4.0]: https://github.com/Parsely/wp-parsely/compare/2.3.0...2.4.0
 [2.3.0]: https://github.com/Parsely/wp-parsely/compare/2.2.1...2.3.0
 [2.2.1]: https://github.com/Parsely/wp-parsely/compare/2.2...2.2.1
 [2.2]: https://github.com/Parsely/wp-parsely/compare/2.1.3...2.2

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Parse.ly
 
-Stable tag: trunk  
+Stable tag: 2.4.0  
 Requires at least: 4.0  
 Tested up to: 5.6  
+Requires PHP: 5.6  
 License: GPLv2 or later  
 Tags: analytics, post, page  
-Contributors: parsely_mike
+Contributors: parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike
 
 The Parse.ly plugin real-time and historical analytics to your content through a platform designed and built for digital publishing.
 

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
       "role": "Developer"
     }
   ],
+  "require": {
+    "php": ">=5.6"
+  },
   "require-dev": {
     "automattic/vipwpcs": "^2.2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
@@ -34,6 +37,10 @@
     ],
     "integration": [
       "@php ./vendor/bin/phpunit --testsuite WP_Tests"
+    ],
+    "integration-ms": [
+      "@putenv WP_MULTISITE=1",
+      "@composer integration"
     ]
   }
 }

--- a/tests/structured-data/archive-post-test.php
+++ b/tests/structured-data/archive-post-test.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Structured Data Tests for non-posts.
+ *
+ * @package Parsely\Tests
+ */
+
+namespace Parsely\Tests;
+
+/**
+ * Structured Data Tests for non-posts.
+ *
+ * @see https://www.parse.ly/help/integration/jsonld
+ * @covers \Parsely::construct_parsely_metadata
+ */
+final class Archive_Post_Test extends TestCase {
+	public function setUp() {
+		parent::setUp();
+
+		update_option( 'show_on_front', 'posts' );
+		delete_option( 'page_for_posts' );
+		delete_option( 'page_on_front' );
+	}
+
+	/**
+	 * Create 2 posts, set posts per page to 1, navigate to page 2 and test the structured data.
+	 */
+	public function test_home_page_for_posts_paged() {
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Insert 2 posts.
+		$page_id = $this->factory()->post->create();
+		$this->factory()->post->create();
+		$page = get_post( $page_id );
+
+		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
+		// See https://github.com/Parsely/wp-parsely/issues/151
+		global $wp_rewrite;
+		$wp_rewrite->set_permalink_structure('/%postname%/');
+
+		// Set the homepage to show 1 post per page.
+		update_option( 'posts_per_page', 1 );
+
+		// Go to Page 2 of posts.
+		$this->go_to( home_url('/page/2' ) );
+
+		// Create the structured data for that post.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
+
+		// Check the required properties exist.
+		$this->assert_data_has_required_properties( $structured_data );
+
+		// The headline should be the name of the site, not the post_title of the latest post.
+		self::assertEquals( 'Test Blog', $structured_data['headline'] );
+		// The URL should be the current page, not the home url.
+		self::assertEquals( home_url('/page/2'), $structured_data['url'] );
+	}
+
+	/**
+	 * Create a single page, set as the posts page (blog archive) but not the home page, go to Page 2, and test the structured data.
+	 */
+	public function test_blog_page_for_posts_paged() {
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Insert a page for the blog posts.
+		$page_id = $this->factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Page for Posts', 'post_name' => 'page-for-posts' ] );
+
+		// Create 2 posts so that posts page has pagination
+		$this->factory()->post->create();
+		$this->factory()->post->create();
+		$page    = get_post( $page_id );
+
+		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
+		// See https://github.com/Parsely/wp-parsely/issues/151
+		global $wp_rewrite;
+		$wp_rewrite->set_permalink_structure('/%postname%/');
+
+		// Set a static page to the homepage, set the newly created page to show the posts, add pagination to posts page
+		update_option( 'show_on_front', 'page' );
+		update_option('page_on_front', 1 );
+		update_option( 'page_for_posts', $page_id );
+		update_option( 'posts_per_page', 1 );
+
+		// Make a request to the root of the site to set the global $wp_query object.
+		$this->go_to( get_permalink( $page_id ) . 'page/2');
+
+		// Create the structured data for that post.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
+
+		// Check the required properties exist.
+		$this->assert_data_has_required_properties( $structured_data );
+
+		// The headline should be the title of the post, not the name of the Site.
+		self::assertEquals( 'Page for Posts', $structured_data['headline'] );
+		self::assertEquals( get_permalink( $page_id ) . 'page/2', $structured_data['url'] );
+	}
+
+	public function test_author_archive() {
+		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
+		// See https://github.com/Parsely/wp-parsely/issues/151
+		$this->set_permalink_structure( '/%postname%/' );
+
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Insert a single user, and a Post assigned to them.
+		$user = self::factory()->user->create( [ 'user_login' => 'parsely' ] );
+		$this->factory()->post->create( [ 'post_author' => $user ] );
+
+		// Make a request to that page to set the global $wp_query object.
+		$author_posts_url = get_author_posts_url( $user );
+		$this->go_to( $author_posts_url );
+
+		// Reset permalinks to default.
+		$this->set_permalink_structure( '' );
+
+		// Create the structured data for that category.
+		// The author archive metadata doesn't use the post data, but the construction method requires it for now.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, get_post() );
+
+		// Check the required properties exist.
+		$this->assert_data_has_required_properties( $structured_data );
+
+		// The headline should be the category name.
+		self::assertEquals( 'Author - parsely', $structured_data['headline'] );
+		self::assertEquals( $author_posts_url, $structured_data['url'] );
+	}
+
+	public function test_term_archive() {
+		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
+		// See https://github.com/Parsely/wp-parsely/issues/151
+		$this->set_permalink_structure( '/%postname%/' );
+
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Insert a single category term, and a Post with that category.
+		$category = self::factory()->category->create( [ 'name' => 'Test Category' ] );
+		self::factory()->post->create( [ 'post_category' => [ $category ] ] );
+
+		// Make a request to that page to set the global $wp_query object.
+		$cat_link = get_category_link( $category );
+		$this->go_to( $cat_link );
+
+		// Reset permalinks to default.
+		$this->set_permalink_structure( '' );
+
+		// Create the structured data for that category.
+		// The category metadata doesn't use the post data, but the construction method requires it for now.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, get_post() );
+
+		// Check the required properties exist.
+		$this->assert_data_has_required_properties( $structured_data );
+
+		// The headline should be the category name.
+		self::assertEquals( 'Test Category', $structured_data['headline'] );
+		self::assertEquals( $cat_link, $structured_data['url'] );
+	}
+
+	public function assert_data_has_required_properties( $structured_data ) {
+		$required_properties = $this->get_required_properties();
+		array_walk(
+			$required_properties,
+			static function( $property, $index ) use ( $structured_data ) {
+				self::assertArrayHasKey( $property, $structured_data, 'Data does not have required property: ' . $property );
+			}
+		);
+	}
+	private function get_required_properties() {
+		return array(
+			'@context',
+			'@type',
+			'headline',
+			'url',
+		);
+	}
+}

--- a/tests/structured-data/single-non-post-test.php
+++ b/tests/structured-data/single-non-post-test.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Structured Data Tests for non-posts.
+ *
+ * @package Parsely\Tests
+ */
+
+namespace Parsely\Tests;
+
+/**
+ * Structured Data Tests for non-posts.
+ *
+ * @see https://www.parse.ly/help/integration/jsonld
+ * @covers \Parsely::construct_parsely_metadata
+ */
+final class Single_Non_Post_Test extends TestCase {
+	public function setUp() {
+		parent::setUp();
+
+		update_option( 'show_on_front', 'posts' );
+		delete_option( 'page_for_posts' );
+		delete_option( 'page_on_front' );
+	}
+
+	/**
+	 * Create a single page, and test the structured data.
+	 */
+	public function test_single_page() {
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Insert a single page.
+		$page_id = $this->factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Single Page', 'post_name' => 'foo' ] );
+		$page    = get_post( $page_id );
+
+		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
+		// See https://github.com/Parsely/wp-parsely/issues/151
+		global $wp_rewrite;
+		$wp_rewrite->set_permalink_structure('/%postname%/');
+
+		// Make a request to that page to set the global $wp_query object.
+		$this->go_to( get_permalink( $page_id ) );
+
+		// Create the structured data for that post.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
+
+		// Check the required properties exist.
+		$this->assert_data_has_required_properties( $structured_data );
+
+		// The headline should be the post_title of the Page.
+		self::assertEquals( 'Single Page', $structured_data['headline'] );
+		self::assertEquals( get_permalink( $page_id ), $structured_data['url'] );
+		self::assertQueryTrue( 'is_page', 'is_singular' );
+
+		// Reset permalinks to Plain.
+		$wp_rewrite->set_permalink_structure('');
+	}
+
+	/**
+	 * Create a single page, set as homepage (blog archive), and test the structured data.
+	 */
+	public function test_home_page_for_posts() {
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Insert a single page.
+		$page_id = $this->factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Page for Posts' ] );
+		$page    = get_post( $page_id );
+
+		// Make a request to the root of the site to set the global $wp_query object.
+		$this->go_to( '/' );
+
+		// Create the structured data for that post.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
+
+		// Check the required properties exist.
+		$this->assert_data_has_required_properties( $structured_data );
+
+		// The headline should be the name of the site, not the post_title of the Page.
+		self::assertEquals( 'Test Blog', $structured_data['headline'] );
+		self::assertEquals( home_url(), $structured_data['url'] );
+	}
+
+	/**
+	 * Create a single page, set as the posts page (blog archive) but not the home page, and test the structured data.
+	 */
+	public function test_blog_page_for_posts() {
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Insert a page for blog posts and insert another post.
+		$page_id = $this->factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Page for Posts', 'post_name' => 'page-for-posts' ] );
+		$this->factory()->post->create();
+		$page    = get_post( $page_id );
+
+		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
+		// See https://github.com/Parsely/wp-parsely/issues/151
+		global $wp_rewrite;
+		$wp_rewrite->set_permalink_structure('/%postname%/');
+
+		// Set a static page to the homepage, set the newly created page to show the posts
+		update_option( 'show_on_front', 'page' );
+		update_option('page_on_front', 1 );
+		update_option( 'page_for_posts', $page_id );
+
+		// Make a request to the root of the site to set the global $wp_query object.
+		$this->go_to( get_permalink( $page_id ) );
+
+		// Create the structured data for that post.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
+
+		// Check the required properties exist.
+		$this->assert_data_has_required_properties( $structured_data );
+
+		// The headline should be the title of the post, not the name of the Site.
+		self::assertEquals( 'Page for Posts', $structured_data['headline'] );
+		self::assertEquals( get_permalink( $page_id ), $structured_data['url'] );
+	}
+
+	/**
+	 * Create a single page, set as homepage (page on front), and test the structured data.
+	 */
+	public function test_home_page_on_front() {
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Insert a single page.
+		$page_id = $this->factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Home' ] );
+		$page    = get_post( $page_id );
+
+		// Set that page as the homepage Page.
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $page_id );
+
+		// Make a request to the root of the site to set the global $wp_query object.
+		$this->go_to( '/' );
+
+		// Create the structured data for that post.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
+
+		// Check the required properties exist.
+		$this->assert_data_has_required_properties( $structured_data );
+
+		// The headline should be the name of the site, not the post_title of the Page.
+		self::assertEquals( 'Test Blog', $structured_data['headline'] );
+		self::assertEquals( home_url(), $structured_data['url'] );
+	}
+
+	/**
+	 * Check for the case when the show_on_front setting is Page, but no Page has been selected.
+	 */
+	public function test_home_for_misconfigured_settings() {
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Insert a single page.
+		$page_id = $this->factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Home' ] );
+		$page    = get_post( $page_id );
+
+		// Set that page as the homepage Page.
+		update_option( 'show_on_front', 'page' );
+		delete_option( 'page_on_front' );
+
+		// Make a request to the root of the site to set the global $wp_query object.
+		$this->go_to( '/' );
+
+		// Create the structured data for that post.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
+
+		// Check the required properties exist.
+		$this->assert_data_has_required_properties( $structured_data );
+
+		// The headline should be the name of the site, not the post_title of the Page.
+		self::assertEquals( 'Test Blog', $structured_data['headline'] );
+		self::assertEquals( home_url(), $structured_data['url'] );
+	}
+
+	public function assert_data_has_required_properties( $structured_data ) {
+		$required_properties = $this->get_required_properties();
+
+		array_walk(
+			$required_properties,
+			static function( $property, $index ) use ( $structured_data ) {
+				self::assertArrayHasKey( $property, $structured_data, 'Data does not have required property: ' . $property );
+			}
+		);
+	}
+
+	private function get_required_properties() {
+		return array(
+			'@context',
+			'@type',
+			'headline',
+			'url',
+		);
+	}
+}

--- a/tests/structured-data/single-post-test.php
+++ b/tests/structured-data/single-post-test.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Structured Data Tests for posts.
+ *
+ * @package Parsely\Tests
+ */
+
+namespace Parsely\Tests;
+
+/**
+ * Structured Data Tests for posts.
+ *
+ * @see https://www.parse.ly/help/integration/jsonld
+ */
+final class Single_Post_Test extends TestCase {
+	/**
+	 * Create a single post, and test the structured data.
+	 */
+	public function test_single_post() {
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Insert a single post and set as global post.
+		$post_id = $this->factory()->post->create();
+		$post    = get_post( $post_id );
+
+		// Make a request to the root of the site to set the global $wp_query object.
+		$this->go_to( get_permalink( $post ) );
+
+		// Create the structured data for that post.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+
+		// Check the required properties exist.
+		$this->assert_data_has_required_properties( $structured_data );
+
+		// Add further checks for this context.
+	}
+
+	public function assert_data_has_required_properties( $structured_data ) {
+		$required_properties = $this->get_required_properties();
+
+		array_walk(
+			$required_properties,
+			static function( $property, $index ) use ( $structured_data ) {
+				self::assertArrayHasKey( $property, $structured_data, 'Data does not have required property: ' . $property );
+			}
+		);
+	}
+
+	private function get_required_properties() {
+		return array(
+			'@context',
+			'@type',
+			'headline',
+			'url',
+			'thumbnailUrl',
+			'datePublished',
+			'articleSection',
+			'creator',
+			'keywords',
+		);
+	}
+}


### PR DESCRIPTION
* Tests: Add structured data tests

Only for posts and pages.

Check for required properties, and check how various front page setting combinations are handled to ensure page_as_posts gives the correct metadata.

See #107.

* Home page: Check is_front_page() earlier

Because the front page is a special circumstance for Pages, then the `is_front_page()` check needs to come before the check for regular page types.

With the check now earlier, the headline and URL will correctly represent the home page of a site (site name, rather than Page title).

Fixes #107.

Also: Handle misconfigured front page settings

When the settings are to show a page on the front, but not Page has been set, then `is_front_page()` returns false.

In terms of generating the Parsely metadata though, whatever is showing at the root of the site, should still show the site name and home URL.

* Add checks for paged archives and is_home()

This will make sure that if the homepage is paged, like `wpvip.com/page/2/` - that the paged URL will show instead of the homepage.

It also makes sure that if the blog page is not the homepage, we also set the right metadata.

* Add unit test for blog archive not on homepage

This tests cases where the homepage is a static page and the blog archive is a separate page.  We want to make sure the blog archive page has the right metadata from the page and not from the posts in the archive.

* Add tests for home and blog page archives

These tests are for paged blog archives when they are on the homepage or on a separate blogs page.

Examples:

```
wpvip.com/page/2
wpvip.com/blog/page/2
```

* PHP: Specify minimum version

Can be used for highlighting incompatible syntax from newer versions of PHP, and let's users know what versions of PHP the plugin works on.

* Adjust plugins headers

- Use a format which supports both WordPress plugin headers requirements, and phpDoc file-level DocBlock format.
- Add a text-domain header to allow translations on translate.wordpress.org.
- Change the plugin URL to be specific to the WordPress integration help docs.
- Add a header to allow updating directly from GitHub via the https://github.com/afragen/git-updater plugin.
- Clarify the license as being GPL v2 _or later_, which matches WordPress core.
- Add "Requires PHP" header, which has no real effect as it's currently the same low level as WordPress core, but it clarifies that a higher version of PHP is not needed.
- Set the author as Parse.ly and author URL as Parse.ly website.
- Removed To-Do items, as there are better places to put these (GitHub issues).

* CI: Small changes

- Splits the jobs into different workflows to give more readable job names.
- Move multisite integration tests from its own job in the matrix, to its own step in the existing job for a version of PHP.

* Tests: Add tests for category metadata

See #155.

* Tests: Add author archive metadata test

See #155.

* Fix metadata for category archives

The plugin would often return metadata from the first post on the category archive rather than the metadata associated with the archive page itself.

This caused incorrect data to be tracked in the dashboard for both the page as well as the post providing the incorrect metadata.

See #155.

* Docs: Update contributors

* Add change log for 2.4.0

* Metadata: Don't show for search results pages

There is logic on the Parse.ly end to exclude search results pages when crawling, so it doesn't make sense to have the request for those pages going through the logic of potentially constructing meta data only to output a redundant meta tag and some HTML comments.

Fixes #201.

* Update changelog

* Update version to 2.4.0

Updates Readme and plugin bootstrap file

Co-authored-by: Jeff Bowen <jblz@users.noreply.github.com>
Co-authored-by: mikeyarce <mikeyarce@gmail.com>
Co-authored-by: hbbtstar <xand.lourenco@automattic.com>
Co-authored-by: Alexander Lourenco <alexander.lourenco@gmail.com>