### PR TITLE
Simplify PHP Main Entry File

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -22,20 +22,29 @@
  * Requires WP:       4.0.0
  */
 
-require 'src/class-parsely.php';
-
-if ( class_exists( 'Parsely' ) ) {
-	define( 'PARSELY_VERSION', Parsely::VERSION );
-	if ( ! defined( 'PARSELY_PLUGIN_DIR' ) ) {
-		define( 'PARSELY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-	}
-	if ( ! defined( 'PARSELY_PLUGIN_URL' ) ) {
-		define( 'PARSELY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-	}
-	$parsely = new Parsely();
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+	die;
 }
 
-require 'src/class-parsely-recommended-widget.php';
+if ( class_exists( 'Parsely' ) ) {
+	return;
+}
+
+if ( ! defined( 'PARSELY_PLUGIN_DIR' ) ) {
+	define( 'PARSELY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+}
+if ( ! defined( 'PARSELY_PLUGIN_URL' ) ) {
+	define( 'PARSELY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+}
+
+require PARSELY_PLUGIN_DIR . 'src/class-parsely.php';
+
+define( 'PARSELY_VERSION', Parsely::VERSION );
+
+$GLOBALS['parsely'] = new Parsely();
+
+require PARSELY_PLUGIN_DIR . 'src/class-parsely-recommended-widget.php';
 
 add_action( 'widgets_init', 'parsely_recommended_widget_register' );
 /**


### PR DESCRIPTION
## Description

As noted in #276, there are concerns about some of the mechanisms in the main PHP entry file.  This PR is so we can hash these out in one place.

At present, what I've done is:

1. Add a check that `WPINC` is defined and halts execution if not. This prevents calling the file directly outside of a WordPress context (see [boilerplate](https://github.com/GaryJones/plugin-boilerplate/blob/353e4fa4071e163a42f7b233983dc25dc50d2076/plugin-slug.php#L27-L30))
1. Bails (via early `return`) if the `Parsely` class is already defined.
1. Explicitly assigns the instance to a `$parsely` global via the `$GLOBALS` superglobal
1. Sources class files relative to `PARSELY_PLUGIN_DIR`

There was some question as to wrapping the `PARSELY_PLUGIN_DIR` & `PARSELY_PLUGIN_URL` constants in `if ( ! defined...` conditionals.  This change leaves them in so it's possible to set prior to this plugin loads (by hosts / users / whomever).  There's also precedent for such [in the boilerplate repo](https://github.com/GaryJones/plugin-boilerplate/blob/353e4fa4071e163a42f7b233983dc25dc50d2076/init.php#L24-L30). That said, I'm happy to discuss any rationale for taking them out.