### PR TITLE
Specify browserslist uses 'defaults'

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/Parsely/wp-parsely/issues"
   },
   "homepage": "https://github.com/Parsely/wp-parsely#readme",
+  "browserslist": [
+    "defaults"
+  ],
   "devDependencies": {
     "@wordpress/eslint-plugin": "^9.1.1",
     "@wordpress/scripts": "^17.1.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Specify that the `browserslist` should use the `defaults` setting when building bundles. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I noticed that unrelated script files were being altered during build. This is suboptimal since it bundles build changes into unrelated PRs making it more difficult to pin down where issues arise (if they do).

### What Happened?

It looks like the `@wordpress/scripts` package has begun to fine tune the build targets to the [specific browser support level in the handbook](https://make.wordpress.org/core/handbook/best-practices/browser-support/):

```
Last 1 Android versions.
Last 1 ChromeAndroid versions.
Last 2 Chrome versions.
Last 2 Firefox versions.
Last 2 Safari versions.
Last 2 iOS versions.
Last 2 Edge versions.
Last 2 Opera versions.
Browsers with > 1% usage based on can I use browser usage table
```

This is manged in code in the [`@wordpress/browserslist-config` package here](https://github.com/WordPress/gutenberg/blob/b72adf8aaa24afd1b1777c641806ad738c523486/packages/browserslist-config/index.js)

Meanwhile, the [default set of targets in the `browserslist` package](https://github.com/browserslist/browserslist/tree/4.16.8#full-list) is larger and includes older user agents such that the resultant built files exclude newer functionality (e.g. variables are declared via the `var` keyword (instead of `const` or `let`):

```
> 0.5%
last 2 versions
Firefox ESR, not dead
```

This changed at some point after #354 landed since that PR did not result in any change to the built files. I confirmed that I was able to check out the hash prior to updating the `@wordpress/scripts` package (69bb168e9c2b7ce93437ad12d378e426c048c34a) and install deps / build our scripts without any changes to any versioned files.

### Alternatively

Perhaps we _do_ want to follow the lead of the WordPress tooling and adopt a more modern set of targets. If that's what we decide, we can close this PR and PR the build as it is.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Confirm the issue

* Check out `origin/develop`
* `npm i`
* `npm run build`
* `git status` / `git diff`
    * Displays that built files have changed

### Confirm the fix

* Check out this branch
* `npm i`
* `npm run build`
* `git status` / `git diff`
    * Displays that no built files have changed

## Screenshots (if appropriate):

## Types of changes

Dev tooling