### PR TITLE
Add export script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,8 @@
 # They are also used when pushing to WordPress.org SVN using the
 # https://github.com/10up/action-wordpress-plugin-deploy GitHub Action.
 
+# Likewise, anything marked `export-ignore` will be excluded by `bin/export-plugin.sh`
+
 # Directories
 /.github             export-ignore
 /.wordpress-org      export-ignore

--- a/bin/export-plugin.sh
+++ b/bin/export-plugin.sh
@@ -23,7 +23,7 @@ if [ ! -w "$OUTPUT_DIRECTORY" ]; then
 fi
 
 BRANCH=$(git branch --show-current)
-REMOTE=$(git config branch."$BRANCH".remote)
+REMOTE="origin"
 REMOTEBRANCH="$REMOTE/$BRANCH"
 LOCALHASH=$(git rev-parse --short $BRANCH)
 
@@ -39,7 +39,7 @@ if [[ "$(git status -sb | wc -l | xargs)" != "1" && -z "$DEBUG" ]]; then
 fi
 
 echo "Fetching remote branch: $REMOTE $BRANCH..."
-git fetch $REMOTE $BRANCH
+git fetch "$REMOTE" "$BRANCH"
 
 if [[ "$?" != "0" && -z "$DEBUG" ]]; then
 	echo "Unable to continue without remote branch: $REMOTEBRANCH"

--- a/bin/export-plugin.sh
+++ b/bin/export-plugin.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+usage () {
+	echo "Usage $0 <OUTPUT_DIRECTORY> <OUTPUT_FORMAT=ZIP>"
+	echo "Supported values for <OUTPUT_FORMAT> are: ZIP, DIR"
+	echo "IMPORTANT! Files in the output directory will be OVERWRITTEN!"
+}
+
+OUTPUT_DIRECTORY="$1"
+OUTPUT_FORMAT="${2:-ZIP}"
+OUTPUT_FORMAT=$(echo "$OUTPUT_FORMAT" | tr '[:lower:]' '[:upper:]')
+
+if [ ! -d "$OUTPUT_DIRECTORY" ]; then
+	usage
+	echo "<OUTPUT_DIRECTORY> is not a dir. Your input was: \"$OUTPUT_DIRECTORY\""
+	exit 1
+fi
+
+if [ ! -w "$OUTPUT_DIRECTORY" ]; then
+	usage
+	echo "Cannot write to <OUTPUT_DIRECTORY>: $OUTPUT_DIRECTORY"
+	exit 2
+fi
+
+BRANCH=$(git branch --show-current)
+REMOTE=$(git config branch."$BRANCH".remote)
+REMOTEBRANCH="$REMOTE/$BRANCH"
+LOCALHASH=$(git rev-parse --short $BRANCH)
+
+echo "Attempting to package..."
+echo "  branch:     $BRANCH"
+echo "  hash:       $LOCALHASH"
+echo "  format:     $OUTPUT_FORMAT"
+echo "  output dir: $OUTPUT_DIRECTORY";
+
+if [[ "$(git status -sb | wc -l | xargs)" != "1" && -z "$DEBUG" ]]; then
+	echo "ERROR: Local branch contains uncommitted changes"
+	exit 10
+fi
+
+echo "Fetching remote branch: $REMOTE $BRANCH..."
+git fetch $REMOTE $BRANCH
+
+if [[ "$?" != "0" && -z "$DEBUG" ]]; then
+	echo "Unable to continue without remote branch: $REMOTEBRANCH"
+	exit 11
+fi
+
+REMOTEHASH=$(git rev-parse --short $REMOTEBRANCH)
+
+echo "Local Branch \`$BRANCH\` is at hash: \`$LOCALHASH\`"
+echo "Remote Branch \`$REMOTE $BRANCH\` is at hash: \`$REMOTEHASH\`"
+
+if [[ "$LOCALHASH" != "$REMOTEHASH" && -z "$DEBUG" ]]; then
+	echo "ERROR: Local hash does not match remote"
+	exit 12
+fi
+
+git diff --exit-code --quiet "$REMOTEBRANCH"..HEAD 2>/dev/null
+if [[ "$?" != "0" && -z "$DEBUG" ]]; then
+	echo "ERROR: Local branch called $REMOTEBRANCH & actual remote branch do not match"
+	exit 13
+fi
+
+git diff --exit-code --quiet "$REMOTEBRANCH" 2>/dev/null
+if [[ "$?" != "0" && -z "$DEBUG" ]]; then
+	echo "ERROR: Local files don't match branch: $REMOTEBRANCH"
+	exit 14
+fi
+
+confirm() {
+	read -p "Are you sure? (y/n) " -n1 -r
+	echo
+	if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+		echo "bailed"
+		exit
+	fi
+}
+
+writezip() {
+	OUTFILE="$OUTPUT_DIRECTORY/wp-parsely-$LOCALHASH-$BRANCH.zip"
+	echo "Preparing to export plugin to: $OUTFILE"
+
+	if [[ -f $OUTFILE ]]; then
+		echo "WARNING: $OUTFILE already exists and will be overwritten."
+		confirm
+	fi
+
+	git archive --format zip --output "$OUTFILE" "$REMOTEBRANCH"
+	if [[ "$?" != "0" ]]; then
+		echo "Error running git archive command";
+		exit 20
+	fi
+	echo "Successfully wrote plugin to: $OUTFILE"
+}
+
+# `git archive` does not support writing directly to a directory, so tar, then extract
+# Inspired by: https://github.com/10up/action-wordpress-plugin-deploy/blob/b3f8b3c0d73bf0af43aea9a0c2cb398d12d46b25/entrypoint.sh#L93-L100
+writedir() {
+	if [ "$(ls -A "$OUTPUT_DIRECTORY")" ]; then
+		echo "WARNING: $OUTPUT_DIRECTORY is NOT EMPTY!"
+		echo "If you continue, its contents will be completely replaced."
+		confirm
+	fi
+
+	TMPDIR=$(mktemp -d)
+
+	echo "Preparing to export plugin to temporary dir: $TMPDIR"
+
+	git archive HEAD | tar -x --directory "$TMPDIR"
+	if [[ "$?" != "0" ]]; then
+		echo "Error running git archive command";
+		exit 30
+	fi
+
+	rsync -a "$TMPDIR"/ "$OUTPUT_DIRECTORY"/ --delete --delete-excluded
+	if [[ "$?" != "0" ]]; then
+		echo "Error running rsync command";
+		exit 31
+	fi
+
+	echo "Successfully wrote plugin to dir: $OUTPUT_DIRECTORY"
+}
+
+if [[ "$OUTPUT_FORMAT" == "ZIP" ]]; then
+	writezip
+	exit
+fi
+
+if [[ "$OUTPUT_FORMAT" == "DIR" ]]; then
+	writedir
+	exit
+fi
+
+echo "Unsupported <OUTPUT_FORMAT>: $OUTPUT_FORMAT"
+exit 99

