### PR TITLE
Support Custom Post Status Slugs

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -784,6 +784,12 @@ class Parsely {
 	 * @return bool Should the post status be tracked for the provided post's post_type. By default, only 'publish' is allowed.
 	 */
 	public static function post_has_trackable_status( $post ) {
+		static $cache = array();
+		$post_id = is_int( $post ) ? $post : $post->ID;
+		if ( isset( $cache[ $post_id ] ) ) {
+			return $cache[ $post_id ];
+		}
+
 		/**
 		 * Filters the statuses that are permitted to be tracked.
 		 *
@@ -795,7 +801,8 @@ class Parsely {
 		 * @param int|WP_Post $post               Which post object or ID is being checked.
 		 */
 		$statuses = apply_filters( 'wp_parsely_trackable_statuses', array( 'publish' ), $post );
-		return in_array( get_post_status( $post ), $statuses, true );
+		$cache[ $post_id ] = in_array( get_post_status( $post ), $statuses, true );
+		return $cache[ $post_id ];
 	}
 
 	/**

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -791,11 +791,11 @@ class Parsely {
 		 *
 		 * @since 2.5.0
 		 *
-		 * @param string[]    $status_slugs The list of post_status slugs that are allowed to be tracked.
-		 * @param int|WP_Post $post         Which post object or id is being checked.
+		 * @param string[]    $trackable_statuses The list of post statuses that are allowed to be tracked.
+		 * @param int|WP_Post $post               Which post object or ID is being checked.
 		 */
-		$status_slugs = apply_filters( 'wp_parsely_track_status_slugs', array( 'publish' ), $post );
-		return in_array( get_post_status( $post ), $status_slugs, true );
+		$statuses = apply_filters( 'wp_parsely_trackable_statuses', array( 'publish' ), $post );
+		return in_array( get_post_status( $post ), $statuses, true );
 	}
 
 	/**

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -785,10 +785,9 @@ class Parsely {
 	 */
 	public static function post_has_trackable_status( $post ) {
 		static $cache = array();
-
-		$post_status = get_post_status( $post );
-		if ( isset( $cache[ $post_status ] ) ) {
-			return $cache[ $post_status ];
+		$post_id = is_int( $post ) ? $post : $post->ID;
+		if ( isset( $cache[ $post_id ] ) ) {
+			return $cache[ $post_id ];
 		}
 
 		/**
@@ -802,8 +801,8 @@ class Parsely {
 		 * @param int|WP_Post $post               Which post object or ID is being checked.
 		 */
 		$statuses = apply_filters( 'wp_parsely_trackable_statuses', array( 'publish' ), $post );
-		$cache[ $post_status ] = in_array( $post_status, $statuses, true );
-		return $cache[ $post_status ];
+		$cache[ $post_id ] = in_array( get_post_status( $post ), $statuses, true );
+		return $cache[ $post_id ];
 	}
 
 	/**

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -785,9 +785,10 @@ class Parsely {
 	 */
 	public static function post_has_trackable_status( $post ) {
 		static $cache = array();
-		$post_id = is_int( $post ) ? $post : $post->ID;
-		if ( isset( $cache[ $post_id ] ) ) {
-			return $cache[ $post_id ];
+
+		$post_status = get_post_status( $post );
+		if ( isset( $cache[ $post_status ] ) ) {
+			return $cache[ $post_status ];
 		}
 
 		/**
@@ -801,8 +802,8 @@ class Parsely {
 		 * @param int|WP_Post $post               Which post object or ID is being checked.
 		 */
 		$statuses = apply_filters( 'wp_parsely_trackable_statuses', array( 'publish' ), $post );
-		$cache[ $post_id ] = in_array( get_post_status( $post ), $statuses, true );
-		return $cache[ $post_id ];
+		$cache[ $post_status ] = in_array( $post_status, $statuses, true );
+		return $cache[ $post_status ];
 	}
 
 	/**

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -785,8 +785,9 @@ class Parsely {
 	 */
 	public static function post_has_trackable_status( $post ) {
 		/**
-		 * Filters the status slugs that are permitted to be tracked.
-		 * By default, the only slug allowed is 'publish'. Override this list if your post type necessitates.
+		 * Filters the statuses that are permitted to be tracked.
+		 *
+		 * By default, the only status tracked is 'publish'. Use this filter if you have other published content that has a different (custom) status.
 		 *
 		 * @since 2.5.0
 		 *

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -776,13 +776,12 @@ class Parsely {
 	}
 
 	/**
-	 * Compare the post_status key against an allowed list (by default, only 'publish'ed content includes tracking data)
+	 * Compare the post_status key against an allowed list (by default, only 'publish'ed content includes tracking data).
 	 *
-	 * @param  int|WP_Post $post  Which post object or id to check.
-	 * @return bool               Should the post status be tracked for the provided post's post_type. By default, only 'publish' is allowed.
-	 *
-	 * @see wp_parsely_track_status_slugs
 	 * @since 2.5.0
+	 *
+	 * @param int|WP_Post $post Which post object or ID to check.
+	 * @return bool Should the post status be tracked for the provided post's post_type. By default, only 'publish' is allowed.
 	 */
 	public static function post_has_trackable_status( $post ) {
 		/**


### PR DESCRIPTION
Fixes #218

Adds a new function `post_has_trackable_status` which accepts a single parameter: `$post`.

That function applies a new filter `wp_parsely_track_status_slugs` to get the allowed list of status slugs to track (It defaults to a list containing only `publish`).

Plugins can  override the list of status slugs that will enable tracking by returning a new list from a function hooked into the new filter.