### PR TITLE
CI: Use Ubuntu 18.04

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,8 +14,9 @@ jobs:
   test:
     name: PHP ${{ matrix.php }}
     # ubuntu-20.04 / ubuntu-latest includes MySQL 8, which has issues with older versions of PHP.
-    # ubuntu-16.04 includes PHP versions 5.6-8.0
-    runs-on: ubuntu-16.04
+    # ubuntu-18.04 includes PHP versions 7.1-8.0, but 5.6-7.1 are cached, so setup is about 5 seconds.
+    # See https://setup-php.com/i/452
+    runs-on: ubuntu-18.04
 
     env:
       WP_VERSION: latest


### PR DESCRIPTION
## Description
Switch from integration-tests.yml workflow from ubuntu-16.04 to ubuntu-18.04.

## Motivation and Context
Ubuntu 16.04 is [now deprecated](https://ubuntu.com/blog/ubuntu-16-04-lts-transitions-to-extended-security-maintenance-esm), but the setup-php action has been updated to make using PHP 5.6-7.1 much quicker than it was previously on ubuntu-18.04. As such, we can now switch to it without too much of a penalty.

See https://setup-php.com/i/452

## How Has This Been Tested?

Compare https://github.com/Parsely/wp-parsely/actions/runs/835962981 (showing deprecation notices), and https://github.com/Parsely/wp-parsely/actions/runs/835924223, the push run from the branch in this PR.
