### PR TITLE
Prevent Unit Tests from echoing

### DIFF
--- a/tests/all-test.php
+++ b/tests/all-test.php
@@ -248,7 +248,7 @@ PARSELYJS;
 	}
 
 	/**
-	 * Check out taxonomy tags.
+	 * Test custom taxonomy terms, categories, and tags in the metadata.
 	 *
 	 * @category   Function
 	 * @package    SampleTest

--- a/tests/all-test.php
+++ b/tests/all-test.php
@@ -221,7 +221,7 @@ PARSELYJS;
 	 * @category   Function
 	 * @package    SampleTest
 	 */
-	public function test_parsely_cats_as_tags() {
+	public function test_parsely_categories_as_tags() {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );

--- a/tests/all-test.php
+++ b/tests/all-test.php
@@ -135,14 +135,29 @@ PARSELYJS;
 	 * @package    SampleTest
 	 */
 	public function test_parsely_ppage_output() {
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Create a single post
+		$post_id = self::factory()->post->create( [ 'post_type' => 'post', 'post_title' => 'Home' ] );
+		$post    = get_post( $post_id );
+
+		// Go to the homepage
 		$this->go_to( '/' );
-		$ppage = self::$parsely->insert_parsely_page();
-		self::assertSame( 'WebPage', $ppage['@type'] );
-		$post_array = $this->create_test_post_array();
-		$post       = $this->factory->post->create( $post_array );
-		$this->go_to( '/?p=' . $post );
-		$ppage = self::$parsely->insert_parsely_page();
-		self::assertSame( 'NewsArticle', $ppage['@type'] );
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+
+		// The metadata '@type' for the context should be 'WebPage' for the homepage.
+		self::assertSame( 'WebPage', $structured_data['@type'] );
+
+		// Go to a single post page
+		$this->go_to( '/?p=' . $post_id );
+
+		// Create the structured data for that post.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+
+		// The metadata '@type' for the context should be 'NewsArticle' for a single post page.
+		self::assertSame( 'NewsArticle', $structured_data['@type'] );
 	}
 
 	/**

--- a/tests/all-test.php
+++ b/tests/all-test.php
@@ -190,16 +190,29 @@ PARSELYJS;
 	 * @package    SampleTest
 	 */
 	public function test_parsely_tags_lowercase() {
-		$post_array                = $this->create_test_post_array();
-		$post_array['tags_input']  = array( 'Sample', 'Tag' );
-		$post                      = $this->factory->post->create( $post_array );
-		$options                   = get_option( 'parsely' );
-		$options['lowercase_tags'] = true;
-		update_option( 'parsely', $options );
-		$this->go_to( '/?p=' . $post );
-		$ppage = self::$parsely->insert_parsely_page();
-		self::assertContains( 'sample', $ppage['keywords'] );
-		self::assertContains( 'tag', $ppage['keywords'] );
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Create two tags with uppercase names and a single post.
+		$tag1 = self::factory()->tag->create( [ 'name' => 'Sample' ] );
+		$tag2 = self::factory()->tag->create( [ 'name' => 'Tag' ] );
+		$post_id = self::factory()->post->create();
+		$post    = get_post( $post_id );
+
+		// Assign the Tags to the Post.
+		wp_set_object_terms( $post_id, array( $tag1, $tag2 ), 'post_tag' );
+
+		// Set the Parsely plugin to use Lowercase tags.
+		$parsely_options['lowercase_tags'] = true;
+		update_option( 'parsely', $parsely_options );
+
+		// Create the structured data for that post.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+
+		// The structured data should contain both tags in lowercase form.
+		self::assertContains( 'sample', $structured_data['keywords'] );
+		self::assertContains( 'tag', $structured_data['keywords'] );
 	}
 
 	/**

--- a/tests/all-test.php
+++ b/tests/all-test.php
@@ -129,7 +129,7 @@ PARSELYJS;
 
 
 	/**
-	 * Check the parsely page output
+	 * Check the context `@type` field for a Post and the Homepage.
 	 *
 	 * @category   Function
 	 * @package    SampleTest

--- a/tests/all-test.php
+++ b/tests/all-test.php
@@ -140,7 +140,12 @@ PARSELYJS;
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Create a single post
-		$post_id = self::factory()->post->create( [ 'post_type' => 'post', 'post_title' => 'Home' ] );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'post',
+				'post_title' => 'Home',
+			) 
+		);
 		$post    = get_post( $post_id );
 
 		// Go to the homepage
@@ -172,9 +177,9 @@ PARSELYJS;
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a single category term, and a Post with that category.
-		$category = self::factory()->category->create( [ 'name' => 'Test Category' ] );
-		$post_id = self::factory()->post->create( [ 'post_category' => [ $category ] ] );
-		$post    = get_post( $post_id );
+		$category = self::factory()->category->create( array( 'name' => 'Test Category' ) );
+		$post_id  = self::factory()->post->create( array( 'post_category' => array( $category ) ) );
+		$post     = get_post( $post_id );
 
 		// Create the structured data for that post.
 		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
@@ -195,8 +200,8 @@ PARSELYJS;
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Create two tags with uppercase names and a single post.
-		$tag1 = self::factory()->tag->create( [ 'name' => 'Sample' ] );
-		$tag2 = self::factory()->tag->create( [ 'name' => 'Tag' ] );
+		$tag1    = self::factory()->tag->create( array( 'name' => 'Sample' ) );
+		$tag2    = self::factory()->tag->create( array( 'name' => 'Tag' ) );
 		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
@@ -227,15 +232,15 @@ PARSELYJS;
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Set the Categories as Tags option to true.
-		$parsely_options['cats_as_tags'] = true;
+		$parsely_options['cats_as_tags']   = true;
 		$parsely_options['lowercase_tags'] = false;
 		update_option( 'parsely', $parsely_options );
 
 		// Create 3 categories and a single post with those categories.
-		$cat1 = self::factory()->category->create( [ 'name' => 'Test Category' ] );
-		$cat2 = self::factory()->category->create( [ 'name' => 'Test Category 2' ] );
-		$cat3 = self::factory()->category->create( [ 'name' => 'Test Category 3' ] );
-		$post_id = self::factory()->post->create( [ 'post_category' => [ $cat1, $cat2, $cat3 ] ] );
+		$cat1    = self::factory()->category->create( array( 'name' => 'Test Category' ) );
+		$cat2    = self::factory()->category->create( array( 'name' => 'Test Category 2' ) );
+		$cat3    = self::factory()->category->create( array( 'name' => 'Test Category 3' ) );
+		$post_id = self::factory()->post->create( array( 'post_category' => array( $cat1, $cat2, $cat3 ) ) );
 		$post    = get_post( $post_id );
 
 		// Create the structured data for that post.
@@ -264,12 +269,17 @@ PARSELYJS;
 
 		// Create a custom taxonomy and add a tag for it.
 		register_taxonomy( 'hockey', 'post' );
-		$custom_tax_tag = self::factory()->tag->create( [ 'name' => 'Gretzky', 'taxonomy' => 'hockey' ] );
+		$custom_tax_tag = self::factory()->tag->create(
+			array(
+				'name'     => 'Gretzky',
+				'taxonomy' => 'hockey',
+			) 
+		);
 
 		// Create a tag and a category and a signle post and assign the category to the post.
-		$tag = self::factory()->tag->create( [ 'name' => 'Tag' ] );
-		$cat = self::factory()->category->create( [ 'name' => 'Category' ] );
-		$post_id = self::factory()->post->create( [ 'post_category' => [ $cat ] ]);
+		$tag     = self::factory()->tag->create( array( 'name' => 'Tag' ) );
+		$cat     = self::factory()->category->create( array( 'name' => 'Category' ) );
+		$post_id = self::factory()->post->create( array( 'post_category' => array( $cat ) ) );
 
 		$post = get_post( $post_id );
 
@@ -303,9 +313,14 @@ PARSELYJS;
 		update_option( 'parsely', $parsely_options );
 
 		// Create 3 categories and a single post with those categories.
-		$cat1 = self::factory()->category->create( [ 'name' => 'Parent Category' ] );
-		$cat2 = self::factory()->category->create( [ 'name' => 'Child Category', 'parent' => $cat1 ] );
-		$post_id = self::factory()->post->create( [ 'post_category' => [ $cat1, $cat2 ] ] );
+		$cat1    = self::factory()->category->create( array( 'name' => 'Parent Category' ) );
+		$cat2    = self::factory()->category->create(
+			array(
+				'name'   => 'Child Category',
+				'parent' => $cat1,
+			) 
+		);
+		$post_id = self::factory()->post->create( array( 'post_category' => array( $cat1, $cat2 ) ) );
 		$post    = get_post( $post_id );
 
 		// Create the structured data for that post.
@@ -335,10 +350,21 @@ PARSELYJS;
 
 		// Create a custom taxonomy, add a term and child term to it, and add them to a post.
 		register_taxonomy( 'sports', 'post' );
-		$custom_tax_tag = self::factory()->term->create( [ 'name' => 'football', 'taxonomy' => 'sports' ] );
-		$custom_tax_tag_child = self::factory()->term->create( [ 'name' => 'premiere league', 'taxonomy' => 'sports', 'parent' =>  $custom_tax_tag ] );
-		$post_id = self::factory()->post->create();
-		$post    = get_post( $post_id );
+		$custom_tax_tag       = self::factory()->term->create(
+			array(
+				'name'     => 'football',
+				'taxonomy' => 'sports',
+			) 
+		);
+		$custom_tax_tag_child = self::factory()->term->create(
+			array(
+				'name'     => 'premiere league',
+				'taxonomy' => 'sports',
+				'parent'   => $custom_tax_tag,
+			) 
+		);
+		$post_id              = self::factory()->post->create();
+		$post                 = get_post( $post_id );
 
 		// Set the custom taxonomy terms to the post.
 		wp_set_object_terms( $post_id, array( $custom_tax_tag, $custom_tax_tag_child ), 'sports' );
@@ -368,10 +394,21 @@ PARSELYJS;
 
 		// Create a custom taxonomy, add a term and child term to it, and add them to a post.
 		register_taxonomy( 'sports', 'post' );
-		$custom_tax_tag = self::factory()->term->create( [ 'name' => 'football', 'taxonomy' => 'sports' ] );
-		$custom_tax_tag_child = self::factory()->term->create( [ 'name' => 'premiere league', 'taxonomy' => 'sports', 'parent' =>  $custom_tax_tag ] );
-		$post_id = self::factory()->post->create();
-		$post    = get_post( $post_id );
+		$custom_tax_tag       = self::factory()->term->create(
+			array(
+				'name'     => 'football',
+				'taxonomy' => 'sports',
+			) 
+		);
+		$custom_tax_tag_child = self::factory()->term->create(
+			array(
+				'name'     => 'premiere league',
+				'taxonomy' => 'sports',
+				'parent'   => $custom_tax_tag,
+			) 
+		);
+		$post_id              = self::factory()->post->create();
+		$post                 = get_post( $post_id );
 
 		// Set the custom taxonomy terms to the post.
 		wp_set_object_terms( $post_id, array( $custom_tax_tag, $custom_tax_tag_child ), 'sports' );
@@ -404,8 +441,8 @@ PARSELYJS;
 		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
 
 		// The url scheme should be 'http'.
-		$url = wp_parse_url($structured_data['url']);
-		self::assertSame('http', $url['scheme']);
+		$url = wp_parse_url( $structured_data['url'] );
+		self::assertSame( 'http', $url['scheme'] );
 
 		// Set Parsely to force https canonicals.
 		$parsely_options['force_https_canonicals'] = true;
@@ -415,8 +452,8 @@ PARSELYJS;
 		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
 
 		// The url scheme should be 'https'.
-		$url = wp_parse_url($structured_data['url']);
-		self::assertSame('https', $url['scheme']);
+		$url = wp_parse_url( $structured_data['url'] );
+		self::assertSame( 'https', $url['scheme'] );
 	}
 
 	/**
@@ -465,12 +502,12 @@ PARSELYJS;
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Create a single post.
-		$post_id       = $this->factory->post->create();
-		$post          = get_post( $post_id );
+		$post_id = $this->factory->post->create();
+		$post    = get_post( $post_id );
 
 
 		// Apply page filtering.
-		$headline   = 'Completely New And Original Filtered Headline';
+		$headline = 'Completely New And Original Filtered Headline';
 		add_filter(
 			'after_set_parsely_page',
 			function( $args ) use ( $headline ) {

--- a/tests/all-test.php
+++ b/tests/all-test.php
@@ -460,13 +460,17 @@ PARSELYJS;
 	 * @package    SampleTest
 	 */
 	public function test_parsely_page_filter() {
-		$options    = get_option( 'parsely' );
-		$post_array = $this->create_test_post_array();
-		$post       = $this->factory->post->create( $post_array );
-		$headline   = 'Completely New And Original Filtered Headline';
-		$this->go_to( '/?p=' . $post );
-		
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Create a single post.
+		$post_id       = $this->factory->post->create();
+		$post          = get_post( $post_id );
+
+
 		// Apply page filtering.
+		$headline   = 'Completely New And Original Filtered Headline';
 		add_filter(
 			'after_set_parsely_page',
 			function( $args ) use ( $headline ) {
@@ -478,8 +482,11 @@ PARSELYJS;
 			3
 		);
 
-		$ppage = self::$parsely->insert_parsely_page();
-		self::assertTrue( strpos( $ppage['headline'], $headline ) === 0 );
+		// Create the structured data for that post.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+
+		// The structured data should contain the headline from the filter.
+		self::assertTrue( strpos( $structured_data['headline'], $headline ) === 0 );
 	}
 
 	/**

--- a/tests/all-test.php
+++ b/tests/all-test.php
@@ -134,7 +134,7 @@ PARSELYJS;
 	 * @category   Function
 	 * @package    SampleTest
 	 */
-	public function test_parsely_ppage_output() {
+	public function test_parsely_metadata_context_output() {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );

--- a/tests/all-test.php
+++ b/tests/all-test.php
@@ -355,26 +355,30 @@ PARSELYJS;
 	 * @package    SampleTest
 	 */
 	public function test_top_level_taxonomy_as_section() {
-		$options                            = get_option( 'parsely' );
-		$options['custom_taxonomy_section'] = 'sports';
-		$options['use_top_level_cats']      = true;
-		update_option( 'parsely', $options );
-		$post_array                  = $this->create_test_post_array();
-		$cat                         = $this->create_test_category( 'news' );
-		$post_array['post_category'] = array( $cat );
-		$post                        = $this->factory->post->create( $post_array );
-		$parent_taxonomy             = $this->create_test_taxonomy( 'sports', 'basketball' );
-		$child_taxonomy              = $this->factory->term->create(
-			array(
-				'name'     => 'lebron',
-				'taxonomy' => 'sports',
-				'parent'   => $parent_taxonomy,
-			)
-		);
-		wp_set_post_terms( $post, array( $parent_taxonomy, $child_taxonomy ), 'sports' );
-		$this->go_to( '/?p=' . $post );
-		$ppage = self::$parsely->insert_parsely_page();
-		self::assertSame( 'basketball', $ppage['articleSection'] );
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Set Parsely to use 'sports' as custom taxonomy for section.
+		$parsely_options['custom_taxonomy_section'] = 'sports';
+
+		// Make sure top-level categories are not set to be used.
+		$parsely_options['use_top_level_cats'] = true;
+		update_option( 'parsely', $parsely_options );
+
+		// Create a custom taxonomy, add a term and child term to it, and add them to a post.
+		register_taxonomy( 'sports', 'post' );
+		$custom_tax_tag = self::factory()->term->create( [ 'name' => 'football', 'taxonomy' => 'sports' ] );
+		$custom_tax_tag_child = self::factory()->term->create( [ 'name' => 'premiere league', 'taxonomy' => 'sports', 'parent' =>  $custom_tax_tag ] );
+		$post_id = self::factory()->post->create();
+		$post    = get_post( $post_id );
+
+		// Set the custom taxonomy terms to the post.
+		wp_set_object_terms( $post_id, array( $custom_tax_tag, $custom_tax_tag_child ), 'sports' );
+
+		// Create the structured data for that post.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		self::assertSame( 'football', $structured_data['articleSection'] );
 	}
 
 	/**

--- a/tests/all-test.php
+++ b/tests/all-test.php
@@ -167,13 +167,20 @@ PARSELYJS;
 	 * @package    SampleTest
 	 */
 	public function test_parsely_categories() {
-		$post_array                  = $this->create_test_post_array();
-		$cat                         = $this->create_test_category( 'Newssss' );
-		$post_array['post_category'] = array( $cat );
-		$post                        = $this->factory->post->create( $post_array );
-		$this->go_to( '/?p=' . $post );
-		$ppage = self::$parsely->insert_parsely_page();
-		self::assertSame( 'Newssss', $ppage['articleSection'] );
+		// Setup Parsley object.
+		$parsely         = new \Parsely();
+		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
+
+		// Insert a single category term, and a Post with that category.
+		$category = self::factory()->category->create( [ 'name' => 'Test Category' ] );
+		$post_id = self::factory()->post->create( [ 'post_category' => [ $category ] ] );
+		$post    = get_post( $post_id );
+
+		// Create the structured data for that post.
+		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+
+		// The category in the structured data should match the category of the post.
+		self::assertSame( 'Test Category', $structured_data['articleSection'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Parsely/wp-parsely/issues/180

Reworks the following unit tests:
-  test_parsely_ppage_output
-  test_parsely_categories
-  test_parsely_tags_lowercase
-  test_parsely_cats_as_tags
-  test_custom_taxonomy_tags
-  test_use_top_level_cats
-  test_custom_taxonomy_as_section
-  test_top_level_taxonomy_as_section
-  test_http_canonicals
-  test_fbia_integration
-  test_amp_integration
-  test_parsely_page_filter
-  test_user_logged_in
-  test_user_logged_in_multisite

The only unit test that still echo's output is `test_parsely_tag`.  The way the JS is going to be included is going to change, so this unit test needs to be reworked along with the other work in progress.

## Changes:
- Most unit tests no longer echo.
- Instead of using `insert_parsely_page` and checking the echo'd out strings, we're now using the `construct_parsely_metadata` function and checking the returned data from that function.
- For the `force_https_canonicals` test, we're now checking the scheme using `wp_parse_url()` instead of using `strpos`.