### PR TITLE
Exclude .nvmrc from exports / published plugin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,7 @@
 /.gitignore          export-ignore
 /.phpcs.xml.dist     export-ignore
 /.prettierrc         export-ignore
+/.nvmrc              export-ignore
 /.travis.yml         export-ignore
 /CHANGELOG.md        export-ignore
 /CODE_OF_CONDUCT.md  export-ignore


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

include `/.nvmrc    export-ignore` in the `.gitattributes` file

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There's no need to include this developer-facing file in the published plugin package

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
wp-parsely $ git archive origin/develop | grep ".nvmrc"
Binary file (standard input) matches
wp-parsely $ git archive origin/rm-nvmrc-from-export | grep ".nvmrc"
wp-parsely $
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
devtool fixup