### PR TITLE
Better load Widget CSS and use plugin version for cache busting

### DIFF
--- a/class-parsely-recommended-widget.php
+++ b/class-parsely-recommended-widget.php
@@ -47,6 +47,8 @@ class Parsely_Recommended_Widget extends WP_Widget {
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $instance['title'] );
 
+		wp_enqueue_style( 'wp-parsely-style', plugins_url( 'wp-parsely.css', __FILE__ ), array(), Parsely::VERSION );
+
 		$allowed_tags = wp_kses_allowed_html( 'post' );
 		$title_html   = $args['before_widget'] . $args['before_title'] . $title . $args['after_title'];
 		echo wp_kses( $title_html, $allowed_tags );

--- a/class-parsely-recommended-widget.php
+++ b/class-parsely-recommended-widget.php
@@ -47,7 +47,7 @@ class Parsely_Recommended_Widget extends WP_Widget {
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $instance['title'] );
 
-		wp_enqueue_style( 'wp-parsely-style', plugins_url( 'wp-parsely.css', __FILE__ ), array(), Parsely::VERSION );
+		wp_enqueue_style( 'wp-parsely-style' );
 
 		$allowed_tags = wp_kses_allowed_html( 'post' );
 		$title_html   = $args['before_widget'] . $args['before_title'] . $title . $args['after_title'];

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -107,6 +107,7 @@ class Parsely {
 		add_action( 'instant_articles_compat_registry_analytics', array( $this, 'insert_parsely_tracking_fbia' ) );
 		add_action( 'template_redirect', array( $this, 'parsely_add_amp_actions' ) );
 		if ( ! defined( 'WP_PARSELY_TESTING' ) ) {
+			add_action( 'wp_enqueue_scripts', [ $this, 'wp_parsely_style_init' ] );
 			add_action( 'wp_enqueue_scripts', [ $this, 'ensure_jquery_exists' ] );
 		}
 	}
@@ -122,6 +123,13 @@ class Parsely {
 			'display'  => 'Every 10 Minutes',
 		);
 		return $schedules;
+	}
+
+	/**
+	 * Initialize parsely WordPress style
+	 */
+	public function wp_parsely_style_init() {
+		wp_register_style( 'wp-parsely-style', plugins_url( 'wp-parsely.css', __FILE__ ), array(), Parsely::VERSION );
 	}
 
 	/**

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -107,7 +107,6 @@ class Parsely {
 		add_action( 'instant_articles_compat_registry_analytics', array( $this, 'insert_parsely_tracking_fbia' ) );
 		add_action( 'template_redirect', array( $this, 'parsely_add_amp_actions' ) );
 		if ( ! defined( 'WP_PARSELY_TESTING' ) ) {
-			add_action( 'wp_enqueue_scripts', [ $this, 'wp_parsely_style_init' ] );
 			add_action( 'wp_enqueue_scripts', [ $this, 'ensure_jquery_exists' ] );
 		}
 	}
@@ -123,13 +122,6 @@ class Parsely {
 			'display'  => 'Every 10 Minutes',
 		);
 		return $schedules;
-	}
-
-	/**
-	 * Initialize parsely WordPress style
-	 */
-	public function wp_parsely_style_init() {
-		wp_enqueue_style( 'wp-parsely-style', plugins_url( 'wp-parsely.css', __FILE__ ), array(), filemtime( get_stylesheet_directory() ) );
 	}
 
 	/**


### PR DESCRIPTION
Move the `wp_enqueue_style` to within the public widget function so that its only enqueued if the widget is being loaded.

Bonus, change the version from `ilemtime( get_stylesheet_directory() )` to use the plugin version instead:  `Parsely::VERSION`

Fixes #231 

I'm also wondering if we should change the name of the file to something like `parsely-widget.css` instead? 