### PR TITLE
CI: Use matrix PHP version

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,7 +13,9 @@ on:
 jobs:
   test:
     name: PHP ${{ matrix.php }}
-    runs-on: ubuntu-latest
+    # ubuntu-20.04 / ubuntu-latest includes MySQL 8, which has issues with older versions of PHP.
+    # ubuntu-16.04 includes PHP versions 5.6-8.0
+    runs-on: ubuntu-16.04
     continue-on-error: ${{ matrix.allowed_failure }}
 
     env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@master
 
-      - name: Setup PHP 7.4
+      - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php }}
           coverage: pcov
           # https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions
           extensions: curl, dom, exif, fileinfo, hash, json, mbstring, mysqli, libsodium, openssl, pcre, imagick, xml, zip


### PR DESCRIPTION
Previously multiple PHP-focused jobs were created from the matrix configuration, but 7.4 was hard-coded to be used in each instance anyway.

Props to @htdat for spotting this oversight and providing a fix.

The fix revealed an issue with the MySQL version (8) that comes with `ubuntu-latest`, which has an issue with older versions of PHP, so the CI now uses a previous OS version that sticks with MySQL 5.7