### PR TITLE
Composer: Add composer/installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
 	"name": "parsely/wp-parsely",
+	"type": "wordpress-plugin",
 	"description": "The Parse.ly WordPress plugin.",
 	"license": "GPL-2.0-or-later",
 	"authors": [
@@ -11,7 +12,8 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6"
+		"php": ">=5.6",
+		"composer/installers": "^1"
 	},
 	"require-dev": {
 		"automattic/vipwpcs": "^2.2",


### PR DESCRIPTION
Add `composer/installers` package and define a type. All WP plugins should have it!

## Description
By adding the [Composer Installers](https://github.com/composer/installers/) package, and defining the type as a `wordpress-plugin`, then there is a better chance that this package will be dropped into the correct location when someone uses Composer to install it.

## Motivation and Context
Without this definition and type, the package will install into the `vendor` directory. 

However, for site-level `composer.json` files, a site developer would want to install it into `wp-content/plugins/` instead. By setting the type and using the installer, then [this definition](https://github.com/composer/installers/blob/ae03311f45dfe194412081526be2e003960df74b/src/Composer/Installers/WordPressInstaller.php#L7) makes that happen.

## How Has This Been Tested?
Not easy to test until this is in, and released and picked up by Packagist, but ultimately running `composer require parsely/wp-parsely` in the root of a WordPress application would put it into `wp-content/plugins/wp-parsely` instead of `vendor/parsely/wp-parsely`.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
