### PR TITLE
Tests: Add WP Test Utils package

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -42,7 +42,7 @@ jobs:
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate
       - name: Validate Composer installation
-        run: composer validate --no-check-all --strict
+        run: composer validate --no-check-all
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7",
 		"squizlabs/php_codesniffer": "^3.5",
-		"wp-coding-standards/wpcs": "^2.3.0"
+		"wp-coding-standards/wpcs": "^2.3.0",
+		"yoast/wp-test-utils": "dev-develop#c0d9edd2"
 	},
 	"scripts": {
 		"coverage": [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,30 +5,36 @@
  * @package wp-parsely
  */
 
+use Yoast\WPTestUtils\WPIntegration;
+
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+	putenv( 'WP_TESTS_DIR=' . $_tests_dir );
 }
 
-if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
-	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+if ( getenv( 'WP_PLUGIN_DIR' ) !== false ) {
+	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
+} else {
+	define( 'WP_PLUGIN_DIR', dirname( dirname( __DIR__ ) ) );
+}
+
+$GLOBALS['wp_tests_options'] = [
+	'active_plugins' => [ 'wp-parsely/wp-parsely.php' ],
+];
+
+require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
+
+/*
+ * Load WordPress, which will load the Composer autoload file, and load the MockObject autoloader after that.
+ */
+WPIntegration\bootstrap_it();
+
+if ( ! defined( 'WP_PLUGIN_DIR' ) || file_exists( WP_PLUGIN_DIR . '/wp-parsely/wp-parsely.php' ) === false ) {
+	echo PHP_EOL, 'ERROR: Please check whether the WP_PLUGIN_DIR environment variable is set and set to the correct value. The unit test suite won\'t be able to run without it.', PHP_EOL;
 	exit( 1 );
 }
-
-// Give access to tests_add_filter() function.
-require_once $_tests_dir . '/includes/functions.php';
-
-/**
- * Manually load the plugin being tested.
- */
-function _manually_load_plugin() {
-	require dirname( dirname( __FILE__ ) ) . '/wp-parsely.php';
-}
-tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
-
-// Start up the WP testing environment.
-require $_tests_dir . '/includes/bootstrap.php';
 
 // Include the Parsely custom test case.
 require_once __DIR__ . '/testcase.php';

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -8,12 +8,14 @@
 
 namespace Parsely\Tests;
 
+use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;
+
 /**
  * Abstract base class for all test case implementations.
  *
  * @package Parsely\Tests
  */
-abstract class TestCase extends \WP_UnitTestCase {
+abstract class TestCase extends WPIntegrationTestCase {
 	const DEFAULT_OPTIONS = array(
 		'apikey'                    => 'blog.parsely.com',
 		'content_id_prefix'         => '',


### PR DESCRIPTION
## Description
The [WP Test Utils](https://github.com/Yoast/wp-test-utils) package is a PHPUnit cross-version compatibility layer for testing plugins and themes build for WordPress.

This PR adds it as a dependency, and makes changes to integrate it.

## Motivation and Context

The package has several useful features, but the features we'll use to start with, are:

- Cross-version compatibility with PHPUnit 5.7 - 9.x via the [PHPUnit Polyfills](https://packagist.org/packages/yoast/phpunit-polyfills) package.
  _Note: WordPress Core limit tests to running on PHPUnit 7.5 max. However, using these polyfills we can already start using the up-to-date PHPUnit 9.x syntax, even though the tests don't use PHPUnit 9 yet._
- A custom autoloader which will selectively autoload the WP copies of the PHPUnit 9 native MockBuilder files for PHPUnit < 9 when run on PHP 8 to get round the use of the new reserved keyword `match` as was used in older versions of these files. Without this, we can't use the MockBuilder in PHPUnit.

In the future, we can split out unit tests from WP (integration) tests (#179), and WP Test Utils provides testcases that have [BrainMonkey](https://brain-wp.github.io/BrainMonkey/) (test utility package with specific mocking features for WordPress) support as well as pre-defining some WP-specific constants that our code might be using.

The version of wp-test-utils is pinned to a commit-ref that addresses a [particular issue](https://github.com/Yoast/wp-test-utils/issues/3) when using the standard WP-CLI tests scaffolding directory structure.

The `cs-lint.yml` change is to stop the action failing on the warning that comes with using a commit-ref.

The bootstrap file changes ensure the custom autoloader works correctly, and mocks can be created.

## How Has This Been Tested?
I've written integration tests that attempt to use mocking, and use assertion methods from newer versions of PHPUnit. These tests will be added in a later PR, so this PR can be seen as laying the groundwork. 

See Actions results to see that the existing tests are still passing.

## Screenshots (if appropriate):

<img width="809" alt="Screenshot 2021-06-04 at 23 41 10" src="https://user-images.githubusercontent.com/88371/120869449-68403b80-c58e-11eb-858a-65da20b8f716.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] ~New feature~ Maintenance (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
