### PR TITLE
Fix text domain (wp-parsley -> wp-parsely)

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -704,7 +704,7 @@ class Parsely {
 
 		$message = sprintf(
 				/* translators: %s: Plugin settings page URL */
-				__( '<strong>The Parse.ly plugin is not active.</strong> You need to <a href="%s">provide your Parse.ly Dash Site ID</a> before things get cooking.', 'wp-parsley' ),
+				__( '<strong>The Parse.ly plugin is not active.</strong> You need to <a href="%s">provide your Parse.ly Dash Site ID</a> before things get cooking.', 'wp-parsely' ),
 				 esc_url( $this->get_settings_url() )
 		);
 		?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update a text domain slug in an i18n function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`wp-parsley` is not correct, `wp-parsely` is. 

I wonder if a generalized lint rule is in order :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
n/a

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Bug fix (non-breaking change which fixes an issue)
