### PR TITLE
Fix the deprecated comment to point to new symbol

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1226,7 +1226,7 @@ class Parsely {
 		 * If true, the JavaScript files are sourced.
 		 *
 		 * @since 2.2.0
-		 * @deprecated 2.5.0 Use `wp_parsely_insert_javascript` filter instead.
+		 * @deprecated 2.5.0 Use `wp_parsely_load_js_tracker` filter instead.
 		 *
 		 * @param bool $display True if the JavaScript file should be included. False if not.
 		 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix the `deprecated` message for the `parsely_filter_insert_javascript` filter added in #281.
It changed to `wp_parsely_load_js_tracker` -- not `wp_parsely_insert_javascript`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Correctness in documentation!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
n/a

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Doc fix
