### PR TITLE
CI: Small improvements

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,19 +14,21 @@ jobs:
   test:
     name: PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allowed_failure }}
 
     env:
       WP_VERSION: latest
 
     strategy:
       matrix:
-        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0' ]
-        allowed_failure: [ false ]
+        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4' ]
         include:
-          # PHP nightly.
-          - php: '8.1'
-            allowed_failure: true
+          - php: '8.0'
+            # Ignore platform requirements, so that PHPUnit 7.5 can be installed on PHP 8.0 (and above).
+            composer-options: "--ignore-platform-reqs"
+          # There is no PHP nightly. Due to https://github.com/sebastianbergmann/phpunit/issues/4575 this is never
+          # going to succeed as WordPress is hard-coded to only support PHPUnit 7.5, and then fix only appears
+          # in PHPUnit 8.5.14.
+      fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -36,21 +38,17 @@ jobs:
         with:
           php-version: '7.4'
           coverage: pcov
-          # https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions
-          extensions: curl, dom, exif, fileinfo, hash, json, mbstring, mysqli, libsodium, openssl, pcre, imagick, xml, zip
 
-      - name: Install Composer dependencies (PHP < 8.0 )
-        if: ${{ matrix.php < 8.0 }}
-        uses: ramsey/composer-install@v1
-
-      - name: Install Composer dependencies (PHP >= 8.0)
-        if: ${{ matrix.php >= 8.0 }}
-        uses: ramsey/composer-install@v1
-        with:
-          composer-options: --ignore-platform-reqs
+      - name: Setup problem matchers for PHP
+        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: "${{ matrix.composer-options }}"
 
 #      - name: Run unit tests
 #        run: composer unit


### PR DESCRIPTION
- Remove PHP 8.1 (nightly) test. Due to a syntax conflict with PHP 8.1 in PHPUnit 7.5, this job will never succeed.
- Add `fail-fast: false` to allow rare job failures to allow other jobs to complete and give more details.
- Add problem matcher for PHP.
- Consolidate near-duplicate Composer Install steps into one.