### PR TITLE
Fix CSS file URL path

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -113,7 +113,7 @@ class Parsely {
 	 * Initialize parsely WordPress style
 	 */
 	public function wp_parsely_style_init() {
-		wp_register_style( 'wp-parsely-style', plugins_url( 'wp-parsely.css', __FILE__ ), array(), Parsely::VERSION );
+		wp_register_style( 'wp-parsely-style', PARSELY_PLUGIN_URL . 'wp-parsely.css', array(), Parsely::VERSION );
 	}
 
 	/**

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -26,6 +26,9 @@ require 'src/class-parsely.php';
 
 if ( class_exists( 'Parsely' ) ) {
 	define( 'PARSELY_VERSION', Parsely::VERSION );
+	if ( ! defined( 'PARSELY_PLUGIN_URL' ) ) {
+		define( 'PARSELY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+	}
 	$parsely = new Parsely();
 }
 


### PR DESCRIPTION
## Description

When the widget loads, the request to load the CSS file is failing since the main class file was moved in #262 (It's trying to load the file from a `src/` path which does not exist.

<img width="1054" alt="Screen Shot 2021-05-03 at 10 50 09 AM" src="https://user-images.githubusercontent.com/1587282/116892022-6127b580-abfd-11eb-9cdc-6aadc9c9e070.png">

This defines a new constant `PARSELY_PLUGIN_URL` for the result of `plugin_dir_url`).  That value is referenced in the `wp_register_style` call instead of calling `plugins_url` making it independent of the location of the referencing PHP file.

## To Test

### Set Up

* Set a value for the API secret
* Configure the widget

### Confirm Current Behavior

* Run the develop branch
* Browse to a URL that displays the widget
* Notice the CSS file call 404s

### Confirm Fix

* Run this branch
* Browse to a URL that displays the widget
* Notice the CSS file call succeeds and is loaded
