### PR TITLE
Fix all Coding Standards violations

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -9,6 +9,8 @@
 	<file>.</file>
 	<!-- Ignoring Files and Folders:
 		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+	<exclude-pattern>/build/</exclude-pattern>
+	<exclude-pattern>/node_modules/</exclude-pattern>
 	<exclude-pattern>/vendor/</exclude-pattern>
 
 	<!-- How to scan -->
@@ -49,6 +51,7 @@
 		<properties>
 			<property name="prefixes" type="array">
 				<element value="parsely"/>
+				<element value="wp_parsely"/>
 			</property>
 		</properties>
 	</rule>
@@ -68,6 +71,7 @@
 	</rule>
 
 	<rule ref="WordPress.Files.FileName">
+		<exclude-pattern>tests/</exclude-pattern>
 		<properties>
 			<property name="custom_test_class_whitelist" type="array">
 				<element value="TestCase"/>

--- a/src/class-parsely-recommended-widget.php
+++ b/src/class-parsely-recommended-widget.php
@@ -63,7 +63,7 @@ class Parsely_Recommended_Widget extends WP_Widget {
 			'limit'  => $return_limit,
 		);
 
-		if ( 'score' === $sort && $boost !== 'no-boost' ) {
+		if ( 'score' === $sort && 'no-boost' !== $boost ) {
 			$query_args['boost'] = $boost;
 		}
 
@@ -91,7 +91,7 @@ class Parsely_Recommended_Widget extends WP_Widget {
 		$removed_title_esc = remove_filter( 'widget_title', 'esc_html' );
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
-		$title = apply_filters( 'widget_title', $instance['title'] );
+		$title      = apply_filters( 'widget_title', $instance['title'] );
 		$title_html = $args['before_widget'] . $args['before_title'] . $title . $args['after_title'];
 
 		if ( $removed_title_esc ) {
@@ -101,17 +101,17 @@ class Parsely_Recommended_Widget extends WP_Widget {
 		wp_enqueue_style( 'wp-parsely-style' );
 		wp_enqueue_script( 'jquery' );
 
-		$title_html   = $args['before_widget'] . $args['before_title'] . $title . $args['after_title'];
+		$title_html = $args['before_widget'] . $args['before_title'] . $title . $args['after_title'];
 		echo wp_kses_post( $title_html );
 
 		// Set up the variables.
 		$options = get_option( 'parsely' );
 		$api_url = $this->get_api_url(
-				$options['apikey'],
-				$instance['published_within'],
-				$instance['sort'],
-				$instance['boost'],
-				$instance['return_limit']
+			$options['apikey'],
+			$instance['published_within'],
+			$instance['sort'],
+			$instance['boost'],
+			$instance['return_limit']
 		);
 
 		$reco_widget_script_asset = require PARSELY_PLUGIN_DIR . 'build/admin-page.asset.php';
@@ -119,7 +119,7 @@ class Parsely_Recommended_Widget extends WP_Widget {
 		wp_register_script(
 			'wp-parsely-recommended-widget',
 			PARSELY_PLUGIN_URL . 'build/recommended-widget.js',
-			$reco_widget_script_asset[ 'dependencies' ],
+			$reco_widget_script_asset['dependencies'],
 			PARSELY::get_asset_cache_buster(),
 			true
 		);
@@ -128,13 +128,13 @@ class Parsely_Recommended_Widget extends WP_Widget {
 			'wp-parsely-recommended-widget',
 			'wpParselyRecommended',
 			array(
-				'displayAuthor' => isset( $instance['display_author'] ) ? wp_json_encode( boolval( $instance['display_author'] ) ) : false,
+				'displayAuthor'    => isset( $instance['display_author'] ) ? wp_json_encode( boolval( $instance['display_author'] ) ) : false,
 				'displayDirection' => isset( $instance['display_direction'] ) ? $instance['display_direction'] : null,
-				'apiUrl' => $api_url,
-				'imgSrc' => isset( $instance['img_src'] ) ? $instance['img_src'] : null,
-				'permalink' => get_permalink(),
-				'personalized' => isset( $instance['personalize_results'] ) ? boolval( $instance['personalize_results'] ): false,
-				'widgetId' => $this->id,
+				'apiUrl'           => $api_url,
+				'imgSrc'           => isset( $instance['img_src'] ) ? $instance['img_src'] : null,
+				'permalink'        => get_permalink(),
+				'personalized'     => isset( $instance['personalize_results'] ) ? boolval( $instance['personalize_results'] ) : false,
+				'widgetId'         => $this->id,
 			)
 		);
 
@@ -219,7 +219,7 @@ class Parsely_Recommended_Widget extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'published_within' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'published_within_label' ) ); ?>"><?php esc_html_e( 'Published within', 'wp-parsely' ); ?></label>
 			<input type="number" id="<?php echo esc_attr( $this->get_field_id( 'published_within' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'published_within' ) ); ?>" value="<?php echo esc_attr( (string) $instance['published_within'] ); ?>" min="0" max="30"
-			       class="tiny-text" aria-labelledby="<?php echo esc_attr( $this->get_field_id( 'published_within_label' ) ); ?> <?php echo esc_attr( $this->get_field_id( 'published_within' ) ); ?> <?php echo esc_attr( $this->get_field_id( 'published_within_unit' ) ); ?>" />
+				class="tiny-text" aria-labelledby="<?php echo esc_attr( $this->get_field_id( 'published_within_label' ) ); ?> <?php echo esc_attr( $this->get_field_id( 'published_within' ) ); ?> <?php echo esc_attr( $this->get_field_id( 'published_within_unit' ) ); ?>" />
 			<span id="<?php echo esc_attr( $this->get_field_id( 'published_within_unit' ) ); ?>"> <?php esc_html_e( 'days (0 for no limit).', 'wp-parsely' ); ?></span>
 		</p>
 		<p>
@@ -301,6 +301,13 @@ class Parsely_Recommended_Widget extends WP_Widget {
 		return $instance;
 	}
 
+	/**
+	 * Return the list of boost parameters, values and labels.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @return array Boost parameters values and labels.
+	 */
 	private function get_boost_params() {
 		return array(
 			'no-boost'              => __( 'No boost', 'wp-parsely' ),
@@ -328,6 +335,13 @@ class Parsely_Recommended_Widget extends WP_Widget {
 		);
 	}
 
+	/**
+	 * Check if both the API key and API secret settings are populated with non-empty values.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @return bool True if apikey and api_secret settings are not empty strings. False otherwise.
+	 */
 	private function api_key_and_secret_are_populated() {
 		$options = get_option( 'parsely' );
 
@@ -337,12 +351,12 @@ class Parsely_Recommended_Widget extends WP_Widget {
 		}
 
 		// Parse.ly Site ID settings field is not populated.
-		if ( ! array_key_exists( 'apikey', $options ) || $options['apikey'] === '' ) {
+		if ( ! array_key_exists( 'apikey', $options ) || '' === $options['apikey'] ) {
 			return false;
 		}
 
 		// Parse.ly API Secret settings field is not populated.
-		if ( ! array_key_exists( 'api_secret', $options ) || $options['api_secret'] === '' ) {
+		if ( ! array_key_exists( 'api_secret', $options ) || '' === $options['api_secret'] ) {
 			return false;
 		}
 

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -20,10 +20,10 @@ class Parsely {
 	 *
 	 * @codeCoverageIgnoreStart
 	 */
-	const VERSION         = PARSELY_VERSION;
-	const MENU_SLUG       = 'parsely';             // Defines the page param passed to options-general.php.
-	const OPTIONS_KEY     = 'parsely';             // Defines the key used to store options in the WP database.
-	const CAPABILITY      = 'manage_options';      // The capability required for the user to administer settings.
+	const VERSION     = PARSELY_VERSION;
+	const MENU_SLUG   = 'parsely';             // Defines the page param passed to options-general.php.
+	const OPTIONS_KEY = 'parsely';             // Defines the key used to store options in the WP database.
+	const CAPABILITY  = 'manage_options';      // The capability required for the user to administer settings.
 
 	/**
 	 * Declare some class propeties
@@ -116,7 +116,8 @@ class Parsely {
 			array( $this, 'add_plugin_meta_links' )
 		);
 
-		add_filter( 'cron_schedules', [ $this, 'wpparsely_add_cron_interval' ] );
+		// phpcs:ignore WordPress.WP.CronInterval.CronSchedulesInterval
+		add_filter( 'cron_schedules', array( $this, 'wpparsely_add_cron_interval' ) );
 		add_filter( 'post_row_actions', array( $this, 'row_actions_add_parsely_link' ), 10, 2 );
 		add_filter( 'page_row_actions', array( $this, 'row_actions_add_parsely_link' ), 10, 2 );
 		add_action( 'parsely_bulk_metas_update', array( $this, 'bulk_update_posts' ) );
@@ -128,7 +129,7 @@ class Parsely {
 		add_action( 'save_post', array( $this, 'update_metadata_endpoint' ) );
 		add_action( 'instant_articles_compat_registry_analytics', array( $this, 'insert_parsely_tracking_fbia' ) );
 		add_action( 'template_redirect', array( $this, 'parsely_add_amp_actions' ) );
-		add_action( 'wp_enqueue_scripts', [ $this, 'wp_parsely_style_init' ] );
+		add_action( 'wp_enqueue_scripts', array( $this, 'wp_parsely_style_init' ) );
 	}
 
 	/**
@@ -172,8 +173,8 @@ class Parsely {
 
 		$aria_label = sprintf(
 				/* translators: Post title */
-				__( 'Go to Parse.ly stats for "%s"', 'wp-parsely' ),
-				$post->post_title
+			__( 'Go to Parse.ly stats for "%s"', 'wp-parsely' ),
+			$post->post_title
 		);
 
 		$actions['find_in_parsely'] = sprintf(
@@ -203,7 +204,7 @@ class Parsely {
 	 * Initialize parsely WordPress style
 	 */
 	public function wp_parsely_style_init() {
-		wp_register_style( 'wp-parsely-style', PARSELY_PLUGIN_URL . 'wp-parsely.css', array(), Parsely::VERSION );
+		wp_register_style( 'wp-parsely-style', PARSELY_PLUGIN_URL . 'wp-parsely.css', array(), self::VERSION );
 	}
 
 	/**
@@ -224,7 +225,7 @@ class Parsely {
 		wp_enqueue_script(
 			'wp-parsely-admin',
 			PARSELY_PLUGIN_URL . 'build/admin-page.js',
-			$admin_script_asset[ 'dependencies' ],
+			$admin_script_asset['dependencies'],
 			self::get_asset_cache_buster(),
 			true
 		);
@@ -238,8 +239,8 @@ class Parsely {
 	 */
 	public function add_settings_sub_menu() {
 		add_options_page(
-				__( 'Parse.ly Settings', 'wp-parsely' ),
-				__( 'Parse.ly', 'wp-parsely' ),
+			__( 'Parse.ly Settings', 'wp-parsely' ),
+			__( 'Parse.ly', 'wp-parsely' ),
 			self::CAPABILITY,
 			self::MENU_SLUG,
 			array( $this, 'display_settings' )
@@ -638,7 +639,6 @@ class Parsely {
 		// these can't be null, if somebody accidentally deselected them just reset to default.
 		if ( ! isset( $input['track_post_types'] ) ) {
 			$input['track_post_types'] = array( 'post' );
-
 		}
 		if ( ! isset( $input['track_page_types'] ) ) {
 			$input['track_page_types'] = array( 'page' );
@@ -798,8 +798,8 @@ class Parsely {
 
 		$message = sprintf(
 				/* translators: %s: Plugin settings page URL */
-				__( '<strong>The Parse.ly plugin is not active.</strong> You need to <a href="%s">provide your Parse.ly Dash Site ID</a> before things get cooking.', 'wp-parsely' ),
-				 esc_url( $this->get_settings_url() )
+			__( '<strong>The Parse.ly plugin is not active.</strong> You need to <a href="%s">provide your Parse.ly Dash Site ID</a> before things get cooking.', 'wp-parsely' ),
+			esc_url( $this->get_settings_url() )
 		);
 		?>
 		<div id="message" class="error"><p><?php echo wp_kses_post( $message ); ?></p></div>
@@ -860,7 +860,7 @@ class Parsely {
 			return;
 		}
 
-		echo "\n" . '<!-- BEGIN Parse.ly ' . esc_html( Parsely::VERSION ) . ' -->' . "\n";
+		echo "\n" . '<!-- BEGIN Parse.ly ' . esc_html( self::VERSION ) . ' -->' . "\n";
 
 		// Insert JSON-LD or repeated metas.
 		if ( 'json_ld' === $parsely_options['meta_type'] ) {
@@ -894,7 +894,7 @@ class Parsely {
 	 */
 	public static function post_has_trackable_status( $post ) {
 		static $cache = array();
-		$post_id = is_int( $post ) ? $post : $post->ID;
+		$post_id      = is_int( $post ) ? $post : $post->ID;
 		if ( isset( $cache[ $post_id ] ) ) {
 			return $cache[ $post_id ];
 		}
@@ -909,7 +909,7 @@ class Parsely {
 		 * @param string[]    $trackable_statuses The list of post statuses that are allowed to be tracked.
 		 * @param int|WP_Post $post               Which post object or ID is being checked.
 		 */
-		$statuses = apply_filters( 'wp_parsely_trackable_statuses', array( 'publish' ), $post );
+		$statuses          = apply_filters( 'wp_parsely_trackable_statuses', array( 'publish' ), $post );
 		$cache[ $post_id ] = in_array( get_post_status( $post ), $statuses, true );
 		return $cache[ $post_id ];
 	}
@@ -956,7 +956,7 @@ class Parsely {
 			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_bloginfo( 'name', 'raw' ) );
 			$parsely_page['url']      = $current_url;
 		} elseif ( is_home() ) {
-			$parsely_page['headline'] = get_the_title( get_option('page_for_posts', true) );
+			$parsely_page['headline'] = get_the_title( get_option( 'page_for_posts', true ) );
 			$parsely_page['url']      = $current_url;
 		} elseif ( is_author() ) {
 			// TODO: why can't we have something like a WP_User object for all the other cases? Much nicer to deal with than functions.
@@ -1042,17 +1042,19 @@ class Parsely {
 			 * @param integer $id           Post ID.
 			 * @param string  $post_type    Post type in WordPress.
 			 */
-			$type          = (string) apply_filters( 'wp_parsely_post_type', 'NewsArticle', $post->ID, $post->post_type );
+			$type            = (string) apply_filters( 'wp_parsely_post_type', 'NewsArticle', $post->ID, $post->post_type );
 			$supported_types = array_merge( $this->supported_jsonld_post_types, $this->supported_jsonld_non_post_types );
 
 			// Validate type before passing it further as an invalid type will not be recognized by Parse.ly.
 			if ( ! in_array( $type, $supported_types ) ) {
 				$error = sprintf(
+					/* translators: 1: JSON @type like NewsArticle, 2: URL */
 					__( '@type %1$s is not supported by Parse.ly. Please use a type mentioned in %2$s', 'wp-parsely' ),
 					$type,
 					'https://www.parse.ly/help/integration/jsonld#distinguishing-between-posts-and-pages'
 				);
-				trigger_error( $error, E_USER_WARNING );
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+				trigger_error( esc_html( $error ), E_USER_WARNING );
 				$type = 'NewsArticle';
 			}
 
@@ -1090,7 +1092,7 @@ class Parsely {
 			$parsely_page['publisher'] = array(
 				'@type' => 'Organization',
 				'name'  => get_bloginfo( 'name' ),
-				'logo'     => $parsely_options['logo'],
+				'logo'  => $parsely_options['logo'],
 			);
 			$parsely_page['keywords']  = $tags;
 		} elseif ( in_array( get_post_type(), $parsely_options['track_page_types'], true ) && self::post_has_trackable_status( $post ) ) {
@@ -1143,8 +1145,8 @@ class Parsely {
 			return '';
 		}
 
-		$post              = get_post( $post_id );
-		$metadata          = $this->construct_parsely_metadata( $parsely_options, $post );
+		$post     = get_post( $post_id );
+		$metadata = $this->construct_parsely_metadata( $parsely_options, $post );
 
 		$endpoint_metadata = array(
 			'canonical_url' => $metadata['url'],
@@ -1181,7 +1183,6 @@ class Parsely {
 		);
 		$current_timestamp       = time();
 		$meta_update             = update_post_meta( $post_id, 'parsely_metadata_last_updated', $current_timestamp );
-
 	}
 
 
@@ -1203,7 +1204,8 @@ class Parsely {
 		);
 		$ids                  = wp_cache_get( 'parsely_post_ids_need_meta_updating' );
 		if ( false === $ids ) {
-			$ids     = array();
+			$ids = array();
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 			$results = $wpdb->get_results(
 				$wpdb->prepare( "SELECT DISTINCT(id) FROM {$wpdb->posts} WHERE post_type IN (\" . %s . \") AND id NOT IN (SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = 'parsely_metadata_last_updated');", $allowed_types_string ),
 				ARRAY_N
@@ -1224,6 +1226,16 @@ class Parsely {
 		}
 	}
 
+	/**
+	 * Get the cache buster value for script and styles.
+	 *
+	 * If WP_DEBUG is defined and truthy and we're not running tests, then use a random number.
+	 * Otherwise, use the plugin version.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @return int|string Random number or plugin version string.
+	 */
 	public static function get_asset_cache_buster() {
 		static $cache_buster;
 		if ( isset( $cache_buster ) ) {
@@ -1242,12 +1254,19 @@ class Parsely {
 		return apply_filters( 'wp_parsely_cache_buster', $cache_buster );
 	}
 
+	/**
+	 * Register JavaScripts, if there's an API key value saved.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @return void
+	 */
 	public function register_js() {
 		$parsely_options = $this->get_options();
 
 		// If we don't have an API key, there's no need to proceed.
 		if ( empty( $parsely_options['apikey'] ) ) {
-			return '';
+			return;
 		}
 
 		wp_register_script(
@@ -1258,18 +1277,18 @@ class Parsely {
 			true
 		);
 
-		$api_script_asset = require PARSELY_PLUGIN_DIR . 'build/init-api.asset.php' ;
+		$api_script_asset = require PARSELY_PLUGIN_DIR . 'build/init-api.asset.php';
 		wp_register_script(
 			'wp-parsely-api',
 			PARSELY_PLUGIN_URL . 'build/init-api.js',
-			$api_script_asset[ 'dependencies' ],
+			$api_script_asset['dependencies'],
 			self::get_asset_cache_buster(),
 			true
 		);
 
 		wp_localize_script(
 			'wp-parsely-api',
-			'wpParsely', // This globally-scoped object holds variables used to interact with the API
+			'wpParsely', // This globally-scoped object holds variables used to interact with the API.
 			array(
 				'apikey' => $parsely_options['apikey'],
 			)
@@ -1277,7 +1296,9 @@ class Parsely {
 	}
 
 	/**
-	 * Enqueues the JavaScript code required to send off beacon requests
+	 * Enqueues the JavaScript code required to send off beacon requests.
+	 *
+	 * @since 2.5.0 Rename from insert_parsely_javascript
 	 */
 	public function load_js_tracker() {
 		$parsely_options = $this->get_options();
@@ -1337,6 +1358,11 @@ class Parsely {
 		wp_enqueue_script( 'wp-parsely-tracker' );
 	}
 
+	/**
+	 * Load JavaScript for Parse.ly API.
+	 *
+	 * @since 2.5.0
+	 */
 	public function load_js_api() {
 		$parsely_options = $this->get_options();
 
@@ -1352,20 +1378,33 @@ class Parsely {
 		wp_enqueue_script( 'wp-parsely-api' );
 	}
 
+	/**
+	 * Filter the script tag for certain scripts to add needed attributes.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @param string $tag    The `script` tag for the enqueued script.
+	 * @param string $handle The script's registered handle.
+	 * @param string $src    The script's source URL.
+	 * @return string Amended `script` tag.
+	 */
 	public function script_loader_tag( $tag, $handle, $src ) {
 		$parsely_options = $this->get_options();
-		if ( in_array( $handle, array(
-			'wp-parsely',
-			'wp-parsely-api',
-			'wp-parsely-tracker',
-			'wp-parsely-recommended-widget',
-		) ) ) {
-			// Have ClouldFlare Rocket Loader ignore these scripts:
-			// https://support.cloudflare.com/hc/en-us/articles/200169436-How-can-I-have-Rocket-Loader-ignore-specific-JavaScripts-
+		if ( in_array(
+			$handle,
+			array(
+				'wp-parsely',
+				'wp-parsely-api',
+				'wp-parsely-tracker',
+				'wp-parsely-recommended-widget',
+			)
+		) ) {
+			// Have CloudFlare Rocket Loader ignore these scripts:
+			// https://support.cloudflare.com/hc/en-us/articles/200169436-How-can-I-have-Rocket-Loader-ignore-specific-JavaScripts-.
 			$tag = preg_replace( '/^<script /', '<script data-cfasync="false" ', $tag );
 		}
 
-		if ( $handle === 'wp-parsely-tracker' ) {
+		if ( 'wp-parsely-tracker' === $handle ) {
 			$tag = preg_replace( '/ id=(\"|\')wp-parsely-tracker-js\1/', ' id="parsely-cfg"', $tag );
 			$tag = preg_replace(
 				'/ src=/',
@@ -1447,7 +1486,7 @@ class Parsely {
 		$id      = esc_attr( $name );
 		$name    = self::OPTIONS_KEY . "[$id]";
 
-		$has_help_text = isset( $args['help_text'] ) ? ' data-has-help-text="true"' : '';
+		$has_help_text    = isset( $args['help_text'] ) ? ' data-has-help-text="true"' : '';
 		$requires_recrawl = isset( $args['requires_recrawl'] ) && true === $args['requires_recrawl'] ? ' data-requires-recrawl="true"' : '';
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static text attribute key-value. ?>
 		<fieldset class="parsely-form-controls" <?php echo $has_help_text . $requires_recrawl; ?>>
@@ -1463,7 +1502,9 @@ class Parsely {
 			</p>
 		<?php
 		if ( isset( $args['help_text'] ) ) {
-			?><div class="help-text"><p class="description .help-text"><?php echo esc_html( $args['help_text'] ); ?></p></div><?php
+			?>
+			<div class="help-text"><p class="description .help-text"><?php echo esc_html( $args['help_text'] ); ?></p></div>
+			<?php
 		}
 		?>
 		</fieldset>
@@ -1497,7 +1538,6 @@ class Parsely {
 			echo '<div class="help-text"><p class="description">' . esc_html( $args['help_text'] ) . '</p></div>';
 		}
 		echo '</div>';
-
 	}
 
 	/**
@@ -1622,15 +1662,16 @@ class Parsely {
 	 * Safely returns options for the plugin by assigning defaults contained in optionDefaults.  As soon as actual
 	 * options are saved, they override the defaults.  This prevents us from having to do a lot of isset() checking
 	 * on variables.
+	 *
+	 * @return array
 	 */
 	private function get_options() {
 		$options = get_option( self::OPTIONS_KEY );
 		if ( false === $options ) {
-			$options = $this->option_defaults;
-		} else {
-			$options = array_merge( $this->option_defaults, $options );
+			return $this->option_defaults;
 		}
-		return $options;
+
+		return array_merge( $this->option_defaults, $options );
 	}
 
 	/**
@@ -2068,7 +2109,6 @@ class Parsely {
 	 * Why is this here?
 	 */
 	public function return_personalized_json() {
-
 	}
 
 	/**
@@ -2081,7 +2121,7 @@ class Parsely {
 	 *
 	 * @see https://www.parse.ly/help/integration/metatags#field-description
 	 *
-	 * @param $type string JSON-LD type.
+	 * @param string $type JSON-LD type.
 	 * @return string "post" or "index".
 	 */
 	public function convert_jsonld_to_parsely_type( $type ) {

--- a/src/parsely-settings.php
+++ b/src/parsely-settings.php
@@ -10,17 +10,16 @@
  */
 
 /* translators: %s: Plugin version */
-$version_string = sprintf( __( 'Version %s', 'wp-parsely' ), $this::VERSION );
+$parsely_version_string = sprintf( __( 'Version %s', 'wp-parsely' ), $this::VERSION );
 ?>
 
 <div class="wrap">
-	<h1 class="wp-heading-inline"><?php echo esc_html( get_admin_page_title() ); ?></h1> <span id="wp-parsely_version"><?php echo esc_html( $version_string ); ?></span>
+	<h1 class="wp-heading-inline"><?php echo esc_html( get_admin_page_title() ); ?></h1> <span id="wp-parsely_version"><?php echo esc_html( $parsely_version_string ); ?></span>
 	<form name="parsely" method="post" action="options.php">
 		<?php settings_fields( $this::OPTIONS_KEY ); ?>
 		<?php do_settings_sections( $this::OPTIONS_KEY ); ?>
 		<p class="submit">
-			<input name="submit" type="submit" class="button-primary"
-				value="<?php esc_attr_e( 'Save Changes', 'wp-parsely' ); ?>"/>
+			<input name="submit" type="submit" class="button-primary" value="<?php esc_attr_e( 'Save Changes', 'wp-parsely' ); ?>"/>
 		</p>
 	</form>
 </div>

--- a/tests/Integrations/FbiaTest.php
+++ b/tests/Integrations/FbiaTest.php
@@ -23,8 +23,8 @@ final class FbiaTest extends TestCase {
 	 * @group fbia
 	 */
 	public function test_fbia_integration() {
-		$parsely  = new Parsely();
-		$options  = get_option( $parsely::OPTIONS_KEY );
+		$parsely           = new Parsely();
+		$options           = get_option( $parsely::OPTIONS_KEY );
 		$options['apikey'] = 'my-api-key.com';
 		update_option( 'parsely', $options );
 		$registry = array();

--- a/tests/StructuredData/AuthorArchiveTest.php
+++ b/tests/StructuredData/AuthorArchiveTest.php
@@ -35,7 +35,7 @@ final class AuthorArchiveTest extends NonPostTestCase {
 	 */
 	public function test_author_archive() {
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
-		// See https://github.com/Parsely/wp-parsely/issues/151
+		// See https://github.com/Parsely/wp-parsely/issues/151.
 		$this->set_permalink_structure( '/%postname%/' );
 
 		// Setup Parsley object.
@@ -43,8 +43,8 @@ final class AuthorArchiveTest extends NonPostTestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a single user, and a Post assigned to them.
-		$user = self::factory()->user->create( [ 'user_login' => 'parsely' ] );
-		self::factory()->post->create( [ 'post_author' => $user ] );
+		$user = self::factory()->user->create( array( 'user_login' => 'parsely' ) );
+		self::factory()->post->create( array( 'post_author' => $user ) );
 
 		// Make a request to that page to set the global $wp_query object.
 		$author_posts_url = get_author_posts_url( $user );

--- a/tests/StructuredData/BlogArchiveTest.php
+++ b/tests/StructuredData/BlogArchiveTest.php
@@ -39,26 +39,32 @@ final class BlogArchiveTest extends NonPostTestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a page for the blog posts.
-		$page_id = self::factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Page for Posts', 'post_name' => 'page-for-posts' ] );
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Page for Posts',
+				'post_name'  => 'page-for-posts',
+			)
+		);
 
-		// Create 2 posts so that posts page has pagination
+		// Create 2 posts so that posts page has pagination.
 		self::factory()->post->create();
 		self::factory()->post->create();
-		$page    = get_post( $page_id );
+		$page = get_post( $page_id );
 
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
-		// See https://github.com/Parsely/wp-parsely/issues/151
+		// See https://github.com/Parsely/wp-parsely/issues/151.
 		global $wp_rewrite;
-		$wp_rewrite->set_permalink_structure('/%postname%/');
+		$wp_rewrite->set_permalink_structure( '/%postname%/' );
 
-		// Set a static page to the homepage, set the newly created page to show the posts, add pagination to posts page
+		// Set a static page to the homepage, set the newly created page to show the posts, add pagination to posts page.
 		update_option( 'show_on_front', 'page' );
-		update_option('page_on_front', 1 );
+		update_option( 'page_on_front', 1 );
 		update_option( 'page_for_posts', $page_id );
 		update_option( 'posts_per_page', 1 );
 
 		// Make a request to the root of the site to set the global $wp_query object.
-		$this->go_to( get_permalink( $page_id ) . 'page/2');
+		$this->go_to( get_permalink( $page_id ) . 'page/2' );
 
 		// Create the structured data for that post.
 		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );

--- a/tests/StructuredData/HomePageTest.php
+++ b/tests/StructuredData/HomePageTest.php
@@ -14,6 +14,9 @@ namespace Parsely\Tests\StructuredData;
  * @covers \Parsely::construct_parsely_metadata
  */
 final class HomePageTest extends NonPostTestCase {
+	/**
+	 * Runs the routine before each test is executed.
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -47,7 +50,12 @@ final class HomePageTest extends NonPostTestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a single page.
-		$page_id = self::factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Page for Posts' ] );
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Page for Posts',
+			)
+		);
 		$page    = get_post( $page_id );
 
 		// Make a request to the root of the site to set the global $wp_query object.
@@ -94,15 +102,15 @@ final class HomePageTest extends NonPostTestCase {
 		$page = get_post( $page_id );
 
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
-		// See https://github.com/Parsely/wp-parsely/issues/151
+		// See https://github.com/Parsely/wp-parsely/issues/151.
 		global $wp_rewrite;
-		$wp_rewrite->set_permalink_structure('/%postname%/');
+		$wp_rewrite->set_permalink_structure( '/%postname%/' );
 
 		// Set the homepage to show 1 post per page.
 		update_option( 'posts_per_page', 1 );
 
 		// Go to Page 2 of posts.
-		$this->go_to( home_url('/page/2' ) );
+		$this->go_to( home_url( '/page/2' ) );
 
 		// Create the structured data for that post.
 		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
@@ -113,7 +121,7 @@ final class HomePageTest extends NonPostTestCase {
 		// The headline should be the name of the site, not the post_title of the latest post.
 		self::assertEquals( 'Test Blog', $structured_data['headline'] );
 		// The URL should be the current page, not the home url.
-		self::assertEquals( home_url('/page/2'), $structured_data['url'] );
+		self::assertEquals( home_url( '/page/2' ), $structured_data['url'] );
 	}
 
 	/**
@@ -141,7 +149,12 @@ final class HomePageTest extends NonPostTestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a single page.
-		$page_id = self::factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Home' ] );
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Home',
+			)
+		);
 		$page    = get_post( $page_id );
 
 		// Set that page as the homepage Page.
@@ -189,7 +202,12 @@ final class HomePageTest extends NonPostTestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a single page.
-		$page_id = self::factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Home' ] );
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Home',
+			)
+		);
 		$page    = get_post( $page_id );
 
 		// Set that page as the homepage Page.

--- a/tests/StructuredData/NonPostTestCase.php
+++ b/tests/StructuredData/NonPostTestCase.php
@@ -14,6 +14,8 @@ use Parsely\Tests\TestCase;
  */
 abstract class NonPostTestCase extends TestCase {
 	/**
+	 * Utility method to check metadata properties correctly set.
+	 *
 	 * @param array $structured_data Array of metadata to check.
 	 */
 	public function assert_data_has_required_properties( $structured_data ) {

--- a/tests/StructuredData/SinglePageTest.php
+++ b/tests/StructuredData/SinglePageTest.php
@@ -40,13 +40,19 @@ final class SinglePageTest extends NonPostTestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a single page.
-		$page_id = self::factory()->post->create( [ 'post_type' => 'page', 'post_title' => 'Single Page', 'post_name' => 'foo' ] );
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Single Page',
+				'post_name'  => 'foo',
+			)
+		);
 		$page    = get_post( $page_id );
 
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
-		// See https://github.com/Parsely/wp-parsely/issues/151
+		// See https://github.com/Parsely/wp-parsely/issues/151.
 		global $wp_rewrite;
-		$wp_rewrite->set_permalink_structure('/%postname%/');
+		$wp_rewrite->set_permalink_structure( '/%postname%/' );
 
 		// Make a request to that page to set the global $wp_query object.
 		$this->go_to( get_permalink( $page_id ) );
@@ -63,6 +69,6 @@ final class SinglePageTest extends NonPostTestCase {
 		self::assertQueryTrue( 'is_page', 'is_singular' );
 
 		// Reset permalinks to Plain.
-		$wp_rewrite->set_permalink_structure('');
+		$wp_rewrite->set_permalink_structure( '' );
 	}
 }

--- a/tests/StructuredData/SinglePostTest.php
+++ b/tests/StructuredData/SinglePostTest.php
@@ -424,6 +424,11 @@ final class SinglePostTest extends TestCase {
 		self::assertSame( 'https', $url['scheme'] );
 	}
 
+	/**
+	 * Utility method to check metadata properties correctly set.
+	 *
+	 * @param array $structured_data Array of metadata to check.
+	 */
 	public function assert_data_has_required_properties( $structured_data ) {
 		$required_properties = $this->get_required_properties();
 
@@ -435,6 +440,11 @@ final class SinglePostTest extends TestCase {
 		);
 	}
 
+	/**
+	 * These are the required properties for posts.
+	 *
+	 * @return string[]
+	 */
 	private function get_required_properties() {
 		return array(
 			'@context',

--- a/tests/StructuredData/TermArchiveTest.php
+++ b/tests/StructuredData/TermArchiveTest.php
@@ -35,7 +35,7 @@ final class TermArchiveTest extends NonPostTestCase {
 	 */
 	public function test_term_archive() {
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
-		// See https://github.com/Parsely/wp-parsely/issues/151
+		// See https://github.com/Parsely/wp-parsely/issues/151.
 		$this->set_permalink_structure( '/%postname%/' );
 
 		// Setup Parsley object.
@@ -43,8 +43,8 @@ final class TermArchiveTest extends NonPostTestCase {
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
 
 		// Insert a single category term, and a Post with that category.
-		$category = self::factory()->category->create( [ 'name' => 'Test Category' ] );
-		self::factory()->post->create( [ 'post_category' => [ $category ] ] );
+		$category = self::factory()->category->create( array( 'name' => 'Test Category' ) );
+		self::factory()->post->create( array( 'post_category' => array( $category ) ) );
 
 		// Make a request to that page to set the global $wp_query object.
 		$cat_link = get_category_link( $category );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,6 +29,11 @@ abstract class TestCase extends WPIntegrationTestCase {
 		'logo'                      => '',
 	);
 
+	/**
+	 * Utility function to update Parse.ly options with a merge of default values and custom values.
+	 *
+	 * @param array $custom_options Associative array of option keys and values that should be saved.
+	 */
 	public static function set_options( $custom_options = array() ) {
 		update_option( \Parsely::OPTIONS_KEY, array_merge( self::DEFAULT_OPTIONS, $custom_options ) );
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,10 +7,14 @@
 
 use Yoast\WPTestUtils\WPIntegration;
 
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 if ( ! $_tests_dir ) {
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv
 	putenv( 'WP_TESTS_DIR=' . $_tests_dir );
 }
 
@@ -20,9 +24,10 @@ if ( getenv( 'WP_PLUGIN_DIR' ) !== false ) {
 	define( 'WP_PLUGIN_DIR', dirname( dirname( __DIR__ ) ) );
 }
 
-$GLOBALS['wp_tests_options'] = [
-	'active_plugins' => [ 'wp-parsely/wp-parsely.php' ],
-];
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+$GLOBALS['wp_tests_options'] = array(
+	'active_plugins' => array( 'wp-parsely/wp-parsely.php' ),
+);
 
 require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
 

--- a/tests/class-all-test.php
+++ b/tests/class-all-test.php
@@ -34,10 +34,11 @@ class All_Test extends ParselyTestCase {
 
 		parent::setUp();
 
-		$wp_scripts = new \WP_Scripts();
-		self::$parsely   = new \Parsely();
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_scripts    = new \WP_Scripts();
+		self::$parsely = new \Parsely();
 
-		// Set the default options prior to each test
+		// Set the default options prior to each test.
 		ParselyTestCase::set_options();
 	}
 
@@ -57,14 +58,25 @@ class All_Test extends ParselyTestCase {
 		);
 	}
 
+	/**
+	 * Test class version.
+	 */
 	public function test_class_version() {
 		self::assertSame( PARSELY_VERSION, \Parsely::VERSION );
 	}
 
+	/**
+	 * Test cache buster string.
+	 *
+	 * During tests, this should only return the version constant.
+	 */
 	public function test_cache_buster() {
 		self::assertSame( PARSELY_VERSION, \Parsely::get_asset_cache_buster() );
 	}
 
+	/**
+	 * Test plugin URL constant is defined and populated.
+	 */
 	public function test_plugin_url_constant() {
 		self::assertTrue( defined( 'PARSELY_PLUGIN_URL' ) && is_string( PARSELY_PLUGIN_URL ) && strlen( PARSELY_PLUGIN_URL ) > 0 );
 	}
@@ -122,7 +134,7 @@ class All_Test extends ParselyTestCase {
 		$post       = $this->factory->post->create( $post_array );
 		$this->go_to( '/?p=' . $post );
 		self::$parsely->register_js();
-		echo self::$parsely->load_js_tracker();
+		self::$parsely->load_js_tracker();
 		$intermediate_output = ob_get_contents();
 		self::assertSame(
 			'',
@@ -157,7 +169,7 @@ class All_Test extends ParselyTestCase {
 		$post       = $this->factory->post->create( $post_array );
 		$this->go_to( '/?p=' . $post );
 		self::$parsely->register_js();
-		echo self::$parsely->load_js_api();
+		self::$parsely->load_js_api();
 		$intermediate_output = ob_get_contents();
 		self::assertSame(
 			'',
@@ -195,7 +207,7 @@ class All_Test extends ParselyTestCase {
 
 		self::set_options( array( 'api_secret' => 'hunter2' ) );
 
-		echo self::$parsely->load_js_api();
+		self::$parsely->load_js_api();
 		$intermediate_output = ob_get_contents();
 		self::assertSame(
 			'',
@@ -223,7 +235,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 		);
 
 		self::assertContains(
-			"<script data-cfasync=\"false\" type='text/javascript' src='" . esc_url( PARSELY_PLUGIN_URL ) . "build/init-api.js?ver=" . PARSELY_VERSION . "' id='wp-parsely-api-js'></script>",
+			"<script data-cfasync=\"false\" type='text/javascript' src='" . esc_url( PARSELY_PLUGIN_URL ) . 'build/init-api.js?ver=' . PARSELY_VERSION . "' id='wp-parsely-api-js'></script>",
 			$output,
 			'Failed to confirm script tag was printed correctly'
 		);
@@ -292,7 +304,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 		wp_set_current_user( $new_user );
 
 		ob_start();
-		echo self::$parsely->load_js_tracker();
+		self::$parsely->load_js_tracker();
 
 		$intermediate_output = ob_get_contents();
 		self::assertSame(
@@ -354,7 +366,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 		// These custom options will be used for both blog_ids.
 		$custom_options = array(
 			'track_authenticated_users' => false,
-			'apikey' => 'blog.parsely.com',
+			'apikey'                    => 'blog.parsely.com',
 		);
 		ParselyTestCase::set_options( $custom_options );
 
@@ -368,7 +380,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 
 		ob_start();
 		self::$parsely->register_js();
-		echo self::$parsely->load_js_tracker();
+		self::$parsely->load_js_tracker();
 
 		$intermediate_output = ob_get_contents();
 		self::assertSame(
@@ -399,7 +411,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 
 		ob_start();
 		self::$parsely->register_js();
-		echo self::$parsely->load_js_tracker();
+		self::$parsely->load_js_tracker();
 
 		$intermediate_output = ob_get_contents();
 		self::assertSame(
@@ -434,9 +446,9 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 
 		ob_start();
 		$post_array = $this->create_test_post_array();
-		$post = $this->factory->post->create( $post_array );
+		$post       = $this->factory->post->create( $post_array );
 		$this->go_to( '/?p=' . $post );
-		echo self::$parsely->load_js_tracker();
+		self::$parsely->load_js_tracker();
 		$intermediate_output = ob_get_contents();
 
 		self::assertSame(
@@ -468,9 +480,9 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 
 		ob_start();
 		$post_array = $this->create_test_post_array();
-		$post = $this->factory->post->create( $post_array );
+		$post       = $this->factory->post->create( $post_array );
 		$this->go_to( '/?p=' . $post );
-		echo self::$parsely->load_js_tracker();
+		self::$parsely->load_js_tracker();
 		$intermediate_output = ob_get_contents();
 
 		self::assertSame(
@@ -489,7 +501,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 		);
 	}
 
-	/*
+	/**
 	 * Test the wp_parsely_post_type filter
 	 *
 	 * @uses \Parsely::get_options()

--- a/tests/recommended-api-test.php
+++ b/tests/recommended-api-test.php
@@ -13,9 +13,14 @@ use Parsely_Recommended_Widget;
  * Recommended Widget tests.
  */
 final class Recommended_API_Test extends TestCase {
+	/**
+	 * Dataprovider for test_recommended_api_url().
+	 *
+	 * @return array[]
+	 */
 	public function data_recommended_api_url() {
 		return array(
-			'Basic (Expected data)' => array(
+			'Basic (Expected data)'                   => array(
 				'my-key',
 				7,
 				'score',
@@ -23,7 +28,7 @@ final class Recommended_API_Test extends TestCase {
 				5,
 				'https://api.parsely.com/v2/related?apikey=my-key&sort=score&limit=5&boost=views&pub_date_start=7d',
 			),
-			'published_within value of 0' => array(
+			'published_within value of 0'             => array(
 				'my-key',
 				0,
 				'score',
@@ -31,7 +36,7 @@ final class Recommended_API_Test extends TestCase {
 				5,
 				'https://api.parsely.com/v2/related?apikey=my-key&sort=score&limit=5&boost=views',
 			),
-			'Sort on publish date (no boost param)' => array(
+			'Sort on publish date (no boost param)'   => array(
 				'my-key',
 				0,
 				'pub_date',
@@ -57,6 +62,17 @@ final class Recommended_API_Test extends TestCase {
 	 * @covers \Parsely_Recommended_Widget::get_api_url
 	 * @uses \Parsely_Recommended_Widget::__construct
 	 * @group widgets
+	 *
+	 * @param string $api_key          Publisher Site ID (API key).
+	 * @param int    $published_within Publication filter start date; see https://www.parse.ly/help/api/time for
+	 *                                 formatting details. No restriction by default.
+	 * @param string $sort             What to sort the results by. There are currently 2 valid options: `score`, which
+	 *                                 will sort articles by overall relevance and `pub_date` which will sort results by
+	 *                                 their publication date. The default is `score`.
+	 * @param string $boost            Available for sort=score only. Sub-sort value to re-rank relevant posts that
+	 *                                 received high e.g. views; default is undefined.
+	 * @param int    $return_limit     Number of records to retrieve; defaults to "10".
+	 * @param string $url              Expected generated URL.
 	 */
 	public function test_recommended_api_url( $api_key, $published_within, $sort, $boost, $return_limit, $url ) {
 		$recommended_widget = new Parsely_Recommended_Widget();

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -16,6 +16,7 @@
 <meta name="parsely-pub-date" content="<?php echo esc_attr( $parsely_page['datePublished'] ); ?>" />
 <meta name="parsely-section" content="<?php echo esc_attr( $parsely_page['articleSection'] ); ?>" />
 <meta name="parsely-tags" content="<?php echo esc_attr( $parsely_page['keywords'] ); ?>" />
-<?php foreach ( (array) $parsely_page['author'] as $author ) { ?>
-<meta name="parsely-author" content="<?php echo esc_attr( $author['name'] ); ?>" />
-<?php }
+<?php foreach ( (array) $parsely_page['author'] as $parsely_author ) { ?>
+<meta name="parsely-author" content="<?php echo esc_attr( $parsely_author['name'] ); ?>" />
+	<?php
+}


### PR DESCRIPTION
## Description
Fix many of the code standards violations. The only outstanding ones are in the tests/ directory, and they will be addressed once #272 is merged.

## Motivation and Context
By fixing the violations, we can eventually turn on PHPCS checks as part of the CI. Following consistent code standards helps us to avoid bugs, avoid performance and security issues, and use the same style of code among different authors.

## How Has This Been Tested?
`composer cs` - and also `phpcs --report-summary` if you just want to see what files have violations in them.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Maintenance (improves the code in some way that isn't to fix a bug)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
