### PR TITLE
Translations: Internationalize strings in PHP

### DIFF
--- a/class-parsely-recommended-widget.php
+++ b/class-parsely-recommended-widget.php
@@ -245,42 +245,42 @@ class Parsely_Recommended_Widget extends WP_Widget {
 		$boost_params = $this->get_boost_params();
 		?>
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">Title:</label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'wp-parsely' ); ?></label>
 			<br>
 			<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" value="<?php echo esc_attr( $title ); ?>" class="widefat" />
 		</p>
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'published_within' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'published_within_label' ) ); ?>">Published within</label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'published_within' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'published_within_label' ) ); ?>"><?php esc_html_e( 'Published within', 'wp-parsely' ); ?></label>
 			<input type="number" id="<?php echo esc_attr( $this->get_field_id( 'published_within' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'published_within' ) ); ?>" value="<?php echo esc_attr( (string) $instance['published_within'] ); ?>" min="0" max="30"
 			       class="tiny-text" aria-labelledby="<?php echo esc_attr( $this->get_field_id( 'published_within_label' ) ); ?> <?php echo esc_attr( $this->get_field_id( 'published_within' ) ); ?> <?php echo esc_attr( $this->get_field_id( 'published_within_unit' ) ); ?>" />
-			<span id="<?php echo esc_attr( $this->get_field_id( 'published_within_unit' ) ); ?>"> days (0 for no limit).</span>
+			<span id="<?php echo esc_attr( $this->get_field_id( 'published_within_unit' ) ); ?>"> <?php esc_html_e( 'days (0 for no limit).', 'wp-parsely' ); ?></span>
 		</p>
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'return_limit' ) ); ?>">Number of posts to show (max 20): </label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'return_limit' ) ); ?>"><?php esc_html_e( 'Number of posts to show (max 20):', 'wp-parsely' ); ?></label>
 			<input type="number" id="<?php echo esc_attr( $this->get_field_id( 'return_limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'return_limit' ) ); ?>" value="<?php echo esc_attr( (string) $instance['return_limit'] ); ?>" min="1" max="20" class="tiny-text" />
 		</p>
 		<p>
 			<fieldset>
-				<legend>Display entries: </legend>
+				<legend><?php esc_html_e( 'Display entries:', 'wp-parsely' ); ?></legend>
 				<p>
 					<input type="radio" id="<?php echo esc_attr( $this->get_field_id( 'display_direction_horizontal' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'display_direction' ) ); ?>"<?php checked( $instance['display_direction'], 'horizontal' ); ?> value="horizontal" />
-					<label for="<?php echo esc_attr( $this->get_field_id( 'display_direction_horizontal' ) ); ?>">Horizontally</label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'display_direction_horizontal' ) ); ?>"><?php esc_html_e( 'Horizontally', 'wp-parsely' ); ?></label>
 					<br />
 					<input type="radio" id="<?php echo esc_attr( $this->get_field_id( 'display_direction_vertical' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'display_direction' ) ); ?>"<?php checked( $instance['display_direction'], 'vertical' ); ?> value="vertical" />
-					<label for="<?php echo esc_attr( $this->get_field_id( 'display_direction_vertical' ) ); ?>">Vertically</label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'display_direction_vertical' ) ); ?>"><?php esc_html_e( 'Vertically', 'wp-parsely' ); ?></label>
 				</p>
 			</fieldset>
 		</p>
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'sort' ) ); ?>">Sort by:</label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'sort' ) ); ?>"><?php esc_html_e( 'Sort by:', 'wp-parsely' ); ?></label>
 			<br>
 			<select id="<?php echo esc_attr( $this->get_field_id( 'sort' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'sort' ) ); ?>" class="widefat">
-				<option<?php selected( $instance['sort'], 'score' ); ?> value="score">Score (relevancy, boostable)</option>
-				<option<?php selected( $instance['sort'], 'pub_date' ); ?> value="pub_date">Publish date (not boostable)</option>
+				<option<?php selected( $instance['sort'], 'score' ); ?> value="score"><?php esc_html_e( 'Score (relevancy, boostable)', 'wp-parsely' ); ?></option>
+				<option<?php selected( $instance['sort'], 'pub_date' ); ?> value="pub_date"><?php esc_html_e( 'Publish date (not boostable)', 'wp-parsely' ); ?></option>
 			</select>
 		</p>
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'boost' ) ); ?>">Boost by:</label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'boost' ) ); ?>"><?php esc_html_e( 'Boost by:', 'wp-parsely' ); ?></label>
 			<br>
 			<select id="<?php echo esc_attr( $this->get_field_id( 'boost' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'boost' ) ); ?>" class="widefat">
 				<?php foreach ( $boost_params as $boost_param => $description ) { ?>
@@ -290,20 +290,20 @@ class Parsely_Recommended_Widget extends WP_Widget {
 
 		</p>
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'img_src' ) ); ?>">Image source:</label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'img_src' ) ); ?>"><?php esc_html_e( 'Image source:', 'wp-parsely' ); ?></label>
 			<br>
 			<select id="<?php echo esc_attr( $this->get_field_id( 'img_src' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'img_src' ) ); ?>" class="widefat">
-				<option<?php selected( $instance['img_src'], 'parsely_thumb' ); ?> value="parsely_thumb">Parse.ly generated thumbnail (85x85px)</option>
-				<option<?php selected( $instance['img_src'], 'original' ); ?> value="original">Original image</option>
-				<option<?php selected( $instance['img_src'], 'none' ); ?> value="none">No image</option>
+				<option<?php selected( $instance['img_src'], 'parsely_thumb' ); ?> value="parsely_thumb"><?php esc_html_e( 'Parse.ly generated thumbnail (85x85px)', 'wp-parsely' ); ?></option>
+				<option<?php selected( $instance['img_src'], 'original' ); ?> value="original"><?php esc_html_e( 'Original image', 'wp-parsely' ); ?></option>
+				<option<?php selected( $instance['img_src'], 'none' ); ?> value="none"><?php esc_html_e( 'No image', 'wp-parsely' ); ?></option>
 			</select>
 		</p>
 		<p>
 			<input type="checkbox" id="<?php echo esc_attr( $this->get_field_id( 'display_author' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'display_author' ) ); ?>" value="display_author"<?php checked( $instance['display_author'], 'display_author' ); ?> />
-			<label for="<?php echo esc_attr( $this->get_field_id( 'display_author' ) ); ?>">Display author</label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'display_author' ) ); ?>"><?php esc_html_e( 'Display author', 'wp-parsely' ); ?></label>
 			<br />
 			<input type="checkbox" id="<?php echo esc_attr( $this->get_field_id( 'personalize_results' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'personalize_results' ) ); ?>" value="personalize_results"<?php checked( $instance['personalize_results'], 'personalize_results' ); ?> />
