### PR TITLE
Fix The Plugin Action Link 

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -76,9 +76,8 @@ class Parsely {
 		// display warning when plugin hasn't been configured.
 		add_action( 'admin_footer', array( $this, 'display_admin_warning' ) );
 
-		$basename = plugin_basename( __FILE__ );
 		add_filter(
-			'plugin_action_links_' . $basename,
+			'plugin_action_links_' . PARSELY_PLUGIN_BASENAME,
 			array( $this, 'add_plugin_meta_links' )
 		);
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -31,6 +31,9 @@ if ( class_exists( 'Parsely' ) ) {
 	return;
 }
 
+if ( ! defined( 'PARSELY_PLUGIN_BASENAME' ) ) {
+	define( 'PARSELY_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+}
 if ( ! defined( 'PARSELY_PLUGIN_DIR' ) ) {
 	define( 'PARSELY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 }


### PR DESCRIPTION
## Description

Moving the `Parsely` class file out of the main entry PHP file (#262) caused a regression in that the "Settings" link on the Plugin listing page was no longer printed.  This reinstates it by adding a constant for the basename in the top-level file and referencing it in the class file.

|Before|After|
|---|---|
|![Screen Shot 2021-05-04 at 1 27 44 PM](https://user-images.githubusercontent.com/1587282/117044707-be466880-acdc-11eb-835f-a7dda4b85cd8.png)|![Screen Shot 2021-05-04 at 1 27 58 PM](https://user-images.githubusercontent.com/1587282/117044727-c30b1c80-acdc-11eb-9b74-859ea7598b5a.png)|

## To Test

### Confirm current behavior

* Browse to `/wp-admin/plugins.php` with this plugin active
* Notice no "Settings" link on this plugin's entry

### Confirm fix

* Browse to `/wp-admin/plugins.php` with this plugin active
* Confirm "Settings" link on this plugin's entry is present and links to our settings page

