### PR TITLE
Install "latest" WordPress tests vs. nightly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --checkstyle"
 		],
 		"prepare-ci": [
-			"bash bin/install-wp-tests.sh wordpress_test root root localhost nightly"
+			"bash bin/install-wp-tests.sh wordpress_test root root localhost latest"
 		],
 		"test": [
 			"@php ./vendor/bin/phpunit --no-coverage"


### PR DESCRIPTION
...to match the value we're setting for WP_VERSION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The `prepare-ci` composer script is currently installing test libs from the `nightly` version, but we're specifying the `latest` version of WordPress via the the `WP_VERSION` env var.

This change moves the former to `latest` so they're in sync.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change was prompted by failing tests due to some changes in how the test lib works.

See: https://core.trac.wordpress.org/ticket/46149

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI was previously failing, now it's passing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
dev-facing, test-only, bug fix