### PR TITLE
Improve "cs-lint" & "integration test" Github Action Event Handling

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -4,9 +4,13 @@ on:
   # Run on all pushes and on all pull requests.
   # Prevent the "push" build from running when there are only irrelevant changes.
   push:
+    branches:
+      - develop
+      - trunk
+      - release/**
+  pull_request:
     paths-ignore:
       - '**.md'
-  pull_request:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - src/js/**
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,9 +4,13 @@ on:
   # Run on all pushes and on all pull requests.
   # Prevent the "push" build from running when there are only irrelevant changes.
   push:
+    branches:
+      - develop
+      - trunk
+      - release/**
+  pull_request:
     paths-ignore:
       - '**.md'
-  pull_request:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - src/js/**
   # Allow manually triggering the workflow.
   workflow_dispatch:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* Limit cs-lint & integration tests from running twice on push
    * Add an "allowed list" of branches to respond to `push` events
* Add `src/js/**` to the paths-ignore list, so changes limited to files there don't trigger these tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Run tests as few times as possible. See previous discussion in #299

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#306 is based on this branch, #307 is based on `develop`

* Pushing to the branch in 306 (based on this one) prior to attaching it to a PR **did not** trigger these tests. Doing so to the branch in 307 **did**.
* Creating the Pull Request **did** run these tests on both branches.
* Pushing to the branch in 306 (based on this one) after it was PR'd ran these tests only once (for the `pull_request.synchronize` action type). Pushing to the branch in 307 (based on develop) after it was PR'd ran these tests twice.

## Screenshots (if appropriate):

### Pushing to a branch attached to a PR:

|Before|After|
|---|---|
|![Screen Shot 2021-05-10 at 3 09 20 PM](https://user-images.githubusercontent.com/1587282/117715781-c0119f80-b1a6-11eb-9371-7b76a78f48e6.png)|![Screen Shot 2021-05-10 at 3 09 34 PM](https://user-images.githubusercontent.com/1587282/117715802-c6078080-b1a6-11eb-948c-924072162e7c.png)|

Note it says "8 successful checks" vs 16.


## Types of changes
Dev tools
