### PR TITLE
Update the "Tested up to" README value to 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Stable tag: 2.6.0-alpha  
 Requires at least: 4.0  
-Tested up to: 5.6  
+Tested up to: 5.7  
 Requires PHP: 5.6  
 License: GPLv2 or later  
 Tags: analytics, parse.ly, parsely, parsley  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`5.6` -> `5.7`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To avoid the `This plugin has not been tested with your current version of WordPress.` warning on the plugin install screen:
![Screen Shot 2021-07-12 at 10 26 37 AM](https://user-images.githubusercontent.com/1587282/125304547-b10cb200-e2fb-11eb-82ba-bb42ad60f325.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

We've been manually testing on 5.7 since its been released and automated tests run against `latest`:
https://github.com/Parsely/wp-parsely/blob/d87733b09c76190e1edd7466f84e448a99118100/.github/workflows/integration-tests.yml#L22

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

docs
