### PR TITLE
Fix Dependabot Reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: 'npm'
-    reviewers: 'Parsely/wp-parsely'
+    reviewers:
+      - 'Parsely/wp-parsely'
     directory: '/'
     schedule:
       interval: 'daily'


### PR DESCRIPTION
## Description

fix for #287

a string is not sufficient...apparently it has to be an array

see: https://github.com/Parsely/wp-parsely/pull/266/checks?check_run_id=2514953476

