### PR TITLE
Node.js Workflow: Run on 'push' event to all branches & tweak paths

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,8 +66,6 @@ jobs:
         with:
           composer-options: '${{ matrix.composer-options }}'
 
-      #      - name: Run unit tests
-      #        run: composer unit
 
       - name: Start MySQL Service
         run: sudo systemctl start mysql.service

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,11 +22,11 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4' ]
+        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
         include:
           - php: '8.0'
             # Ignore platform requirements, so that PHPUnit 7.5 can be installed on PHP 8.0 (and above).
-            composer-options: "--ignore-platform-reqs"
+            composer-options: '--ignore-platform-reqs'
             extensions: pcov
             ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
             coverage: pcov
@@ -64,10 +64,10 @@ jobs:
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v1
         with:
-          composer-options: "${{ matrix.composer-options }}"
+          composer-options: '${{ matrix.composer-options }}'
 
-#      - name: Run unit tests
-#        run: composer unit
+      #      - name: Run unit tests
+      #        run: composer unit
 
       - name: Start MySQL Service
         run: sudo systemctl start mysql.service

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,15 +7,13 @@ on:
   pull_request:
     paths:
       - .github/workflows/*.js.yml
-      - src/js/**/*[tj]sx?
-      - tests/js/**/*.[tj]s
-      - package.json
-      - '*.js'
+      - '**/*[tj]sx?'
+      - package*.json
   push:
-    branches:
-      - develop
-      - trunk
-      - release/**
+    paths:
+      - .github/workflows/*.js.yml
+      - '**/*[tj]sx?'
+      - package*.json
   # Allow manually triggering the workflow.
   workflow_dispatch:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Per [this comment](https://github.com/Parsely/wp-parsely/pull/308#issuecomment-838602612), this will run this test on pushes as well as pull request events.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since the tests are distinct, it makes sense to run them on both events.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On this PR:

* The workflow ran on initial push (before PR'ing)
* The workflow ran on attaching the branch to a PR
* The workflow ran on pushing a change to the PR'd branch

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Devtools
