### PR TITLE
Parsely: Move hooks out of constructor

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -86,12 +86,11 @@ class Parsely {
 	);
 
 	/**
-	 * The constructor
+	 * Register action and filter hook callbacks.
 	 *
-	 * @category   Function
-	 * @package    Parsely
+	 * Also immediately upgrade options if needed.
 	 */
-	public function __construct() {
+	public function run() {
 		// Run upgrade options if they exist for the version currently defined.
 		$options = $this->get_options();
 		if ( empty( $options['plugin_version'] ) || self::VERSION !== $options['plugin_version'] ) {

--- a/tests/GetCurrentUrlTest.php
+++ b/tests/GetCurrentUrlTest.php
@@ -90,9 +90,8 @@ final class GetCurrentUrlTest extends TestCase {
 	 *
 	 * @dataProvider data_for_test_get_current_url
 	 * @covers \Parsely::get_current_url
-	 * @uses \Parsely::__construct()
-	 * @uses \Parsely::get_options()
-	 * @uses \Parsely::update_metadata_endpoint()
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::update_metadata_endpoint
 	 *
 	 * @param bool   $force_https Force HTTPS Canonical setting value.
 	 * @param string $home        Home URL.

--- a/tests/Integrations/AmpTest.php
+++ b/tests/Integrations/AmpTest.php
@@ -18,7 +18,6 @@ final class AmpTest extends TestCase {
 	 * Check the AMP integration when plugin is not active or request is not an AMP request.
 	 *
 	 * @covers \Parsely::parsely_add_amp_actions
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_options()
 	 * @uses \Parsely::is_amp_request()
 	 * @group amp
@@ -39,7 +38,6 @@ final class AmpTest extends TestCase {
 	 * Check the AMP integration when plugin is active and a request is an AMP request.
 	 *
 	 * @covers \Parsely::parsely_add_amp_actions
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_options()
 	 * @uses \Parsely::is_amp_request()
 	 * @group amp
@@ -76,7 +74,6 @@ final class AmpTest extends TestCase {
 	 *
 	 * @covers \Parsely::parsely_add_amp_actions
 	 * @covers \Parsely::parsely_add_amp_analytics
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_options()
 	 * @uses \Parsely::is_amp_request()
 	 * @group amp

--- a/tests/Integrations/FbiaTest.php
+++ b/tests/Integrations/FbiaTest.php
@@ -18,7 +18,6 @@ final class FbiaTest extends TestCase {
 	 * Check the Facebook Instant Articles integration.
 	 *
 	 * @covers \Parsely::insert_parsely_tracking_fbia
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_options()
 	 * @group fbia
 	 */

--- a/tests/OtherTest.php
+++ b/tests/OtherTest.php
@@ -65,7 +65,6 @@ final class OtherTest extends TestCase {
 	 * During tests, this should only return the version constant.
 	 *
 	 * @covers \Parsely::get_asset_cache_buster
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_options
 	 */
 	public function test_cache_buster() {
@@ -85,7 +84,6 @@ final class OtherTest extends TestCase {
 	 * Test JavaScript registrations.
 	 *
 	 * @covers \Parsely::register_js
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_asset_cache_buster
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::update_metadata_endpoint
@@ -130,7 +128,6 @@ final class OtherTest extends TestCase {
 	 * Test the tracker script enqueue.
 	 *
 	 * @covers \Parsely::load_js_tracker
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_asset_cache_buster
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::post_has_trackable_status
@@ -172,7 +169,6 @@ final class OtherTest extends TestCase {
 	 * Test the API init script enqueue.
 	 *
 	 * @covers \Parsely::load_js_api
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_asset_cache_buster
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::register_js
@@ -212,7 +208,6 @@ final class OtherTest extends TestCase {
 	 * Test the API init script enqueue.
 	 *
 	 * @covers \Parsely::load_js_api
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_asset_cache_buster
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::register_js
@@ -268,7 +263,6 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 *
 	 * @expectedDeprecated after_set_parsely_page
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term
@@ -317,7 +311,6 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * Make sure users can log in.
 	 *
 	 * @covers \Parsely::load_js_tracker
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::parsely_is_user_logged_in
 	 * @group insert-js
@@ -372,7 +365,6 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * Make sure users can log in to more than one site.
 	 *
 	 * @covers \Parsely::load_js_tracker
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_asset_cache_buster
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::parsely_is_user_logged_in
@@ -473,7 +465,6 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * When it returns false, the tracking script should not be enqueued.
 	 *
 	 * @covers \Parsely::load_js_tracker
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::post_has_trackable_status
 	 * @uses \Parsely::update_metadata_endpoint
@@ -513,7 +504,6 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * @expectedDeprecated parsely_filter_insert_javascript
 	 *
 	 * @covers \Parsely::load_js_tracker
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::post_has_trackable_status
 	 * @uses \Parsely::update_metadata_endpoint
@@ -548,7 +538,6 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * Test the wp_parsely_post_type filter
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names

--- a/tests/StructuredData/AuthorArchiveTest.php
+++ b/tests/StructuredData/AuthorArchiveTest.php
@@ -18,7 +18,6 @@ final class AuthorArchiveTest extends NonPostTestCase {
 	 * Check metadata for author archive.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term

--- a/tests/StructuredData/BlogArchiveTest.php
+++ b/tests/StructuredData/BlogArchiveTest.php
@@ -18,7 +18,6 @@ final class BlogArchiveTest extends NonPostTestCase {
 	 * Create a single page, set as the posts page (blog archive) but not the home page, go to Page 2, and test the structured data.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term

--- a/tests/StructuredData/HomePageTest.php
+++ b/tests/StructuredData/HomePageTest.php
@@ -29,7 +29,6 @@ final class HomePageTest extends NonPostTestCase {
 	 * Create a single page, set as homepage (blog archive), and test the structured data.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term
@@ -76,7 +75,6 @@ final class HomePageTest extends NonPostTestCase {
 	 * Create 2 posts, set posts per page to 1, navigate to page 2 and test the structured data.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term
@@ -128,7 +126,6 @@ final class HomePageTest extends NonPostTestCase {
 	 * Create a single page, set as homepage (page on front), and test the structured data.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term
@@ -181,7 +178,6 @@ final class HomePageTest extends NonPostTestCase {
 	 * Check for the case when the show_on_front setting is Page, but no Page has been selected.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term

--- a/tests/StructuredData/SinglePageTest.php
+++ b/tests/StructuredData/SinglePageTest.php
@@ -19,7 +19,6 @@ final class SinglePageTest extends NonPostTestCase {
 	 * Create a single page, and test the structured data.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term

--- a/tests/StructuredData/SinglePostTest.php
+++ b/tests/StructuredData/SinglePostTest.php
@@ -19,7 +19,6 @@ final class SinglePostTest extends TestCase {
 	 * Create a single post, and test the structured data.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term
@@ -59,7 +58,6 @@ final class SinglePostTest extends TestCase {
 	 * Check the category.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term
@@ -95,7 +93,6 @@ final class SinglePostTest extends TestCase {
 	 * Check that the tags assigned to a post are lowercase.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term
@@ -141,7 +138,6 @@ final class SinglePostTest extends TestCase {
 	 * Check the categories as tags.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term
@@ -189,7 +185,6 @@ final class SinglePostTest extends TestCase {
 	 * Test custom taxonomy terms, categories, and tags in the metadata.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term
@@ -249,7 +244,6 @@ final class SinglePostTest extends TestCase {
 	 * Are the top level categories what we expect?
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term
@@ -307,7 +301,6 @@ final class SinglePostTest extends TestCase {
 	 * Check out the custom taxonomy as section.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term
@@ -376,7 +369,6 @@ final class SinglePostTest extends TestCase {
 	 * Check the canonicals.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term

--- a/tests/StructuredData/TermArchiveTest.php
+++ b/tests/StructuredData/TermArchiveTest.php
@@ -18,7 +18,6 @@ final class TermArchiveTest extends NonPostTestCase {
 	 * Check metadata for term archive.
 	 *
 	 * @covers \Parsely::construct_parsely_metadata
-	 * @uses \Parsely::__construct
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
 	 * @uses \Parsely::get_bottom_level_term

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -46,6 +46,7 @@ if ( ! defined( 'PARSELY_PLUGIN_URL' ) ) {
 require PARSELY_PLUGIN_DIR . 'src/class-parsely.php';
 
 $GLOBALS['parsely'] = new Parsely();
+$GLOBALS['parsely']->run();
 
 require PARSELY_PLUGIN_DIR . 'src/class-parsely-recommended-widget.php';
 


### PR DESCRIPTION
## Description
Rename `Parsely::__construct()` to `Parsely::run()`, as the only contents of the constructor were integration code, and not class setup code.

## Motivation and Context
Class constructors should contain logic to help set the class up (i.e. populate properties) if needed, but that's it.

Moving the adding of action and filter hooks to a `run()` method, and calling that after class instantiation, means the class can now be instantiated in tests without having potential side-effects - for instance, the upgrade code can be moved to a new method and tested.

Fixes #280.

## How Has This Been Tested?
Tests and CS still pass, but this needs some manual check of behaviour as well (not yet done).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Maintenance (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
