### PR TITLE
Admin page: Improve page title

### DIFF
--- a/parsely-settings.php
+++ b/parsely-settings.php
@@ -14,7 +14,7 @@ $version_string = sprintf( __( 'Version %s', 'wp-parsely' ), $this::VERSION );
 ?>
 
 <div class="wrap">
-	<h2><?php echo esc_html( get_admin_page_title() ); ?> <span id="wp-parsely_version"><?php echo esc_html( $version_string ); ?></span></h2>
+	<h1><?php echo esc_html( get_admin_page_title() ); ?> <span id="wp-parsely_version"><?php echo esc_html( $version_string ); ?></span></h1>
 	<form name="parsely" method="post" action="options.php">
 		<?php settings_fields( $this::OPTIONS_KEY ); ?>
 		<?php do_settings_sections( $this::OPTIONS_KEY ); ?>

--- a/parsely-settings.php
+++ b/parsely-settings.php
@@ -14,7 +14,7 @@ $version_string = sprintf( __( 'Version %s', 'wp-parsely' ), $this::VERSION );
 ?>
 
 <div class="wrap">
-	<h1><?php echo esc_html( get_admin_page_title() ); ?> <span id="wp-parsely_version"><?php echo esc_html( $version_string ); ?></span></h1>
+	<h1 class="wp-heading-inline"><?php echo esc_html( get_admin_page_title() ); ?></h1> <span id="wp-parsely_version"><?php echo esc_html( $version_string ); ?></span>
 	<form name="parsely" method="post" action="options.php">
 		<?php settings_fields( $this::OPTIONS_KEY ); ?>
 		<?php do_settings_sections( $this::OPTIONS_KEY ); ?>


### PR DESCRIPTION
Use a H1 instead of H2 - it's better for accessibility, and WordPress changed this for wp-admin pages quite a few versions ago.

Also, move the Version span outside of the heading.

There is no visual style change, but it fixes the semantics.

Before:

<img width="338" alt="Screenshot 2021-04-23 at 14 36 19" src="https://user-images.githubusercontent.com/88371/115879237-56bd2d00-a441-11eb-9e07-02cf972962c7.png">

After first commit (switch to h1):

<img width="338" alt="Screenshot 2021-04-23 at 14 36 27" src="https://user-images.githubusercontent.com/88371/115879257-5ae94a80-a441-11eb-9a65-cb83bae822fb.png">

After second commit (move version number out):

<img width="338" alt="Screenshot 2021-04-23 at 14 40 12" src="https://user-images.githubusercontent.com/88371/115879720-e367eb00-a441-11eb-93b1-7bad41e1e7c4.png">

After all commits:

<img width="620" alt="Screenshot 2021-04-23 at 14 41 16" src="https://user-images.githubusercontent.com/88371/115879818-fbd80580-a441-11eb-930b-504761a54908.png">


Fixes #222.