--- a/bin/export-plugin.sh
+++ b/bin/export-plugin.sh
@@ -78,7 +78,8 @@ confirm() {
 }
 
 writezip() {
-	OUTFILE="$OUTPUT_DIRECTORY/wp-parsely-$LOCALHASH-$BRANCH.zip"
+	TIDYBRANCH=$(echo $BRANCH | sed 's/[^a-zA-Z0-9_]/-/g')
+	OUTFILE="$OUTPUT_DIRECTORY/wp-parsely-$LOCALHASH-$TIDYBRANCH.zip"
 	echo "Preparing to export plugin to: $OUTFILE"
 
 	if [[ -f $OUTFILE ]]; then

--- a/bin/export-plugin.sh
+++ b/bin/export-plugin.sh
@@ -78,7 +78,7 @@ confirm() {
 }
 
 writezip() {
-	TIDYBRANCH=$(echo $BRANCH | sed 's/[^a-zA-Z0-9_]/-/g')
+	TIDYBRANCH=$(echo $BRANCH | sed 's/[^a-zA-Z0-9_.]/-/g')
 	OUTFILE="$OUTPUT_DIRECTORY/wp-parsely-$LOCALHASH-$TIDYBRANCH.zip"
 	echo "Preparing to export plugin to: $OUTFILE"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

New script to export the appropriate files for inclusion in a WordPress plugin to a zip or directory.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Provide a standardized method for pulling an archive from a branch. This leverages `git archive` (& the settings in the [.gitattributes](.gitattributes) file by proxy) to only include the files which will be included in the published plugin.

The only required parameter is an output directory.
There's an optional parameter to specify the output format.

```
Usage ./bin/export-plugin.sh <OUTPUT_DIRECTORY> <OUTPUT_FORMAT=ZIP>
Supported values for <OUTPUT_FORMAT> are: ZIP, DIR
```

By default, this will write a zip file named like:
`$OUTPUT_DIRECTORY/wp-parsely-$HASH-$BRANCH.zip`
This is useful to export a plugin file that can be uploaded directly to a test site or shared to invite someone to test a particular pre-release version of the plugin.

If the second param (`OUTPUT_FORMAT`) is `DIR`, the plugin will be written to the `OUTPUT_DIRECTORY` specified in the first param.  This is useful for pulling the plugin files into another file system (e.g. another repository or plugins path for a development environment).

There are checks that the branch is clean & matches the remote. These checks can be bypassed by setting a `DEBUG` environment variable (useful for debugging changes to this script).

There are also prompts to confirm when files would be overwritten.  When writing a zip file, this only prompts if a file is already present at the `$OUTFILE` path.  When writing a dir, this prompts if the directory is not empty (since it deletes files which are not present in the archive).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Assumptions

`~/Downloads/testing` is an empty directory I can write to

* `./bin/export-plugin.sh` prints usage
* `./bin/export-plugin.sh ~/Downloads/testing` writes an appropriately-named zip file containing appropriate files to the specified directory
* Repeating `./bin/export-plugin.sh ~/Downloads/testing` prompts me to continue and bails if I press anything except for `Y` (or `y`)
* Repeating `./bin/export-plugin.sh ~/Downloads/testing` prompts me to continue and, if I press `Y` (or `y`), writes an appropriately-named zip file containing appropriate files to the specified directory
* `./bin/export-plugin.sh ~/Downloads/testing` prompts me to continue and bails if I press anything except for `Y` (or `y`)
* Repeating `./bin/export-plugin.sh ~/Downloads/testing` prompts me to continue and, if I press `Y` (or `y`), writes appropriate files to the specified directory (with no superfluous files)
* `rm -r ~/Downloads/testing/*`, then repeating `./bin/export-plugin.sh ~/Downloads/testing` **DOES NOT* prompt me to continue and writes appropriate files to the specified directory (with no superfluous files)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Dev tools
