### PR TITLE
Wrap post list links in an opt-in filter

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -117,8 +117,12 @@ class Parsely {
 
 		// phpcs:ignore WordPress.WP.CronInterval.CronSchedulesInterval
 		add_filter( 'cron_schedules', array( $this, 'wpparsely_add_cron_interval' ) );
-		add_filter( 'post_row_actions', array( $this, 'row_actions_add_parsely_link' ), 10, 2 );
-		add_filter( 'page_row_actions', array( $this, 'row_actions_add_parsely_link' ), 10, 2 );
+
+		if ( apply_filters( 'wp_parsely_enable_row_action_links', false ) ) {
+			add_filter( 'post_row_actions', array( $this, 'row_actions_add_parsely_link' ), 10, 2 );
+			add_filter( 'page_row_actions', array( $this, 'row_actions_add_parsely_link' ), 10, 2 );
+		}
+
 		add_action( 'parsely_bulk_metas_update', array( $this, 'bulk_update_posts' ) );
 		// inserting parsely code.
 		add_action( 'wp_head', array( $this, 'insert_parsely_page' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Gate the calls to filter `post_row_actions` & `page_row_actions` behind a "feature flag" filter that's opt-in by default.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This feature needs more testing + R&D. This change leaves the code merged to the `develop` branch, but uncalled unless a site has opted in in code to do so.

Having a feature that's not ready for prime time in the code base is good for iterative development, but makes cutting a plugin release a lot more difficult.  This change alleviates that issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Run this branch
* Browse to the Post list at `/wp-admin/edit.php`
* Mouse over a published post
    * There should be no links to "Parse.ly stats" in the "row actions"
* Repeat in the Page list (`/wp-admin/edit.php?post_type=page`) & custom post type listings
    * Mouse over a published page
    * There should be no links to "Parse.ly stats" in the "row actions"

### Test the opt-in

* Add the following to an mu-plugin or other plugin that's active: `add_filter( 'wp_parsely_enable_row_action_links', '__return_true' );`
* Repeat the post / page / cpt list interactions
    * There SHOULD be links to "Parse.ly stats" in the "row actions"

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

This is functionally a partial revert of #291. The code is still present, but the `Parsely::row_actions_add_parsely_link` function is not called unless a site intentionally enables the feature in code.