### PR TITLE
Remove redundant plugin version meta tag

### DIFF
--- a/parsely-parsely-page.php
+++ b/parsely-parsely-page.php
@@ -11,7 +11,7 @@
 
 ?>
 
-<!-- BEGIN wp-parsely Plugin Version <?php echo esc_html( Parsely::VERSION ); ?> -->
+<!-- BEGIN Parse.ly <?php echo esc_html( Parsely::VERSION ); ?> -->
 <?php if ( ! empty( $parsely_page ) && isset( $parsely_page['headline'] ) ) : ?>
 	<?php
 	if ( 'json_ld' === $parsely_options['meta_type'] ) {
@@ -50,5 +50,5 @@
 	<?php else : ?>
 		<!-- parsleyPage is not defined / has no attributes.  What kind of page are you loading? -->
 	<?php endif; ?>
-<!-- END wp-parsely Plugin Version <?php echo esc_html( Parsely::VERSION ); ?> -->
+<!-- END Parse.ly -->
 <?php

--- a/parsely-parsely-page.php
+++ b/parsely-parsely-page.php
@@ -12,7 +12,6 @@
 ?>
 
 <!-- BEGIN wp-parsely Plugin Version <?php echo esc_html( Parsely::VERSION ); ?> -->
-<meta name="wp-parsely_version" id="wp-parsely_version" content="<?php echo esc_attr( Parsely::VERSION ); ?>"/>
 <?php if ( ! empty( $parsely_page ) && isset( $parsely_page['headline'] ) ) : ?>
 	<?php
 	if ( 'json_ld' === $parsely_options['meta_type'] ) {


### PR DESCRIPTION
The meta tag only existed to tell Parse.ly support what version of the plugin was being used. The crawler doesn't use it.

The version number is also in the HTML comment that wraps the meta tag + structured data element anyway, so it is redundant.

Fixes #244.