### PR TITLE
Improve handling of "home" page edge cases & make get_clean_parsely_page_value public

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -945,11 +945,12 @@ class Parsely {
 	 * @return mixed|void
 	 */
 	public function construct_parsely_metadata( array $parsely_options, $post ) {
-		$parsely_page = array(
+		$parsely_page      = array(
 			'@context' => 'http://schema.org',
 			'@type'    => 'WebPage',
 		);
-		$current_url  = $this->get_current_url();
+		$current_url       = $this->get_current_url();
+		$queried_object_id = get_queried_object_id();
 
 		if ( is_front_page() && ! is_paged() ) {
 			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_bloginfo( 'name', 'raw' ) );
@@ -957,7 +958,12 @@ class Parsely {
 		} elseif ( is_front_page() && is_paged() ) {
 			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_bloginfo( 'name', 'raw' ) );
 			$parsely_page['url']      = $current_url;
-		} elseif ( is_home() ) {
+		} elseif (
+			is_home() && (
+				! ( 'page' === get_option( 'show_on_front' ) && ! get_option( 'page_on_front' ) ) ||
+				$queried_object_id && (int) get_option( 'page_for_posts' ) === $queried_object_id
+			)
+		) {
 			$parsely_page['headline'] = get_the_title( get_option( 'page_for_posts', true ) );
 			$parsely_page['url']      = $current_url;
 		} elseif ( is_author() ) {

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1902,10 +1902,12 @@ class Parsely {
 	/**
 	 * Sanitize content
 	 *
+	 * @since 2.6.0
+	 *
 	 * @param string $val The content you'd like sanitized.
 	 * @return string
 	 */
-	private function get_clean_parsely_page_value( $val ) {
+	public function get_clean_parsely_page_value( $val ) {
 		if ( is_string( $val ) ) {
 			$val = str_replace( "\n", '', $val );
 			$val = str_replace( "\r", '', $val );

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -951,7 +951,7 @@ class Parsely {
 		);
 		$current_url  = $this->get_current_url();
 
-		if ( is_front_page() && ! is_paged() || ( 'page' === get_option( 'show_on_front' ) && ! get_option( 'page_on_front' ) ) ) {
+		if ( is_front_page() && ! is_paged() ) {
 			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_bloginfo( 'name', 'raw' ) );
 			$parsely_page['url']      = home_url();
 		} elseif ( is_front_page() && is_paged() ) {
@@ -1100,6 +1100,9 @@ class Parsely {
 		} elseif ( in_array( get_post_type(), $parsely_options['track_page_types'], true ) && self::post_has_trackable_status( $post ) ) {
 			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_the_title( $post ) );
 			$parsely_page['url']      = $this->get_current_url( 'post' );
+		} elseif ( 'page' === get_option( 'show_on_front' ) && ! get_option( 'page_on_front' ) ) {
+			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_bloginfo( 'name', 'raw' ) );
+			$parsely_page['url']      = home_url();
 		}
 
 		/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* Move the `show_on_front` but no `page_on_front` case to a fallback.
* Qualify the is_home() case to only apply when the `show_on_front` but no `page_on_front` case applies
* Make `Parsely::get_clean_parsely_page_value` method public 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We want the plugin logic to apply as often as possible for cases like author pages and other archives. De-prioritizing the "mis-configured" case (of `show_on_front` but no `page_on_front`) allows this to occur and permits the meta data filtering functions to do less work.

If `get_clean_parsely_page_value` is private, it cannot be used in other plugins -- namely, within `wp_parsely_metadata` filter function overrides. Changing it to public lets users apply the same "clean" routine as the main code path.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Automated tests are passing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Bug fix (non-breaking change which fixes an issue)
