### PR TITLE
Load the api init script before the tracker so values are populated

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -123,8 +123,8 @@ class Parsely {
 		// inserting parsely code.
 		add_action( 'wp_head', array( $this, 'insert_parsely_page' ) );
 		add_action( 'init', array( $this, 'register_js' ) );
+		add_action( 'wp_footer', array( $this, 'load_js_api' ), 9 );
 		add_action( 'wp_footer', array( $this, 'load_js_tracker' ) );
-		add_action( 'wp_footer', array( $this, 'load_js_api' ) );
 		add_action( 'save_post', array( $this, 'update_metadata_endpoint' ) );
 		add_action( 'instant_articles_compat_registry_analytics', array( $this, 'insert_parsely_tracking_fbia' ) );
 		add_action( 'template_redirect', array( $this, 'parsely_add_amp_actions' ) );

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -123,8 +123,11 @@ class Parsely {
 		// inserting parsely code.
 		add_action( 'wp_head', array( $this, 'insert_parsely_page' ) );
 		add_action( 'init', array( $this, 'register_js' ) );
-		add_action( 'wp_footer', array( $this, 'load_js_api' ), 9 );
+
+		// load_js_api should be called prior to load_js_tracker so the relevant scripts are enqueued in order
+		add_action( 'wp_footer', array( $this, 'load_js_api' ) );
 		add_action( 'wp_footer', array( $this, 'load_js_tracker' ) );
+
 		add_action( 'save_post', array( $this, 'update_metadata_endpoint' ) );
 		add_action( 'instant_articles_compat_registry_analytics', array( $this, 'insert_parsely_tracking_fbia' ) );
 		add_action( 'template_redirect', array( $this, 'parsely_add_amp_actions' ) );

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -124,7 +124,7 @@ class Parsely {
 		add_action( 'wp_head', array( $this, 'insert_parsely_page' ) );
 		add_action( 'init', array( $this, 'register_js' ) );
 
-		// load_js_api should be called prior to load_js_tracker so the relevant scripts are enqueued in order
+		// load_js_api should be called prior to load_js_tracker so the relevant scripts are enqueued in order.
 		add_action( 'wp_footer', array( $this, 'load_js_api' ) );
 		add_action( 'wp_footer', array( $this, 'load_js_tracker' ) );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The function that enqueues the tracker script from the CDN is currently firing prior to the one that enqueues the API init script.

This change reverses that and makes explicit via the [`add_action`'s `$priority` param](https://developer.wordpress.org/reference/functions/add_action/#parameters) that it should run in that order.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `global.PARSELY.onload` function has to be populated prior to the tracker being loaded so it can actually be called and the `/profile` API call conditionally fired.

See: https://github.com/Parsely/wp-parsely/blob/12976fb9feba317caa3a51236a11fdfe385b133b/src/js/lib/init-api/index.js#L18-L30

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On a sandboxed version of blog.parse.ly

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Bug fix (non-breaking change which fixes an issue)
