### PR TITLE
Widget: Add missing translator comment

### DIFF
--- a/src/class-parsely-recommended-widget.php
+++ b/src/class-parsely-recommended-widget.php
@@ -256,6 +256,7 @@ class Parsely_Recommended_Widget extends WP_Widget {
 			$settings_page_url = add_query_arg( 'page', 'parsely', get_admin_url() . 'options-general.php' );
 
 			$message = sprintf(
+				/* translators: %s: Plugin settings page URL */
 				__( 'The <i>Parse.ly Site ID</i> and <i>Parse.ly API Secret</i> fields need to be populated on the <a href="%s">Parse.ly settings page</a> for this widget to work.', 'wp-parsely' ),
 				esc_url( $settings_page_url )
 			);


### PR DESCRIPTION
`vendor/bin/phpcs --standard=WordPress-Extra --sniffs=WordPress.WP.i18n . --ignore=vendor` revealed only one violation.