### PR TITLE
Docs: Use standard markdown for code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,12 @@ Dash code will only be placed on pages and posts which have been published in Wo
 
 You can use the `after_set_parsely_page` filter, which sends three arguments: the array of metadata, the post object, and the `parselyOptions` array:
 
-```
-function filter_parsely_page($parselyPage, $post, $parselyOptions ) {
-  $parselyPage['articleSection'] = ; // whatever values you want Parse.ly's Section to be
-  return $parselyPage;
-}
-
-add_filter( 'after_set_parsely_page', 'filter_parsely_page', 10, 3);
-```
+    add_filter( 'after_set_parsely_page', 'filter_parsely_page', 10, 3 );
+    function filter_parsely_page( $parselyPage, $post, $parselyOptions ) {
+        $parselyPage['articleSection'] = '...'; // Whatever values you want Parse.ly's Section to be.
+				
+        return $parselyPage;
+    }
 
 This filter can go anywhere in your codebase, provided it always gets loaded. We recommend putting it in your header file, so that it gets loaded with wp_head.
 


### PR DESCRIPTION
Standard markdown code blocks use four-space indentation to delimit code blocks, and this is what's needed for correct viewing on WordPress.org.