-			<label for="<?php echo esc_attr( $this->get_field_id( 'personalize_results' ) ); ?>">Personalize recommended results</label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'personalize_results' ) ); ?>"><?php esc_html_e( 'Personalize recommended results', 'wp-parsely' ); ?></label>
 		</p>
 
 

--- a/parsely-settings.php
+++ b/parsely-settings.php
@@ -9,16 +9,18 @@
  * @subpackage Parse.ly
  */
 
+/* translators: %s: Plugin version */
+$version_string = sprintf( __( 'Version %s', 'wp-parsely' ), $this::VERSION );
 ?>
 
 <div class="wrap">
-	<h2>Parse.ly - Settings <span id="wp-parsely_version">Version <?php echo esc_html( $this::VERSION ); ?></span></h2>
+	<h2><?php echo esc_html( get_admin_page_title() ); ?> <span id="wp-parsely_version"><?php echo esc_html( $version_string ); ?></span></h2>
 	<form name="parsely" method="post" action="options.php">
 		<?php settings_fields( $this::OPTIONS_KEY ); ?>
 		<?php do_settings_sections( $this::OPTIONS_KEY ); ?>
 		<p class="submit">
 			<input name="submit" type="submit" class="button-primary"
-				value="<?php esc_attr_e( 'Save Changes' ); ?>"/>
+				value="<?php esc_attr_e( 'Save Changes', 'wp-parsely' ); ?>"/>
 		</p>
 	</form>
 </div>

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -224,10 +224,7 @@ class Parsely {
 			self::MENU_SLUG
 		);
 
