### PR TITLE
Set node.js workflow to run on v 16 instead of 15, gte engine/npm

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 15.x]
+        node-version: [14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "prettier": "^2.3.0"
       },
       "engines": {
-        "node": "^14",
-        "npm": "^7"
+        "node": ">=14",
+        "npm": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "test": "tests"
   },
   "engines": {
-    "node": "^14",
-    "npm": "^7"
+    "node": ">=14",
+    "npm": ">=7"
   },
   "scripts": {
     "build": "wp-scripts build",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This changes the v 15 test target to use v 16

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Node.js version 16 is the current `current` as of April 20 and will become the supported LTS on October 26.

https://nodejs.org/en/about/releases/

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This PR will run the tests on sync.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Devtools
