### PR TITLE
Stop Using Protocol-Relative URL for Tracking Script

### DIFF
--- a/parsely-javascript.php
+++ b/parsely-javascript.php
@@ -54,6 +54,6 @@ if ( ! isset( $parsely_options['apikey'] ) || empty( $parsely_options['apikey'] 
 	</script>
 <?php endif; ?>
 
-<script data-cfasync="false" id="parsely-cfg" data-parsely-site="<?php echo esc_attr( $parsely_options['apikey'] ); ?>" src="//cdn.parsely.com/keys/<?php echo esc_attr( $parsely_options['apikey'] ); ?>/p.js"></script>
+<script data-cfasync="false" id="parsely-cfg" data-parsely-site="<?php echo esc_attr( $parsely_options['apikey'] ); ?>" src="https://cdn.parsely.com/keys/<?php echo esc_attr( $parsely_options['apikey'] ); ?>/p.js"></script>
 
 <!-- END Parse.ly Include: Standard -->

--- a/tests/all-test.php
+++ b/tests/all-test.php
@@ -104,7 +104,7 @@ class SampleTest extends ParselyTestCase {
 		);
 		update_option( 'parsely', $option_defaults );
 		self::$parsely_html = <<<PARSELYJS
-<script data-cfasync="false" id="parsely-cfg" data-parsely-site="blog.parsely.com" src="//cdn.parsely.com/keys/blog.parsely.com/p.js"></script>
+<script data-cfasync="false" id="parsely-cfg" data-parsely-site="blog.parsely.com" src="https://cdn.parsely.com/keys/blog.parsely.com/p.js"></script>
 PARSELYJS;
 	}
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -1647,7 +1647,7 @@ class Parsely {
 				}
 			}
 		</script>
-		<script data-cfasync="false" id="parsely-cfg" data-parsely-site="' . esc_attr( $options['apikey'] ) . '" src="//cdn.parsely.com/keys/' . esc_attr( $options['apikey'] ) . '/p.js"></script>
+		<script data-cfasync="false" id="parsely-cfg" data-parsely-site="' . esc_attr( $options['apikey'] ) . '" src="https://cdn.parsely.com/keys/' . esc_attr( $options['apikey'] ) . '/p.js"></script>
 		<!-- END Parse.ly Include: Standard -->';
 
 		$registry[ $identifier ] = array(


### PR DESCRIPTION
Explicitly specify that the tracking script is loaded via https instead of using a protocol-relative URL.

Update snippet in the automated tests to match.

Fixes #219