-		$h      = __( 'Your API secret is your secret code to %s%s%saccess our API.%s
-			It can be found at dash.parsely.com/yoursitedomain/settings/api
-		 ( replace yoursitedomain with your domain name, e.g. `mydomain.com` ) If you haven\'t purchased access to the API, and would
-		  like to do so, email your account manager or support@parsely.com!', 'wp-parsely' );
+		$h      = __( 'Your API secret is your secret code to %s%s%saccess our API.%s It can be found at dash.parsely.com/yoursitedomain/settings/api ( replace yoursitedomain with your domain name, e.g. `mydomain.com` ) If you haven\'t purchased access to the API, and would like to do so, email your account manager or support@parsely.com!', 'wp-parsely' );
 		$h_link = 'https://www.parse.ly/help/api/analytics/';
 
 		$field_args = array(
@@ -262,8 +259,7 @@ class Parsely {
 		);
 
 		// Clear metadata.
-		$h = __( 'Check this radio button and hit "Save Changes" to clear all metadata information for Parse.ly posts and re-send all metadata
-		to Parse.ly. WARNING: do not do this unless explicitly instructed by Parse.ly Staff!', 'wp-parsely' );
+		$h = __( 'Check this radio button and hit "Save Changes" to clear all metadata information for Parse.ly posts and re-send all metadata to Parse.ly. WARNING: do not do this unless explicitly instructed by Parse.ly Staff!', 'wp-parsely' );
 		add_settings_field(
 			'parsely_wipe_metadata_cache',
 			__( 'Wipe Parse.ly Metadata Info', 'wp-parsely' ),
@@ -277,9 +273,7 @@ class Parsely {
 			)
 		);
 
-		$h      = __( 'Choose the metadata format for our crawlers to access. ' .
-			'Most publishers are fine with JSON-LD ( %s%s%shttps://www.parse.ly/help/integration/jsonld/%s ), ' .
-			'but if you prefer to use our proprietary metadata format then you can do so here.', 'wp-parsely' );
+		$h      = __( 'Choose the metadata format for our crawlers to access. Most publishers are fine with JSON-LD ( %s%s%shttps://www.parse.ly/help/integration/jsonld/%s ), but if you prefer to use our proprietary metadata format then you can do so here.', 'wp-parsely' );
 		$h_link = 'https://www.parse.ly/help/integration/jsonld/';
 
 		add_settings_field(
@@ -321,11 +315,7 @@ class Parsely {
 		);
 
 		// Content ID Prefix.
-		$h = __( 'If you use more than one content management system (e.g. ' .
-			'WordPress and Drupal), you may end up with duplicate content ' .
-			'IDs. Adding a Content ID Prefix will ensure the content IDs ' .
-			'from WordPress will not conflict with other content management ' .
-			'systems. We recommend using "WP-" for your prefix.', 'wp-parsely' );
+		$h = __( 'If you use more than one content management system (e.g. WordPress and Drupal), you may end up with duplicate content IDs. Adding a Content ID Prefix will ensure the content IDs from WordPress will not conflict with other content management systems. We recommend using "WP-" for your prefix.', 'wp-parsely' );
 
 		$field_args = array(
 			'option_key'       => 'content_id_prefix',
@@ -345,10 +335,7 @@ class Parsely {
 		);
 
 		// Disable javascript.
-		$h = __( 'If you use a separate system for JavaScript tracking ( Tealium / Segment / Google Tag Manager / other tag manager solution ) ' .
-			'you may want to use that instead of having the plugin load the tracker. WARNING: disabling this option ' .
-			'will also disable the "Personalize Results" section of the recommended widget! We highly recommend leaving ' .
-			'this option set to "No"!', 'wp-parsely' );
+		$h = __( 'If you use a separate system for JavaScript tracking ( Tealium / Segment / Google Tag Manager / other tag manager solution ) you may want to use that instead of having the plugin load the tracker. WARNING: disabling this option will also disable the "Personalize Results" section of the recommended widget! We highly recommend leaving this option set to "No"!', 'wp-parsely' );
 		add_settings_field(
 			'disable_javascript',
 			__( 'Disable JavaScript', 'wp-parsely' ),
@@ -363,8 +350,7 @@ class Parsely {
 		);
 
 		// Disable amp tracking.
-		$h = __( 'If you use a separate system for JavaScript tracking on AMP pages ( Tealium / Segment / Google Tag Manager / other tag manager solution ) ' .
-			'you may want to use that instead of having the plugin load the tracker.', 'wp-parsely' );
+		$h = __( 'If you use a separate system for JavaScript tracking on AMP pages ( Tealium / Segment / Google Tag Manager / other tag manager solution ) you may want to use that instead of having the plugin load the tracker.', 'wp-parsely' );
 		add_settings_field(
 			'disable_amp',
 			__( 'Disable AMP Tracking', 'wp-parsely' ),
@@ -379,10 +365,7 @@ class Parsely {
 		);
 
 		// Use top-level categories.
-		$h = __( 'The plugin will use the first category assigned to a post. ' .
-			'With this option selected, if you post a story to News > ' .
-			'National > Florida, the plugin will use the "News" for the ' .
-			'section name in your dashboard instead of "Florida".', 'wp-parsely' );
+		$h = __( 'The plugin will use the first category assigned to a post. With this option selected, if you post a story to News > National > Florida, the plugin will use the "News" for the section name in your dashboard instead of "Florida".', 'wp-parsely' );
 		add_settings_field(
 			'use_top_level_cats',
 			__( 'Use Top-Level Categories for Section', 'wp-parsely' ),
@@ -397,9 +380,7 @@ class Parsely {
 		);
 
 		// Allow use of custom taxonomy to populate articleSection in parselyPage; defaults to category.
-		$h = __( 'By default, the section value in your Parse.ly dashboard maps to a post\'s category. ' .
-			'You can optionally choose a custom taxonomy, if you\'ve created one, to ' .
-			'populate the section value instead.', 'wp-parsely' );
+		$h = __( 'By default, the section value in your Parse.ly dashboard maps to a post\'s category. You can optionally choose a custom taxonomy, if you\'ve created one, to populate the section value instead.', 'wp-parsely' );
 		add_settings_field(
 			'custom_taxonomy_section',
 			__( 'Use Custom Taxonomy for Section', 'wp-parsely' ),
@@ -416,10 +397,7 @@ class Parsely {
 		);
 
 		// Use categories and custom taxonomies as tags.
-		$h = __( 'You can use this option to add all assigned categories and taxonomies to ' .
-			'your tags.  For example, if you had a post assigned to ' .
-			'the categories: "Business/Tech", "Business/Social", your tags would include ' .
-			'"Business/Tech" and "Business/Social" in addition to your other tags.', 'wp-parsely' );
+		$h = __( 'You can use this option to add all assigned categories and taxonomies to your tags.  For example, if you had a post assigned to the categories: "Business/Tech", "Business/Social", your tags would include "Business/Tech" and "Business/Social" in addition to your other tags.', 'wp-parsely' );
 		add_settings_field(
 			'cats_as_tags',
 			__( 'Add Categories to Tags', 'wp-parsely' ),
@@ -434,11 +412,7 @@ class Parsely {
 		);
 
 		// Track logged-in users.
-		$h = __( 'By default, the plugin will track the activity of users that ' .
-			'are logged into this site. You can change this setting to only ' .
-			'track the activity of anonymous visitors. Note: You will no ' .
-			'longer see the Parse.ly tracking code on your site if you ' .
-			'browse while logged in.', 'wp-parsely' );
+		$h = __( 'By default, the plugin will track the activity of users that are logged into this site. You can change this setting to only track the activity of anonymous visitors. Note: You will no longer see the Parse.ly tracking code on your site if you browse while logged in.', 'wp-parsely' );
 		add_settings_field(
 			'track_authenticated_users',
 			__( 'Track Logged-in Users', 'wp-parsely' ),
@@ -453,9 +427,7 @@ class Parsely {
 		);
 
 		// Lowercase all tags.
-		$h = __( 'By default, the plugin will use lowercase versions of your ' .
-			'tags to correct for potential misspellings. You can change this ' .
-			'setting to ensure that tag names are used verbatim.', 'wp-parsely' );
+		$h = __( 'By default, the plugin will use lowercase versions of your tags to correct for potential misspellings. You can change this setting to ensure that tag names are used verbatim.', 'wp-parsely' );
 		add_settings_field(
 			'lowercase_tags',
 			__( 'Lowercase All Tags', 'wp-parsely' ),
@@ -469,9 +441,7 @@ class Parsely {
 			)
 		);
 
-		$h = __( 'The plugin uses http canonical URLs by default. If this needs to be forced to use https, set this option ' .
-			' to true. Note: the default is fine for almost all publishers, it\'s unlikely you\'ll have to change this unless' .
-			' directed to do so by a Parse.ly support rep.', 'wp-parsely' );
+		$h = __( 'The plugin uses http canonical URLs by default. If this needs to be forced to use https, set this option to true. Note: the default is fine for almost all publishers, it\'s unlikely you\'ll have to change this unless directed to do so by a Parse.ly support rep.', 'wp-parsely' );
 		add_settings_field(
 			'force_https_canonicals',
 			__( 'Force HTTPS canonicals', 'wp-parsely' ),
@@ -486,8 +456,7 @@ class Parsely {
 		);
 
 		// Allow use of custom taxonomy to populate articleSection in parselyPage; defaults to category.
-		$h = __( 'By default, Parse.ly only tracks the default post type as a post page. ' .
-			'If you want to track custom post types, select them here!', 'wp-parsely' );
+		$h = __( 'By default, Parse.ly only tracks the default post type as a post page. If you want to track custom post types, select them here!', 'wp-parsely' );
 		add_settings_field(
 			'track_post_types',
 			__( 'Post Types To Track', 'wp-parsely' ),
@@ -505,8 +474,7 @@ class Parsely {
 		);
 
 		// Allow use of custom taxonomy to populate articleSection in parselyPage; defaults to category.
-		$h = __( 'By default, Parse.ly only tracks the default page type as a non-post page. ' .
-			'If you want to track custom post types as non-post pages, select them here!', 'wp-parsely' );
+		$h = __( 'By default, Parse.ly only tracks the default page type as a non-post page. If you want to track custom post types as non-post pages, select them here!', 'wp-parsely' );
 		add_settings_field(
 			'track_page_types',
 			__( 'Page Types To Track', 'wp-parsely' ),

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -224,7 +224,7 @@ class Parsely {
 			self::MENU_SLUG
 		);
 
-		$h      = __( 'Your API secret is your secret code to %s%s%saccess our API.%s It can be found at dash.parsely.com/yoursitedomain/settings/api ( replace yoursitedomain with your domain name, e.g. `mydomain.com` ) If you haven\'t purchased access to the API, and would like to do so, email your account manager or support@parsely.com!', 'wp-parsely' );
+		$h      = __( 'Your API secret is your secret code to %1$s%2$s%3$saccess our API.%4$s It can be found at dash.parsely.com/yoursitedomain/settings/api ( replace yoursitedomain with your domain name, e.g. `mydomain.com` ) If you haven\'t purchased access to the API, and would like to do so, email your account manager or support@parsely.com!', 'wp-parsely' );
 		$h_link = 'https://www.parse.ly/help/api/analytics/';
 
 		$field_args = array(
@@ -273,7 +273,7 @@ class Parsely {
 			)
 		);
 
-		$h      = __( 'Choose the metadata format for our crawlers to access. Most publishers are fine with JSON-LD ( %s%s%shttps://www.parse.ly/help/integration/jsonld/%s ), but if you prefer to use our proprietary metadata format then you can do so here.', 'wp-parsely' );
+		$h      = __( 'Choose the metadata format for our crawlers to access. Most publishers are fine with JSON-LD ( %1$s%2$s%3$shttps://www.parse.ly/help/integration/jsonld/%4$s ), but if you prefer to use our proprietary metadata format then you can do so here.', 'wp-parsely' );
 		$h_link = 'https://www.parse.ly/help/integration/jsonld/';
 
 		add_settings_field(
@@ -722,7 +722,7 @@ class Parsely {
 	 */
 	public function print_dynamic_tracking_note() {
 		printf(
-			wp_kses_post( __( 'This plugin does not currently support dynamic tracking ( the tracking of multiple pageviews on a single page). Some common use-cases for dynamic tracking are slideshows or articles loaded via AJAX calls in single-page applications -- situations in which new content is loaded without a full page refresh. Tracking these events requires manually implementing additional JavaScript above <a href="%s">the standard Parse.ly include</a> that the plugin injects into your page source. Please consult <a href="%s">the Parse.ly documentation on dynamic tracking</a> for instructions on implementing dynamic tracking, or contact Parse.ly support (<a href="%s">support@parsely.com</a> ) for additional assistance.', 'wp-parsely' ) ),
+			wp_kses_post( __( 'This plugin does not currently support dynamic tracking ( the tracking of multiple pageviews on a single page). Some common use-cases for dynamic tracking are slideshows or articles loaded via AJAX calls in single-page applications -- situations in which new content is loaded without a full page refresh. Tracking these events requires manually implementing additional JavaScript above <a href="%1$s">the standard Parse.ly include</a> that the plugin injects into your page source. Please consult <a href="%2$s">the Parse.ly documentation on dynamic tracking</a> for instructions on implementing dynamic tracking, or contact Parse.ly support (<a href="%3$s">support@parsely.com</a> ) for additional assistance.', 'wp-parsely' ) ),
 			esc_url( 'http://www.parsely.com/help/integration/basic/' ),
 			esc_url( 'https://www.parsely.com/help/integration/dynamic/' ),
 			esc_url( 'mailto:support@parsely.com' )

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -224,6 +224,7 @@ class Parsely {
 			self::MENU_SLUG
 		);
 
+		/* translators: 1: Opening anchor tag markup, 2: Documentation URL, 3: Opening anchor tag markup continued, 4: Closing anchor tag */
 		$h      = __( 'Your API secret is your secret code to %1$s%2$s%3$saccess our API.%4$s It can be found at dash.parsely.com/yoursitedomain/settings/api ( replace yoursitedomain with your domain name, e.g. `mydomain.com` ) If you haven\'t purchased access to the API, and would like to do so, email your account manager or support@parsely.com!', 'wp-parsely' );
 		$h_link = 'https://www.parse.ly/help/api/analytics/';
 
@@ -273,6 +274,7 @@ class Parsely {
 			)
 		);
 
+		/* translators: 1: Opening anchor tag markup, 2: Documentation URL, 3: Opening anchor tag markup continued, 4: Closing anchor tag */
 		$h      = __( 'Choose the metadata format for our crawlers to access. Most publishers are fine with JSON-LD ( %1$s%2$s%3$shttps://www.parse.ly/help/integration/jsonld/%4$s ), but if you prefer to use our proprietary metadata format then you can do so here.', 'wp-parsely' );
 		$h_link = 'https://www.parse.ly/help/integration/jsonld/';
 
@@ -722,6 +724,7 @@ class Parsely {
 	 */
 	public function print_dynamic_tracking_note() {
 		printf(
+			/* translators: 1: Documentation URL 2: Documentation URL */
 			wp_kses_post( __( 'This plugin does not currently support dynamic tracking ( the tracking of multiple pageviews on a single page). Some common use-cases for dynamic tracking are slideshows or articles loaded via AJAX calls in single-page applications -- situations in which new content is loaded without a full page refresh. Tracking these events requires manually implementing additional JavaScript above <a href="%1$s">the standard Parse.ly include</a> that the plugin injects into your page source. Please consult <a href="%2$s">the Parse.ly documentation on dynamic tracking</a> for instructions on implementing dynamic tracking, or contact Parse.ly support (<a href="%3$s">support@parsely.com</a> ) for additional assistance.', 'wp-parsely' ) ),
 			esc_url( 'http://www.parsely.com/help/integration/basic/' ),
 			esc_url( 'https://www.parsely.com/help/integration/dynamic/' ),

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -36,8 +36,6 @@ class Parsely {
 	 */
 	const VERSION         = '2.4.1';
 	const MENU_SLUG       = 'parsely';             // Defines the page param passed to options-general.php.
-	const MENU_TITLE      = 'Parse.ly';            // Text to be used for the menu as seen in Settings sub-menu.
-	const MENU_PAGE_TITLE = 'Parse.ly > Settings'; // Text shown in <title></title> when the settings screen is viewed.
 	const OPTIONS_KEY     = 'parsely';             // Defines the key used to store options in the WP database.
 	const CAPABILITY      = 'manage_options';      // The capability required for the user to administer settings.
 
@@ -120,7 +118,7 @@ class Parsely {
 	public function wpparsely_add_cron_interval( $schedules ) {
 		$schedules['everytenminutes'] = array(
 			'interval' => 600, // time in seconds.
-			'display'  => 'Every 10 Minutes',
+			'display'  => __( 'Every 10 Minutes', 'wp-parsely' ),
 		);
 		return $schedules;
 	}
@@ -157,8 +155,8 @@ class Parsely {
 	 */
 	public function add_settings_sub_menu() {
 		add_options_page(
-			self::MENU_PAGE_TITLE,
-			self::MENU_TITLE,
+				__( 'Parse.ly Settings', 'wp-parsely' ),
+				__( 'Parse.ly', 'wp-parsely' ),
 			self::CAPABILITY,
 			self::MENU_SLUG,
 			array( $this, 'display_settings' )
@@ -173,7 +171,7 @@ class Parsely {
 	 */
 	public function display_settings() {
 		if ( ! current_user_can( self::CAPABILITY ) ) {
-			wp_die( esc_attr( 'You do not have sufficient permissions to access this page.' ) );
+			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-parsely' ) );
 		}
 
 		include 'parsely-settings.php';
@@ -197,13 +195,13 @@ class Parsely {
 		// These are the Required Settings.
 		add_settings_section(
 			'required_settings',
-			'Required Settings',
+			__( 'Required Settings', 'wp-parsely' ),
 			array( $this, 'print_required_settings' ),
 			self::MENU_SLUG
 		);
 
 		// Get the API Key.
-		$h = 'Your Site ID is your own site domain ( e.g. `mydomain.com` )';
+		$h = __( 'Your Site ID is your own site domain ( e.g. `mydomain.com` )', 'wp-parsely' );
 
 		$field_args = array(
 			'option_key' => 'apikey',
@@ -211,7 +209,7 @@ class Parsely {
 		);
 		add_settings_field(
 			'apikey',
-			'Parse.ly Site ID <div class="help-icons"></div>',
+			__( 'Parse.ly Site ID', 'wp-parsely' ),
 			array( $this, 'print_text_tag' ),
 			self::MENU_SLUG,
 			'required_settings',
@@ -221,15 +219,15 @@ class Parsely {
 		// These are the Optional Settings.
 		add_settings_section(
 			'optional_settings',
-			'Optional Settings',
+			__( 'Optional Settings', 'wp-parsely' ),
 			array( $this, 'print_optional_settings' ),
 			self::MENU_SLUG
 		);
 
-		$h      = 'Your API secret is your secret code to %s%s%saccess our API.%s
+		$h      = __( 'Your API secret is your secret code to %s%s%saccess our API.%s
 			It can be found at dash.parsely.com/yoursitedomain/settings/api
-		 ( replace yoursitedown with your domain name, e.g. `mydomain.com` ) If you haven\'t purchased access to the API, and would
-		  like to do so, email your account manager or support@parsely.com!';
+		 ( replace yoursitedomain with your domain name, e.g. `mydomain.com` ) If you haven\'t purchased access to the API, and would
+		  like to do so, email your account manager or support@parsely.com!', 'wp-parsely' );
 		$h_link = 'https://www.parse.ly/help/api/analytics/';
 
 		$field_args = array(
@@ -239,14 +237,14 @@ class Parsely {
 		);
 		add_settings_field(
 			'api_secret',
-			'Parse.ly API Secret <div class="help-icons"></div>',
+			__( 'Parse.ly API Secret', 'wp-parsely' ),
 			array( $this, 'print_text_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
 			$field_args
 		);
 
-		$h      = 'Your metadata secret is given to you by Parse.ly support. DO NOT enter anything here unless given to you by Parse.ly support!';
+		$h      = __( 'Your metadata secret is given to you by Parse.ly support. DO NOT enter anything here unless given to you by Parse.ly support!', 'wp-parsely' );
 		$h_link = 'https://www.parse.ly/help/api/analytics/';
 
 		$field_args = array(
@@ -256,7 +254,7 @@ class Parsely {
 		);
 		add_settings_field(
 			'metadata_secret',
-			'Parse.ly Metadata Secret <div class="help-icons"></div>',
+			__( 'Parse.ly Metadata Secret', 'wp-parsely' ),
 			array( $this, 'print_text_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -264,11 +262,11 @@ class Parsely {
 		);
 
 		// Clear metadata.
-		$h = 'Check this radio button and hit "Save Changes" to clear all metadata information for Parsely posts and re-send all metadata
-		to Parsely. WARNING: do not do this unless explicitly instructed by Parse.ly Staff!';
+		$h = __( 'Check this radio button and hit "Save Changes" to clear all metadata information for Parse.ly posts and re-send all metadata
+		to Parse.ly. WARNING: do not do this unless explicitly instructed by Parse.ly Staff!', 'wp-parsely' );
 		add_settings_field(
 			'parsely_wipe_metadata_cache',
-			'Wipe Parsely Metadata Info <div class="help-icons"></div>',
+			__( 'Wipe Parse.ly Metadata Info', 'wp-parsely' ),
 			array( $this, 'print_checkbox_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -279,14 +277,14 @@ class Parsely {
 			)
 		);
 
-		$h      = 'Choose the metadata format for our crawlers to access. ' .
+		$h      = __( 'Choose the metadata format for our crawlers to access. ' .
 			'Most publishers are fine with JSON-LD ( %s%s%shttps://www.parse.ly/help/integration/jsonld/%s ), ' .
-			'but if you prefer to use our proprietary metadata format then you can do so here.';
+			'but if you prefer to use our proprietary metadata format then you can do so here.', 'wp-parsely' );
 		$h_link = 'https://www.parse.ly/help/integration/jsonld/';
 
 		add_settings_field(
 			'meta_type',
-			'Metadata Format  <div class="help-icons"></div>',
+			__( 'Metadata Format', 'wp-parsely' ),
 			array( $this, 'print_select_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -304,7 +302,7 @@ class Parsely {
 			)
 		);
 
-		$h = 'If you want to specify the url for your logo, you can do so here.';
+		$h = __( 'If you want to specify the url for your logo, you can do so here.', 'wp-parsely' );
 
 		$option_defaults['logo'] = $this->get_logo_default();
 
@@ -315,7 +313,7 @@ class Parsely {
 
 		add_settings_field(
 			'logo',
-			'Logo <div class="help-icons"></div>',
+			__( 'Logo', 'wp-parsely' ),
 			array( $this, 'print_text_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -323,11 +321,11 @@ class Parsely {
 		);
 
 		// Content ID Prefix.
-		$h = 'If you use more than one content management system (e.g. ' .
+		$h = __( 'If you use more than one content management system (e.g. ' .
 			'WordPress and Drupal), you may end up with duplicate content ' .
 			'IDs. Adding a Content ID Prefix will ensure the content IDs ' .
 			'from WordPress will not conflict with other content management ' .
-			'systems. We recommend using "WP-" for your prefix.';
+			'systems. We recommend using "WP-" for your prefix.', 'wp-parsely' );
 
 		$field_args = array(
 			'option_key'       => 'content_id_prefix',
@@ -339,7 +337,7 @@ class Parsely {
 		);
 		add_settings_field(
 			'content_id_prefix',
-			'Content ID Prefix <div class="help-icons"></div>',
+			__( 'Content ID Prefix', 'wp-parsely' ),
 			array( $this, 'print_text_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -347,13 +345,13 @@ class Parsely {
 		);
 
 		// Disable javascript.
-		$h = 'If you use a separate system for Javascript tracking ( Tealium / Segment / Google Tag Manager / other tag manager solution ) ' .
+		$h = __( 'If you use a separate system for JavaScript tracking ( Tealium / Segment / Google Tag Manager / other tag manager solution ) ' .
 			'you may want to use that instead of having the plugin load the tracker. WARNING: disabling this option ' .
 			'will also disable the "Personalize Results" section of the recommended widget! We highly recommend leaving ' .
-			'this option set to "No"!';
+			'this option set to "No"!', 'wp-parsely' );
 		add_settings_field(
 			'disable_javascript',
-			'Disable Javascript <div class="help-icons"></div>',
+			__( 'Disable JavaScript', 'wp-parsely' ),
 			array( $this, 'print_binary_radio_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -365,11 +363,11 @@ class Parsely {
 		);
 
 		// Disable amp tracking.
-		$h = 'If you use a separate system for Javascript tracking on AMP pages ( Tealium / Segment / Google Tag Manager / other tag manager solution ) ' .
-			'you may want to use that instead of having the plugin load the tracker.';
+		$h = __( 'If you use a separate system for JavaScript tracking on AMP pages ( Tealium / Segment / Google Tag Manager / other tag manager solution ) ' .
+			'you may want to use that instead of having the plugin load the tracker.', 'wp-parsely' );
 		add_settings_field(
 			'disable_amp',
-			'Disable Amp Tracking <div class="help-icons"></div>',
+			__( 'Disable AMP Tracking', 'wp-parsely' ),
 			array( $this, 'print_binary_radio_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -381,13 +379,13 @@ class Parsely {
 		);
 
 		// Use top-level categories.
-		$h = 'wp-parsely will use the first category assigned to a post. ' .
+		$h = __( 'The plugin will use the first category assigned to a post. ' .
 			'With this option selected, if you post a story to News > ' .
-			'National > Florida, wp-parsely will use the "News" for the ' .
-			'section name in your dashboard instead of "Florida".';
+			'National > Florida, the plugin will use the "News" for the ' .
+			'section name in your dashboard instead of "Florida".', 'wp-parsely' );
 		add_settings_field(
 			'use_top_level_cats',
-			'Use Top-Level Categories for Section <div class="help-icons"></div>',
+			__( 'Use Top-Level Categories for Section', 'wp-parsely' ),
 			array( $this, 'print_binary_radio_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -399,12 +397,12 @@ class Parsely {
 		);
 
 		// Allow use of custom taxonomy to populate articleSection in parselyPage; defaults to category.
-		$h = 'By default, the section value in your Parse.ly dashboard maps to a post\'s category. ' .
+		$h = __( 'By default, the section value in your Parse.ly dashboard maps to a post\'s category. ' .
 			'You can optionally choose a custom taxonomy, if you\'ve created one, to ' .
-			'populate the section value instead. ';
+			'populate the section value instead.', 'wp-parsely' );
 		add_settings_field(
 			'custom_taxonomy_section',
-			'Use Custom Taxonomy for Section  <div class="help-icons"></div>',
+			__( 'Use Custom Taxonomy for Section', 'wp-parsely' ),
 			array( $this, 'print_select_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -418,13 +416,13 @@ class Parsely {
 		);
 
 		// Use categories and custom taxonomies as tags.
-		$h = 'You can use this option to add all assigned categories and taxonomies to ' .
+		$h = __( 'You can use this option to add all assigned categories and taxonomies to ' .
 			'your tags.  For example, if you had a post assigned to ' .
 			'the categories: "Business/Tech", "Business/Social", your tags would include ' .
-			'"Business/Tech" and "Business/Social" in addition to your other tags.';
+			'"Business/Tech" and "Business/Social" in addition to your other tags.', 'wp-parsely' );
 		add_settings_field(
 			'cats_as_tags',
-			'Add Categories to Tags <div class="help-icons"></div>',
+			__( 'Add Categories to Tags', 'wp-parsely' ),
 			array( $this, 'print_binary_radio_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -436,14 +434,14 @@ class Parsely {
 		);
 
 		// Track logged-in users.
-		$h = 'By default, wp-parsely will track the activity of users that ' .
+		$h = __( 'By default, the plugin will track the activity of users that ' .
 			'are logged into this site. You can change this setting to only ' .
 			'track the activity of anonymous visitors. Note: You will no ' .
 			'longer see the Parse.ly tracking code on your site if you ' .
-			'browse while logged in.';
+			'browse while logged in.', 'wp-parsely' );
 		add_settings_field(
 			'track_authenticated_users',
-			'Track Logged-in Users <div class="help-icons"></div>',
+			__( 'Track Logged-in Users', 'wp-parsely' ),
 			array( $this, 'print_binary_radio_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -455,12 +453,12 @@ class Parsely {
 		);
 
 		// Lowercase all tags.
-		$h = 'By default, wp-parsely will use lowercase versions of your ' .
+		$h = __( 'By default, the plugin will use lowercase versions of your ' .
 			'tags to correct for potential misspellings. You can change this ' .
-			'setting to ensure that tag names are used verbatim.';
+			'setting to ensure that tag names are used verbatim.', 'wp-parsely' );
 		add_settings_field(
 			'lowercase_tags',
-			'Lowercase All Tags <div class="help-icons"></div>',
+			__( 'Lowercase All Tags', 'wp-parsely' ),
 			array( $this, 'print_binary_radio_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -471,12 +469,12 @@ class Parsely {
 			)
 		);
 
-		$h = 'wp-parsely uses http canonical URLs by default. If this needs to be forced to use https, set this option ' .
+		$h = __( 'The plugin uses http canonical URLs by default. If this needs to be forced to use https, set this option ' .
 			' to true. Note: the default is fine for almost all publishers, it\'s unlikely you\'ll have to change this unless' .
-			' directed to do so by a Parsely support rep.';
+			' directed to do so by a Parse.ly support rep.', 'wp-parsely' );
 		add_settings_field(
 			'force_https_canonicals',
-			'Force HTTPS canonicals <div class="help-icons"></div>',
+			__( 'Force HTTPS canonicals', 'wp-parsely' ),
 			array( $this, 'print_binary_radio_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -488,11 +486,11 @@ class Parsely {
 		);
 
 		// Allow use of custom taxonomy to populate articleSection in parselyPage; defaults to category.
-		$h = 'By default, Parsely only tracks the default post type as a post page. ' .
-			'If you want to track custom post types, select them here!';
+		$h = __( 'By default, Parse.ly only tracks the default post type as a post page. ' .
+			'If you want to track custom post types, select them here!', 'wp-parsely' );
 		add_settings_field(
 			'track_post_types',
-			'Post Types To Track  <div class="help-icons"></div>',
+			__( 'Post Types To Track', 'wp-parsely' ),
 			array( $this, 'print_select_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -507,11 +505,11 @@ class Parsely {
 		);
 
 		// Allow use of custom taxonomy to populate articleSection in parselyPage; defaults to category.
-		$h = 'By default, Parsely only tracks the default page type as a non-post page. ' .
-			'If you want to track custom post types as non-post pages, select them here!';
+		$h = __( 'By default, Parse.ly only tracks the default page type as a non-post page. ' .
+			'If you want to track custom post types as non-post pages, select them here!', 'wp-parsely' );
 		add_settings_field(
 			'track_page_types',
-			'Page Types To Track  <div class="help-icons"></div>',
+			__( 'Page Types To Track', 'wp-parsely' ),
 			array( $this, 'print_select_tag' ),
 			self::MENU_SLUG,
 			'optional_settings',
@@ -528,7 +526,7 @@ class Parsely {
 		// Dynamic tracking note.
 		add_settings_field(
 			'dynamic_tracking_note',
-			'Note: ',
+			__( 'Note: ', 'wp-parsely' ),
 			array( $this, 'print_dynamic_tracking_note' ),
 			self::MENU_SLUG,
 			'optional_settings'
@@ -564,7 +562,7 @@ class Parsely {
 			add_settings_error(
 				self::OPTIONS_KEY,
 				'apikey',
-				'Please specify the Site ID'
+				__( 'Please specify the Site ID', 'wp-parsely' )
 			);
 		} else {
 			$input['apikey'] = strtolower( $input['apikey'] );
@@ -573,7 +571,7 @@ class Parsely {
 				add_settings_error(
 					self::OPTIONS_KEY,
 					'apikey',
-					'Your Parse.ly Site ID looks incorrect, it should look like "example.com".'
+					__( 'Your Parse.ly Site ID looks incorrect, it should look like "example.com".', 'wp-parsely' )
 				);
 			}
 		}
@@ -604,7 +602,7 @@ class Parsely {
 			add_settings_error(
 				self::OPTIONS_KEY,
 				'use_top_level_cats',
-				'Value passed for use_top_level_cats must be either "true" or "false".'
+				__( 'Value passed for use_top_level_cats must be either "true" or "false".', 'wp-parsely' )
 			);
 		} else {
 			$input['use_top_level_cats'] = 'true' === $input['use_top_level_cats'];
@@ -615,7 +613,7 @@ class Parsely {
 			add_settings_error(
 				self::OPTIONS_KEY,
 				'cats_as_tags',
-				'Value passed for cats_as_tags must be either "true" or "false".'
+				__( 'Value passed for cats_as_tags must be either "true" or "false".', 'wp-parsely' )
 			);
 		} else {
 			$input['cats_as_tags'] = 'true' === $input['cats_as_tags'];
@@ -626,7 +624,7 @@ class Parsely {
 			add_settings_error(
 				self::OPTIONS_KEY,
 				'track_authenticated_users',
-				'Value passed for track_authenticated_users must be either "true" or "false".'
+				__( 'Value passed for track_authenticated_users must be either "true" or "false".', 'wp-parsely' )
 			);
 		} else {
 			$input['track_authenticated_users'] = 'true' === $input['track_authenticated_users'];
@@ -637,7 +635,7 @@ class Parsely {
 			add_settings_error(
 				self::OPTIONS_KEY,
 				'lowercase_tags',
-				'Value passed for lowercase_tags must be either "true" or "false".'
+				__( 'Value passed for lowercase_tags must be either "true" or "false".', 'wp-parsely' )
 			);
 		} else {
 			$input['lowercase_tags'] = 'true' === $input['lowercase_tags'];
@@ -647,7 +645,7 @@ class Parsely {
 			add_settings_error(
 				self::OPTIONS_KEY,
 				'force_https_canonicals',
-				'Value passed for force_https_canonicals must be either "true" or "false".'
+				__( 'Value passed for force_https_canonicals must be either "true" or "false".', 'wp-parsely' )
 			);
 		} else {
 			$input['force_https_canonicals'] = 'true' === $input['force_https_canonicals'];
@@ -657,7 +655,7 @@ class Parsely {
 			add_settings_error(
 				self::OPTIONS_KEY,
 				'disable_javascript',
-				'Value passed for disable_javascript must be either "true" or "false".'
+				__( 'Value passed for disable_javascript must be either "true" or "false".', 'wp-parsely' )
 			);
 		} else {
 			$input['disable_javascript'] = 'true' === $input['disable_javascript'];
@@ -667,7 +665,7 @@ class Parsely {
 			add_settings_error(
 				self::OPTIONS_KEY,
 				'disable_amp',
-				'Value passed for disable_amp must be either "true" or "false".'
+				__( 'Value passed for disable_amp must be either "true" or "false".', 'wp-parsely' )
 			);
 		} else {
 			$input['disable_amp'] = 'true' === $input['disable_amp'];
@@ -678,7 +676,7 @@ class Parsely {
 				add_settings_error(
 					self::OPTIONS_KEY,
 					'metadata_secret',
-					'Metadata secret is incorrect. Please contact Parse.ly support!'
+					__( 'Metadata secret is incorrect. Please contact Parse.ly support!', 'wp-parsely' )
 				);
 			} elseif ( 'true' === $input['parsely_wipe_metadata_cache'] ) {
 				delete_post_meta_by_key( 'parsely_metadata_last_updated' );
@@ -721,7 +719,7 @@ class Parsely {
 	 * @param array $links The links to add.
 	 */
 	public function add_plugin_meta_links( $links ) {
-		array_unshift( $links, '<a href="' . esc_url( $this->get_settings_url() ) . '">' . __( 'Settings' ) . '</a>' );
+		array_unshift( $links, '<a href="' . esc_url( $this->get_settings_url() ) . '">' . __( 'Settings', 'wp-parsely' ) . '</a>' );
 		return $links;
 	}
 
@@ -733,20 +731,19 @@ class Parsely {
 	 */
 	public function display_admin_warning() {
 		$options = $this->get_options();
-		if ( ! isset( $options['apikey'] ) || empty( $options['apikey'] ) ) {
-			?>
-			<div id='message' class='error'>
-				<p>
-					<strong>Parse.ly - Dash plugin is not active.</strong>
-					You need to
-					<a href='<?php echo esc_url( $this->get_settings_url() ); ?>'>
-						provide your Parse.ly Dash Site ID
-					</a>
-					before things get cooking.
-				</p>
-			</div>
-			<?php
+
+		if ( isset( $options['apikey'] ) && ! empty( $options['apikey'] ) ) {
+			return;
 		}
+
+		$message = sprintf(
+				/* translators: %s: Plugin settings page URL */
+				__( '<strong>The Parse.ly plugin is not active.</strong> You need to <a href="%s">provide your Parse.ly Dash Site ID</a> before things get cooking.', 'wp-parsley' ),
+				 esc_url( $this->get_settings_url() )
+		);
+		?>
+		<div id="message" class="error"><p><?php echo wp_kses_post( $message ); ?></p></div>
+		<?php
 	}
 
 	/**
@@ -757,7 +754,7 @@ class Parsely {
 	 */
 	public function print_dynamic_tracking_note() {
 		printf(
-			'This plugin does not currently support dynamic tracking ( the tracking of multiple pageviews on a single page). Some common use-cases for dynamic tracking are slideshows or articles loaded via AJAX calls in single-page applications -- situations in which new content is loaded without a full page refresh. Tracking these events requires manually implementing additional JavaScript above <a href="%s">the standard Parse.ly include</a> that the plugin injects into your page source. Please consult <a href="%s">the Parse.ly documentation on dynamic tracking</a> for instructions on implementing dynamic tracking, or contact Parse.ly support (<a href="%s">support@parsely.com</a> ) for additional assistance.',
+			wp_kses_post( __( 'This plugin does not currently support dynamic tracking ( the tracking of multiple pageviews on a single page). Some common use-cases for dynamic tracking are slideshows or articles loaded via AJAX calls in single-page applications -- situations in which new content is loaded without a full page refresh. Tracking these events requires manually implementing additional JavaScript above <a href="%s">the standard Parse.ly include</a> that the plugin injects into your page source. Please consult <a href="%s">the Parse.ly documentation on dynamic tracking</a> for instructions on implementing dynamic tracking, or contact Parse.ly support (<a href="%s">support@parsely.com</a> ) for additional assistance.', 'wp-parsely' ) ),
 			esc_url( 'http://www.parsely.com/help/integration/basic/' ),
 			esc_url( 'https://www.parsely.com/help/integration/dynamic/' ),
 			esc_url( 'mailto:support@parsely.com' )
@@ -836,13 +833,17 @@ class Parsely {
 			$parsely_page['url']      = $current_url;
 		} elseif ( is_date() ) {
 			if ( is_year() ) {
-				$parsely_page['headline'] = 'Yearly Archive - ' . get_the_time( 'Y' );
+				/* translators: %s: Archive year */
+				$parsely_page['headline'] = sprintf( __( 'Yearly Archive - %s', 'wp-parsely' ), get_the_time( 'Y' ) );
 			} elseif ( is_month() ) {
-				$parsely_page['headline'] = 'Monthly Archive - ' . get_the_time( 'F, Y' );
+				/* translators: %s: Archive month, formatted as F, Y */
+				$parsely_page['headline'] = sprintf( __( 'Monthly Archive - %s', 'wp-parsely' ), get_the_time( 'F, Y' ) );
 			} elseif ( is_day() ) {
-				$parsely_page['headline'] = 'Daily Archive - ' . get_the_time( 'F jS, Y' );
+				/* translators: %s: Archive day, formatted as F jS, Y */
+				$parsely_page['headline'] = sprintf( __( 'Daily Archive - %s', 'wp-parsely' ), get_the_time( 'F jS, Y' ) );
 			} elseif ( is_time() ) {
-				$parsely_page['headline'] = 'Hourly, Minutely, or Secondly Archive - ' . get_the_time( 'F jS g:i:s A' );
+				/* translators: %s: Archive time, formatted as F jS g:i:s A */
+				$parsely_page['headline'] = sprintf( __( 'Hourly, Minutely, or Secondly Archive - %s', 'wp-parsely' ), get_the_time( 'F jS g:i:s A' ) );
 			}
 			$parsely_page['url'] = $current_url;
 		} elseif ( is_tag() ) {
@@ -850,7 +851,8 @@ class Parsely {
 			if ( empty( $tag ) ) {
 				$tag = single_term_title( '', false );
 			}
-			$parsely_page['headline'] = $this->get_clean_parsely_page_value( 'Tagged - ' . $tag );
+			/* translators: %s: Tag name */
+			$parsely_page['headline'] = $this->get_clean_parsely_page_value( sprintf( __( 'Tagged - %s', 'wp-parsely' ), $tag ) );
 			$parsely_page['url']      = $current_url;
 		} elseif ( in_array( get_post_type( $post ), $parsely_options['track_post_types'], true ) && 'publish' === $post->post_status ) {
 			$authors  = $this->get_author_names( $post );
@@ -1660,7 +1662,7 @@ class Parsely {
 	 */
 	public function insert_parsely_tracking_fbia( &$registry ) {
 		$options      = $this->get_options();
-		$display_name = 'Parsely Analytics';
+		$display_name = 'Parsely Analytics'; // Do not translate at this time.
 		$identifier   = 'parsely-analytics-for-wordpress';
 
 		$embed_code = '<script>


### PR DESCRIPTION
This PR is made up of four commits which make a big dent into supporting translations (#225).

To see all PHP strings are internationalized, apply the PR locally and add the following to the bottom of the `wp-parsely.php` file:

```
add_filter( 'gettext', '__return_empty_string', PHP_INT_MAX );
add_filter( 'gettext_with_context', '__return_empty_string', PHP_INT_MAX );
add_filter( 'ngettext', '__return_empty_string', PHP_INT_MAX );
add_filter( 'ngettext_with_context', '__return_empty_string', PHP_INT_MAX );
```
This will replace all internationalized strings with an empty string - so any strings remaining are not internationalised. The screenshot below shows this in action (the Important string is added via JS, not PHP, and is outside the scope of this PR):

<img width="607" alt="Screenshot 2021-04-16 at 00 06 11" src="https://user-images.githubusercontent.com/88371/114948768-9be0ce00-9e47-11eb-85c1-5582ac23cb64.png">

----

## 1. Internationalize strings in PHP

To allow strings to be displayed in other locales, we have to wrap them in i18n functions.

Also:
- Added text domains where they were missing (better to include strings under the plugin's text domain, than re-use strings from core's language packs.
- Fixed a couple of types / incorrect capitalizations.
- Adding some translator comments.

## 2. Fix concatenated i18n strings

The `WordPress.WP.I18n.NonSingularStringLiteralText` PHPCS sniff checks if the `$text_arg` from i18n functions contains a single string literal, which is required to properly extract the string.

This fixes the arguments that contained concatenated strings.

Strings literals can't be broken onto multiple lines, as while the display is fine (browsers normalize the line break into a space), the translatable string in the .pot file contains `\n` and a number of `\t` tab characters, which is undesirable for translation contributors to deal with.

## 3. Use numbered placeholders

Multiple placeholders should be ordered (`WordPress.WP.I18n.UnorderedPlaceholdersText`).

Some help texts contain multiple placeholders to handle anchor elements within the text (these don't need to be abstracted away - simple HTML is fine to include in translatable strings. Fixing this requires changing how the `$help_link` code works though, which falls outside the scope of these changes).

## 4. Add missing translator comments

These help translators to understand what the placeholders will be replaced with to give them more context when translating.