### PR TITLE
Use strict code coverage and add code coverage output

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,9 +77,9 @@ jobs:
 
       - name: Run integration tests (single site)
         if: ${{ matrix.php != 8.0 }}
-        run: composer integration
+        run: composer test
       - name: Run integration tests (single site with code coverage)
         if: ${{ matrix.php == 8.0 }}
-        run: ./vendor/bin/phpunit --testsuite WP_Tests --coverage-text
+        run: composer coverage
       - name: Run integration tests (multisite)
-        run: composer integration-ms
+        run: composer test-ms

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,10 +39,21 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: pcov
+          ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
           coverage: pcov
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+      # Setup PCOV since we're using PHPUnit < 8 which has it integrated. Requires PHP 7.1.
+      # Ignore platform reqs to make it install on PHP 8.
+      # https://github.com/krakjoe/pcov-clobber
+      - name: Setup PCOV
+        if: ${{ matrix.php == 8.0 }}
+        run: |
+          composer require pcov/clobber --ignore-platform-reqs
+          vendor/bin/pcov clobber
 
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -62,6 +73,10 @@ jobs:
         run: composer prepare
 
       - name: Run integration tests (single site)
+        if: ${{ matrix.php != 8.0 }}
         run: composer integration
+      - name: Run integration tests (single site with code coverage)
+        if: ${{ matrix.php == 8.0 }}
+        run: ./vendor/bin/phpunit --testsuite WP_Tests --coverage-text
       - name: Run integration tests (multisite)
         run: composer integration-ms

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,6 +27,9 @@ jobs:
           - php: '8.0'
             # Ignore platform requirements, so that PHPUnit 7.5 can be installed on PHP 8.0 (and above).
             composer-options: "--ignore-platform-reqs"
+            extensions: pcov
+            ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
+            coverage: pcov
           # There is no PHP nightly. Due to https://github.com/sebastianbergmann/phpunit/issues/4575 this is never
           # going to succeed as WordPress is hard-coded to only support PHPUnit 7.5, and then fix only appears
           # in PHPUnit 8.5.14.
@@ -39,9 +42,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: pcov
-          ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
-          coverage: pcov
+          extensions: ${{ matrix.extensions }}
+          ini-values: ${{ matrix.ini-values }}
+          coverage: ${{ matrix.coverage }}
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .DS_Store
 .idea
 node_modules
+/build/logs/
+/build/coverage-html/
+

--- a/composer.json
+++ b/composer.json
@@ -32,15 +32,21 @@
     "lint-ci": [
       "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --checkstyle"
     ],
+    "test": [
+      "@php ./vendor/bin/phpunit --no-coverage"
+    ],
+    "test-ms": [
+      "@putenv WP_MULTISITE=1",
+      "@composer test"
+    ],
+    "coverage": [
+      "@php ./vendor/bin/phpunit"
+    ],
+    "coverage-local": [
+      "@php ./vendor/bin/phpunit --coverage-html ./build/coverage-html"
+    ],
     "prepare": [
       "bash bin/install-wp-tests.sh wordpress_test root root localhost nightly"
-    ],
-    "integration": [
-      "@php ./vendor/bin/phpunit --testsuite WP_Tests"
-    ],
-    "integration-ms": [
-      "@putenv WP_MULTISITE=1",
-      "@composer integration"
     ]
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,8 +24,11 @@
 	<filter>
 		<whitelist>
 			<directory suffix=".php">src</directory>
-			<directory suffix=".php">views</directory>
 			<file>wp-parsely.php</file>
 		</whitelist>
 	</filter>
+
+	<logging>
+		<log type="coverage-clover" target="build/logs/clover.xml"/>
+	</logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,4 +18,11 @@
 			<directory suffix="-test.php">./tests/</directory>
 		</testsuite>
 	</testsuites>
+
+	<filter>
+		<whitelist>
+			<file>wp-parsely.php</file>
+			<file>class-parsely-recommended-widget.php</file>
+		</whitelist>
+	</filter>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,10 +2,12 @@
 <phpunit
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
-	backupGlobals="false"
 	bootstrap="./tests/bootstrap.php"
