### PR TITLE
Try: REST API Endpoint for Settings

### DIFF
--- a/settings-api.php
+++ b/settings-api.php
@@ -1,0 +1,16 @@
+<?php
+
+function wp_parsely_settings_api_init() {
+	register_rest_route( 'wp-parsely/v1', 'settings', array(
+		'methods' => 'GET',
+		'callback' => 'wp_parsely_settings_http_get',
+	) );
+}
+add_action( 'rest_api_init', 'wp_parsely_settings_api_init' );
+
+function wp_parsely_settings_http_get() {
+	global $parsely;
+	$settings = $parsely->get_options();
+	unset( $settings['api_secret'] );
+	return $settings;
+}

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -1304,7 +1304,7 @@ class Parsely {
 	 * options are saved, they override the defaults.  This prevents us from having to do a lot of isset() checking
 	 * on variables.
 	 */
-	private function get_options() {
+	public function get_options() { // TODO reconsider the method visibility and how to refactor this if we want to keep the method private
 		$options = get_option( self::OPTIONS_KEY );
 		if ( false === $options ) {
 			$options = $this->option_defaults;
@@ -1769,3 +1769,5 @@ add_action( 'widgets_init', 'parsely_recommended_widget_register' );
 function parsely_recommended_widget_register() {
 	register_widget( 'Parsely_Recommended_Widget' );
 }
+
+require_once 'settings-api.php';


### PR DESCRIPTION
Super quick and dirty REST API Endpoint to expose the plugin options / settings.

## To access

Make a request to `/wp-json/wp-parsely/v1/settings`