### PR TITLE
Composer: Use tagged version of wp-test-utils

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -42,7 +42,7 @@ jobs:
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate
       - name: Validate Composer installation
-        run: composer validate --no-check-all
+        run: composer validate --no-check-all --strict
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7",
 		"squizlabs/php_codesniffer": "^3.5",
 		"wp-coding-standards/wpcs": "^2.3.0",
-		"yoast/wp-test-utils": "dev-develop#c0d9edd2"
+		"yoast/wp-test-utils": "0.2.2"
 	},
 	"autoload-dev": {
 		"psr-4": {


### PR DESCRIPTION
## Description
In #333, we temporarily used a commit ref for the `yoast/wp-test-utils` package version to address a particular issue. This issue has now been fixed and is available in a [tagged release](https://github.com/Yoast/wp-test-utils/releases/tag/0.2.2), so we can now use that.

We had also had to remove the `--strict` flag from the `composer validate` command in a CI workflow to allow the commit ref to be used; this has now been changed back as well.

## How Has This Been Tested?
See https://github.com/Parsely/wp-parsely/actions/runs/956424312 and https://github.com/Parsely/wp-parsely/actions/runs/956424311

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Maintenance
