### PR TITLE
Admin page: Improve accessibility of radio inputs

### DIFF
--- a/parsely-admin-header.php
+++ b/parsely-admin-header.php
@@ -39,7 +39,7 @@
 		recrawlRequiredMessage.append(supportLink);
 
 		recrawlRequiredMessage
-			.appendTo("div.parsely-form-controls[data-requires-recrawl='true'] .help-text");
+			.appendTo(".parsely-form-controls[data-requires-recrawl='true'] .help-text");
 	});
 })(jQuery);
 </script>

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -345,6 +345,7 @@ class Parsely {
 			self::MENU_SLUG,
 			'optional_settings',
 			array(
+				'title'            => __( 'Disable JavaScript', 'wp-parsely' ), // Passed for legend element.
 				'option_key'       => 'disable_javascript',
 				'help_text'        => $h,
 				'requires_recrawl' => false,
@@ -360,6 +361,7 @@ class Parsely {
 			self::MENU_SLUG,
 			'optional_settings',
 			array(
+				'title'            => __( 'Disable AMP Tracking', 'wp-parsely' ), // Passed for legend element.
 				'option_key'       => 'disable_amp',
 				'help_text'        => $h,
 				'requires_recrawl' => false,
@@ -375,6 +377,7 @@ class Parsely {
 			self::MENU_SLUG,
 			'optional_settings',
 			array(
+				'title'            => __( 'Use Top-Level Categories for Section', 'wp-parsely' ), // Passed for legend element.
 				'option_key'       => 'use_top_level_cats',
 				'help_text'        => $h,
 				'requires_recrawl' => true,
@@ -407,6 +410,7 @@ class Parsely {
 			self::MENU_SLUG,
 			'optional_settings',
 			array(
+				'title'            => __( 'Add Categories to Tags', 'wp-parsely' ), // Passed for legend element.
 				'option_key'       => 'cats_as_tags',
 				'help_text'        => $h,
 				'requires_recrawl' => true,
@@ -422,6 +426,7 @@ class Parsely {
 			self::MENU_SLUG,
 			'optional_settings',
 			array(
+				'title'            => __( 'Track Logged-in Users', 'wp-parsely' ), // Passed for legend element.
 				'option_key'       => 'track_authenticated_users',
 				'help_text'        => $h,
 				'requires_recrawl' => true,
@@ -437,6 +442,7 @@ class Parsely {
 			self::MENU_SLUG,
 			'optional_settings',
 			array(
+				'title'            => __( 'Lowercase All Tags', 'wp-parsely' ), // Passed for legend element.
 				'option_key'       => 'lowercase_tags',
 				'help_text'        => $h,
 				'requires_recrawl' => true,
@@ -451,6 +457,7 @@ class Parsely {
 			self::MENU_SLUG,
 			'optional_settings',
 			array(
+				'title'            => __( 'Force HTTPS canonicals', 'wp-parsely' ), // Passed for legend element.
 				'option_key'       => 'force_https_canonicals',
 				'help_text'        => $h,
 				'requires_recrawl' => true,
@@ -1128,24 +1135,27 @@ class Parsely {
 		$id      = esc_attr( $name );
 		$name    = self::OPTIONS_KEY . "[$id]";
 
+		$has_help_text = isset( $args['help_text'] ) ? ' data-has-help-text="true"' : '';
+		$requires_recrawl = isset( $args['requires_recrawl'] ) && $args['requires_recrawl'] ? ' data-requires-recrawl="true"' : '';
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static text attribute key-value. ?>
+		<fieldset class="parsely-form-controls" <?php echo $has_help_text . $requires_recrawl; ?>>
+			<legend class="screen-reader-text"><span><?php echo esc_html( $args['title'] ); ?></span></legend>
+			<p>
+				<label for="<?php echo esc_attr( "{$id}_true" ); ?>">
+					<input type="radio" name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( "{$id}_true" ); ?>" value="true"<?php checked( $value ); ?> />Yes
+				</label>
+				<br />
+				<label for="<?php echo esc_attr( "{$id}_false" ); ?>">
+					<input type="radio" name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( "{$id}_false" ); ?>" value="false"<?php checked( $value, false ); ?> />No
+				</label>
+			</p>
+		<?php
 		if ( isset( $args['help_text'] ) ) {
-			echo '<div class="parsely-form-controls" data-has-help-text="true">';
+			?><div class="help-text"><p class="description .help-text"><?php echo esc_html( $args['help_text'] ); ?></p></div><?php
 		}
-		if ( isset( $args['requires_recrawl'] ) ) {
-			echo '<div class="parsely-form-controls" data-requires-recrawl="true">';
-		}
-
-		echo sprintf( "<input type='radio' name='%s' id='%s_true' value='true' ", esc_attr( $name ), esc_attr( $id ) );
-		echo checked( true === $value, true, false );
-		echo sprintf( " /> <label for='%s_true'>Yes</label> <input type='radio' name='%s' id='%s_false' value='false' ", esc_attr( $id ), esc_attr( $name ), esc_attr( $id ) );
-		echo checked( true !== $value, true, false );
-		echo sprintf( " /> <label for='%s_false'>No</label>", esc_attr( $id ) );
-
-		if ( isset( $args['help_text'] ) ) {
-			echo '<div class="help-text"><p class="description">' . esc_html( $args['help_text'] ) . '</p></div>';
-		}
-		echo '</div>';
-
+		?>
+		</fieldset>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
- Groups related radio buttons in `fieldset` element instead of `div`.
- Adds `legend` element to give context to what the radio button values mean. Populated with same string as used in the visual appearance of faux-label.
- Fixes bug where only help text or requires recrawl data attributes were added, and consequently fixes recrawl notice from appearing when `requires_recrawl=false`.
- Displays radio buttons vertically, which makes it more obvious which radio button goes with which label.
- Switched the HTML-in-PHP-strings to be HTML-with-embedded-PHP, which helps with syntax highlighting and auto-completion in IDEs, and more focus on ensuring dynamic values are escaped.
- Fixed the recrawl message JS to not be so specific about which element the `.parsely-form-controls` class is on, because `div` is not always the best grouping element.

Fixes #228.

Other than displaying vertically, visually there's no difference. It's a big improvement for screen reader users though, as now the answers have an associated question, and it's cognitively easier to associate the label and the control.

<img width="1189" alt="Screenshot 2021-04-23 at 15 38 30" src="https://user-images.githubusercontent.com/88371/115888926-5d50a200-a44b-11eb-9413-d883000c9abd.png">
