### PR TITLE
Fix require_recrawl warnings

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -429,7 +429,7 @@ class Parsely {
 				'title'            => __( 'Track Logged-in Users', 'wp-parsely' ), // Passed for legend element.
 				'option_key'       => 'track_authenticated_users',
 				'help_text'        => $h,
-				'requires_recrawl' => true,
+				'requires_recrawl' => false,
 			)
 		);
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -1271,9 +1271,6 @@ class Parsely {
 				echo ' ' . esc_attr( $key ) . '="' . esc_attr( $val ) . '"';
 			}
 		}
-		if ( isset( $args['requires_recrawl'] ) ) {
-			echo ' data-requires-recrawl="true"';
-		}
 		echo ' />';
 
 		if ( isset( $args['help_text'] ) ) {

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -1140,7 +1140,7 @@ class Parsely {
 		if ( isset( $args['help_text'] ) ) {
 			echo '<div class="parsely-form-controls" data-has-help-text="true">';
 		}
-		if ( isset( $args['requires_recrawl'] ) ) {
+		if ( isset( $args['requires_recrawl'] ) && true === $args['requires_recrawl'] ) {
 			echo '<div class="parsely-form-controls" data-requires-recrawl="true">';
 		}
 
@@ -1191,7 +1191,7 @@ class Parsely {
 		$name    = self::OPTIONS_KEY . "[$id]";
 
 		$has_help_text = isset( $args['help_text'] ) ? ' data-has-help-text="true"' : '';
-		$requires_recrawl = isset( $args['requires_recrawl'] ) && $args['requires_recrawl'] ? ' data-requires-recrawl="true"' : '';
+		$requires_recrawl = isset( $args['requires_recrawl'] ) && true === $args['requires_recrawl'] ? ' data-requires-recrawl="true"' : '';
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static text attribute key-value. ?>
 		<fieldset class="parsely-form-controls" <?php echo $has_help_text . $requires_recrawl; ?>>
 			<legend class="screen-reader-text"><span><?php echo esc_html( $args['title'] ); ?></span></legend>
@@ -1228,7 +1228,7 @@ class Parsely {
 		if ( isset( $args['help_text'] ) ) {
 			echo '<div class="parsely-form-controls" data-has-help-text="true">';
 		}
-		if ( isset( $args['requires_recrawl'] ) ) {
+		if ( isset( $args['requires_recrawl'] ) && true === $args['requires_recrawl'] ) {
 			echo '<div class="parsely-form-controls" data-requires-recrawl="true">';
 		}
 
@@ -1261,7 +1261,7 @@ class Parsely {
 		if ( isset( $args['help_text'] ) ) {
 			echo '<div class="parsely-form-controls" data-has-help-text="true">';
 		}
-		if ( isset( $args['requires_recrawl'] ) ) {
+		if ( isset( $args['requires_recrawl'] ) && true === $args['requires_recrawl'] ) {
 			echo '<div class="parsely-form-controls" data-requires-recrawl="true">';
 		}
 


### PR DESCRIPTION
### Fix `requires_recrawl` check 
The settings can pass either `true` or `false` to `requires_recrawl` but we only check with `isset` which means all the settings get the Warning even if they don't need it.    This fixes that by adding a check to make sure we only display the warning when `requires_recrawl` is set to `true`.

### Set `requires_recrawl => false` for Tracking Logged-In users since this does not require a recrawl

Testing to make sure tracking is removed for logged-in users without needing a recrawl:
1. Make sure the option is enabled first, and then go to a page that is tracked like the homepage.
2. Check to make sure it has this in the source: `<script data-cfasync="false" id="parsely-cfg" data-parsely-site="arstechnica.com" src="//cdn.parsely.com/keys/wpvip.com/p.js"></script>`
3. Disable the tracking for logged-in Users and refresh the page, the tracking script should be gone.

### Remove extra code from `print_text_tag`
There was an additional `data-requires-recrawl` attribute being added to the input within the `print_text_tag` function, but we don't use that to display the Re-crawl Warning  so we don't need to have it there. 