### PR TITLE
Add Dependabot Reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: 'npm'
+    reviewers: 'Parsely/wp-parsely'
     directory: '/'
     schedule:
       interval: 'daily'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds `Parsely/wp-parsely` as a reviewer to to dependabot config

## Motivation and Context
Save a few clicks n keystrokes!

## How Has This Been Tested?

n/a

https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#reviewers

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Maintenance
