### PR TITLE
GitHub Actions: Update correct PHP versions for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@master
 
-      - name: Setup PHP 7.4
+      - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php }}
           coverage: pcov
           # https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions
           extensions: curl, dom, exif, fileinfo, hash, json, mbstring, mysqli, libsodium, openssl, pcre, imagick, xml, zip

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,6 +20,7 @@ jobs:
       WP_VERSION: latest
 
     strategy:
+      fail-fast: false
       matrix:
         php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0' ]
         allowed_failure: [ false ]

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -58,6 +58,11 @@ jobs:
       - name: Start MySQL Service
         run: sudo systemctl start mysql.service
 
+      - name: Switch to use mysql_native_password for PHP < 7.4
+        if: ${{ matrix.php < 7.4 }}
+        # Info https://www.php.net/manual/en/mysqli.requirements.php
+        run: mysql -u root -p"root" -e "ALTER USER 'root'@localhost IDENTIFIED WITH mysql_native_password BY 'root'";  
+
       - name: Prepare environment for integration tests
         run: composer prepare
 


### PR DESCRIPTION
### Issue 

I notice that with this fixed PHP version value, all of current tests are only run on PHP 7.4.x.

https://github.com/Parsely/wp-parsely/blob/1a398fac2ebc4935199299977522c5a817b62505/.github/workflows/integration-tests.yml#L37

### Description of this PR 

This PR is to change all fixed PHP version 7.4 to the dynamic version in the matrix configuration. 