### PR TITLE
Git: Add CS and commit message validation hooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,6 +26,7 @@
 /.prettierrc         export-ignore
 /.nvmrc              export-ignore
 /.travis.yml         export-ignore
+/captainhook.json    export-ignore
 /CHANGELOG.md        export-ignore
 /CODE_OF_CONDUCT.md  export-ignore
 /CONTRIBUTING.md     export-ignore

--- a/captainhook.json
+++ b/captainhook.json
@@ -1,0 +1,58 @@
+{
+    "commit-msg": {
+        "enabled": true,
+        "actions": [
+            {
+                "action": "\\CaptainHook\\App\\Hook\\Message\\Action\\Beams",
+                "options": {
+                    "subjectLength": 50,
+                    "bodyLineLength": 72
+                },
+                "conditions": []
+            }
+        ]
+    },
+    "pre-push": {
+        "enabled": false,
+        "actions": []
+    },
+    "pre-commit": {
+        "enabled": true,
+        "actions": [
+            {
+                "action": "\\CaptainHook\\App\\Hook\\PHP\\Action\\Linting",
+                "options": [],
+                "conditions": []
+            },
+            {
+                "action": "composer cs",
+                "options": [],
+                "conditions": []
+            }
+        ]
+    },
+    "prepare-commit-msg": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-commit": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-merge": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-checkout": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-rewrite": {
+        "enabled": false,
+        "actions": []
+    },
+    "post-change": {
+        "enabled": false,
+        "actions": []
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7",
 		"squizlabs/php_codesniffer": "^3.5",
 		"wp-coding-standards/wpcs": "^2.3.0",
-		"yoast/wp-test-utils": "dev-develop#c0d9edd2"
+		"yoast/wp-test-utils": "dev-develop#c0d9edd2",
+		"captainhook/captainhook": "^5.10"
 	},
 	"autoload-dev": {
 		"psr-4": {
@@ -48,6 +49,9 @@
 		],
 		"prepare-ci": [
 			"bash bin/install-wp-tests.sh wordpress_test root root localhost nightly"
+		],
+		"post-autoload-dump": [
+			"vendor/bin/captainhook install -f -s"
 		],
 		"test": [
 			"@php ./vendor/bin/phpunit --no-coverage"


### PR DESCRIPTION
## Description
Adds githooks, managed via a single JSON file.

Happy for this to be treated as an experiment, which can then be refined or removed if it unnecessarily hinders workflows more than it benefits the quality of the work.

## Motivation and Context
Doing work, committing, pushing, and then waiting on Actions to complete to then find out there is a CS error, can be frustrating. 

It's possible to run `composer cs` and other linting tasks locally, but these may often be forgotten.

To bring the check earlier, we can use local git hooks to do the linting.

The hooks can also be used to improve the quality of the commit message, to make it easier to review work later on.

Hooks are automatically installed/updated whenever a `dumpautoload` event happens, which happens at the end of `composer update` and `composer install` (and `composer dumpautoload`, naturally).

### Hooks

These are the checks that are done.

PHP (on `pre-commit` hook)
 - `php -l` is run, and must not error
 - `composer cs` is run, and must not report a violation

Commit message (on `commit-msg` hook)
 - Subject length is max 50 characters
 - Capitalize the subject line
 - Body line length is 72 <-- Not a strong objection if this gets substantially increased.
 - No period at end of subject
 - Must use imperative mood (i.e. "add", not "added")
 - Separate subject from body with a blank line
 
Tests are _not_ run, as the code uses integration tests, which need a live database to work; if in the future, tests are split out into unit tests, then these can be run pre-commit.

### Sourcetree
 
If using Sourctree, then Install Command-line Tools from the Sourcetree main menu, and then open Sourcetree from the terminal in the correct wp-parsely directory with `stree` - this ensures the `PATH` environment variables are set correctly so that the commands in the hooks work. [Reference](https://community.atlassian.com/t5/Bitbucket-questions/SourceTree-Hook-failing-because-paths-don-t-seem-to-be-set/qaq-p/274792).

To make it easier to know where the 50 character and 72 character limits are, I have the following in Sourcetree -> Settings -> Commit:

<img width="789" alt="Screenshot 2021-06-21 at 14 12 05" src="https://user-images.githubusercontent.com/88371/122767589-bb0e3880-d29a-11eb-9c6e-456e748825ce.png">

The `-x-x-x-x-|-x-x-x-x-|-x-x-x-x-|-x-x-x-x-|-x-x-x-x-|` string is 50 characters long, so I can write my subject on the line above it, check my subject doesn't go longer than it, and then remove that template string. It's a workflow I've used for a few years, and it works well. 

The 72 value column guide just adds a white line at the 72nd column but doesn't block extending past that.

If you use git from the command-line then no extra steps are needed, though you can create a git commit template that follows the same approach as I use in Sourcetree.

### Potential Downsides
- Running PHPCS on every commit might get annoying - it currently takes around 8.85 seconds, with 4.71 seconds coming from `class-parsely.php`; being a single large file, it can't benefit from the parallel processing that we do, which is another reason to break it up into smaller class files. Once files are smaller, PHPCS should be quicker.
- Writing good commit messages are hard, but that's what a good developer should do; it shouldn't just be down to the Pull Request, since a move from GitHub to another provider (or just looking at a local repo while offline), would lose all of the context if not in the commit messages themselves. The above constraints may be annoying to some, but other than body line length, the rest are pretty easy to follow.

## How Has This Been Tested?
Tested locally. To test yourself, checkout the branch, do a `composer dumpautoload`, and then try doing a commit on any branch with a constraint above (commit message subject length, or make some PHP invalid, etc.)

## Screenshots (if appropriate):

Commit blocked in terminal:
<img width="1089" alt="Screenshot 2021-06-21 at 14 18 41" src="https://user-images.githubusercontent.com/88371/122768544-9bc3db00-d29b-11eb-8521-6876d547c4c0.png">

Commit blocked in Sourcetree:
<img width="593" alt="Screenshot 2021-06-21 at 14 18 18" src="https://user-images.githubusercontent.com/88371/122768550-9d8d9e80-d29b-11eb-9e32-0c6c716b8aed.png">


## Types of changes
- [X] Maintenance (non-breaking change which fixes an issue)

