### PR TITLE
CI: Enable CS checks on CI

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -62,9 +62,8 @@ jobs:
           xml-schema-file: ./vendor/phpunit/phpunit/phpunit.xsd
 
       # Check the code-style consistency of the PHP files.
-#      - name: Check PHP code style
-#        continue-on-error: true
-#        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
+      - name: Check PHP code style
+        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
 
-#      - name: Show PHPCS results in PR
-#        run: cs2pr ./phpcs-report.xml
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -61,6 +61,12 @@ jobs:
           xml-file: ./phpunit.xml.dist
           xml-schema-file: ./vendor/phpunit/phpunit/phpunit.xsd
 
+      - name: Lint .phpcs.xml.dist
+        uses: ChristophWurst/xmllint-action@v1
+        with:
+          xml-file: ./.phpcs.xml.dist
+          xml-schema-file: ./vendor/squizlabs/php_codesniffer/phpcs.xsd
+
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
         run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml


### PR DESCRIPTION
## Description
Enable code standards checks (via PHPCS) on all pushes and PRs, and also lint the PHPCS config file, similar to how the PHPUnit config file was already being linted.

## Motivation and Context
Now that #337 addressed all of the remaining CS issues, we can now enable this check here to stop future violations from being merged into the codebase.

## How Has This Been Tested?
See https://github.com/Parsely/wp-parsely/runs/2856943521?check_suite_focus=true that shows the Action from the updated workflow for the push to the branch of this PR, passing the two new steps successfully.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