+	backupGlobals="false"
+	beStrictAboutCoversAnnotation="true"
 	beStrictAboutTestsThatDoNotTestAnything="false"
 	colors="true"
+	forceCoversAnnotation="true"
 	>
 	<php>
 		<server name="SERVER_PORT" value="80"/>
@@ -21,8 +23,9 @@
 
 	<filter>
 		<whitelist>
+			<directory suffix=".php">src</directory>
+			<directory suffix=".php">views</directory>
 			<file>wp-parsely.php</file>
-			<file>class-parsely-recommended-widget.php</file>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/tests/class-all-test.php
+++ b/tests/class-all-test.php
@@ -21,51 +21,9 @@ class All_Test extends ParselyTestCase {
 	/**
 	 * Internal variables
 	 *
-	 * @var string $post Name of the post to test.
-	 */
-	protected static $post;
-
-	/**
-	 * Internal variables
-	 *
-	 * @var string $news Unused?
-	 */
-	protected static $news;
-
-	/**
-	 * Internal variables
-	 *
-	 * @var string $local Unused?
-	 */
-	protected static $local;
-
-	/**
-	 * Internal variables
-	 *
-	 * @var string $example_county Unused?
-	 */
-	protected static $example_county;
-
-	/**
-	 * Internal variables
-	 *
 	 * @var string $parsely Holds the Parsely object.
 	 */
 	protected static $parsely;
-
-	/**
-	 * Internal variables
-	 *
-	 * @var string $custom_taxonomy Custom taxonomy for testing.
-	 */
-	protected static $custom_taxonomy;
-
-	/**
-	 * Internal variables
-	 *
-	 * @var string $taxonomy_factory Unused?
-	 */
-	protected static $taxonomy_factory;
 
 	/**
 	 * Internal variables
@@ -75,19 +33,7 @@ class All_Test extends ParselyTestCase {
 	protected static $parsely_html;
 
 	/**
-	 * The setUp before the entire class
-	 *
-	 * @category   Function
-	 * @package    SampleTest
-	 */
-	public static function setUpBeforeClass() {
-	}
-
-	/**
 	 * The setUp run before each test
-	 *
-	 * @category   Function
-	 * @package    SampleTest
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -113,8 +59,13 @@ PARSELYJS;
 	/**
 	 * Test the parsely tag.
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::insert_parsely_javascript
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::parsely_is_user_logged_in
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group insert-js
 	 */
 	public function test_parsely_tag() {
 		echo 'NOW IT BEGINS';
@@ -132,8 +83,21 @@ PARSELYJS;
 	/**
 	 * Check the context `@type` field for a Post and the Homepage.
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
 	 */
 	public function test_parsely_metadata_context_output() {
 		// Setup Parsley object.
@@ -169,8 +133,21 @@ PARSELYJS;
 	/**
 	 *  Check the category
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
 	 */
 	public function test_parsely_categories() {
 		// Setup Parsley object.
@@ -192,8 +169,22 @@ PARSELYJS;
 	/**
 	 * Check that the tags are lowercase
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
+	 * @group settings
 	 */
 	public function test_parsely_tags_lowercase() {
 		// Setup Parsley object.
@@ -224,8 +215,24 @@ PARSELYJS;
 	/**
 	 * Check the categories as tags.
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_categories
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_custom_taxonomy_values
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
+	 * @group settings
 	 */
 	public function test_parsely_categories_as_tags() {
 		// Setup Parsley object.
@@ -256,8 +263,24 @@ PARSELYJS;
 	/**
 	 * Test custom taxonomy terms, categories, and tags in the metadata.
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_categories
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_custom_taxonomy_values
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
+	 * @group settings
 	 */
 	public function test_custom_taxonomy_tags() {
 		// Setup Parsley object.
@@ -301,8 +324,23 @@ PARSELYJS;
 	/**
 	 * Are the top level categories what we expect?
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::get_top_level_term
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
+	 * @group settings
 	 */
 	public function test_use_top_level_cats() {
 		// Setup Parsley object.
@@ -334,8 +372,23 @@ PARSELYJS;
 	/**
 	 * Check out the custom taxonomy as section.
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::get_top_level_term
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
+	 * @group settings
 	 */
 	public function test_custom_taxonomy_as_section() {
 		// Setup Parsley object.
@@ -378,8 +431,23 @@ PARSELYJS;
 	/**
 	 * Check out the top level taxonomy as a section.
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::get_top_level_term
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
+	 * @group settings
 	 */
 	public function test_top_level_taxonomy_as_section() {
 		// Setup Parsley object.
@@ -422,8 +490,22 @@ PARSELYJS;
 	/**
 	 * Check the canonicals.
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
+	 * @group settings
 	 */
 	public function test_http_canonicals() {
 		// Setup Parsley object.
@@ -460,8 +542,10 @@ PARSELYJS;
 	/**
 	 * Check the facebook instant articles integration.
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::insert_parsely_tracking_fbia
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_options()
+	 * @group fbia
 	 */
 	public function test_fbia_integration() {
 		$options = get_option( 'parsely' );
@@ -474,8 +558,12 @@ PARSELYJS;
 	/**
 	 * Check the AMP integration.
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::parsely_add_amp_actions
+	 * @covers \Parsely::parsely_add_amp_analytics
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_options()
+	 * @group amp
+	 * @group settings
 	 */
 	public function test_amp_integration() {
 		$options   = get_option( 'parsely' );
@@ -494,8 +582,22 @@ PARSELYJS;
 	/**
 	 * Check out page filtering.
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
+	 * @group filters
 	 */
 	public function test_parsely_page_filter() {
 		// Setup Parsley object.
@@ -530,8 +632,14 @@ PARSELYJS;
 	/**
 	 * Make sure users can log in.
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::insert_parsely_javascript
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::parsely_is_user_logged_in
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group insert-js
+	 * @group settings
 	 */
 	public function test_user_logged_in() {
 		$options                              = get_option( 'parsely' );
@@ -548,8 +656,14 @@ PARSELYJS;
 	/**
 	 * Make sure users can log in to more than one site.
 	 *
-	 * @category   Function
-	 * @package    SampleTest
+	 * @covers \Parsely::insert_parsely_javascript
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::parsely_is_user_logged_in
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group insert-js
+	 * @group settings
 	 */
 	public function test_user_logged_in_multisite() {
 		if ( ! is_multisite() ) {
@@ -666,10 +780,14 @@ PARSELYJS;
 	}
 
 	/**
-	 * @category   Function
-	 * @package    SampleTest
+	 * Test the get_current_url() method.
+	 *
 	 * @dataProvider data_for_test_get_current_url
-	 * @covers Parsely::get_current_url
+	 * @covers \Parsely::get_current_url
+	 * @uses \Parsely::__construct()
+	 * @uses \Parsely::get_options()
+	 * @uses \Parsely::update_metadata_endpoint()
+	 * @group get-current-url
 	 */
 	public function test_get_current_url( $force_https, $url, $expected ) {
 		$options                           = get_option( \Parsely::OPTIONS_KEY );

--- a/tests/recommended-api-test.php
+++ b/tests/recommended-api-test.php
@@ -54,6 +54,9 @@ final class Recommended_API_Test extends TestCase {
 	 * Test the basic generation of the API URL.
 	 *
 	 * @dataProvider data_recommended_api_url
+	 * @covers \Parsely_Recommended_Widget::get_api_url
+	 * @uses \Parsely_Recommended_Widget::__construct
+	 * @group widgets
 	 */
 	public function test_recommended_api_url( $api_key, $published_within, $sort, $boost, $return_limit, $url ) {
 		$recommended_widget = new Parsely_Recommended_Widget();

--- a/tests/structured-data/class-archive-post-test.php
+++ b/tests/structured-data/class-archive-post-test.php
@@ -24,6 +24,22 @@ final class Archive_Post_Test extends TestCase {
 
 	/**
 	 * Create 2 posts, set posts per page to 1, navigate to page 2 and test the structured data.
+	 *
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
 	 */
 	public function test_home_page_for_posts_paged() {
 		// Setup Parsley object.
@@ -60,6 +76,22 @@ final class Archive_Post_Test extends TestCase {
 
 	/**
 	 * Create a single page, set as the posts page (blog archive) but not the home page, go to Page 2, and test the structured data.
+	 *
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
 	 */
 	public function test_blog_page_for_posts_paged() {
 		// Setup Parsley object.
@@ -99,6 +131,25 @@ final class Archive_Post_Test extends TestCase {
 		self::assertEquals( get_permalink( $page_id ) . 'page/2', $structured_data['url'] );
 	}
 
+	/**
+	 * Check metadata for author archive.
+	 *
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
+	 */
 	public function test_author_archive() {
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
 		// See https://github.com/Parsely/wp-parsely/issues/151
@@ -131,6 +182,25 @@ final class Archive_Post_Test extends TestCase {
 		self::assertEquals( $author_posts_url, $structured_data['url'] );
 	}
 
+	/**
+	 * Check metadata for term archive.
+	 *
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
+	 */
 	public function test_term_archive() {
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
 		// See https://github.com/Parsely/wp-parsely/issues/151

--- a/tests/structured-data/class-single-non-post-test.php
+++ b/tests/structured-data/class-single-non-post-test.php
@@ -24,6 +24,22 @@ final class Single_Non_Post_Test extends TestCase {
 
 	/**
 	 * Create a single page, and test the structured data.
+	 *
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
 	 */
 	public function test_single_page() {
 		// Setup Parsley object.
@@ -59,6 +75,22 @@ final class Single_Non_Post_Test extends TestCase {
 
 	/**
 	 * Create a single page, set as homepage (blog archive), and test the structured data.
+	 *
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
 	 */
 	public function test_home_page_for_posts() {
 		// Setup Parsley object.
@@ -85,6 +117,22 @@ final class Single_Non_Post_Test extends TestCase {
 
 	/**
 	 * Create a single page, set as the posts page (blog archive) but not the home page, and test the structured data.
+	 *
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
 	 */
 	public function test_blog_page_for_posts() {
 		// Setup Parsley object.
@@ -122,6 +170,22 @@ final class Single_Non_Post_Test extends TestCase {
 
 	/**
 	 * Create a single page, set as homepage (page on front), and test the structured data.
+	 *
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
 	 */
 	public function test_home_page_on_front() {
 		// Setup Parsley object.
@@ -152,6 +216,22 @@ final class Single_Non_Post_Test extends TestCase {
 
 	/**
 	 * Check for the case when the show_on_front setting is Page, but no Page has been selected.
+	 *
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
 	 */
 	public function test_home_for_misconfigured_settings() {
 		// Setup Parsley object.

--- a/tests/structured-data/class-single-post-test.php
+++ b/tests/structured-data/class-single-post-test.php
@@ -15,6 +15,22 @@ namespace Parsely\Tests;
 final class Single_Post_Test extends TestCase {
 	/**
 	 * Create a single post, and test the structured data.
+	 *
+	 * @covers \Parsely::construct_parsely_metadata
+	 * @uses \Parsely::__construct
+	 * @uses \Parsely::get_author_name
+	 * @uses \Parsely::get_author_names
+	 * @uses \Parsely::get_bottom_level_term
+	 * @uses \Parsely::get_category_name
+	 * @uses \Parsely::get_clean_parsely_page_value
+	 * @uses \Parsely::get_coauthor_names
+	 * @uses \Parsely::get_current_url
+	 * @uses \Parsely::get_first_image
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::get_tags
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group metadata
 	 */
 	public function test_single_post() {
 		// Setup Parsley object.


### PR DESCRIPTION
Finish configuring PCOV to display code coverage for single site integration tests.

Currently focused on just two files with functions/methods on them - the main plugin file, and the widget class file.

If the PHP version is `8.0`, then the code coverage runs, otherwise it doesn't. There's no need to run it on every job.

Once #234 has been merged, this PR can be rebased and updated to set `coverage: none` and remove ext-pcov for all but PHP 8.0.