### PR TITLE
Fix repeated metas notices

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -894,7 +894,7 @@ class Parsely {
 			$parsely_metas = array_filter( $parsely_metas, array( $this, 'filter_empty_and_not_string_from_array' ) );
 
 			if ( isset( $parsely_page['author'] ) ) {
-				$parsely_page_authors = array_map( array( $this, 'map_extract_author_name' ), $parsely_page['author'] );
+				$parsely_page_authors = wp_list_pluck( $parsely_page['author'], 'name' );
 				$parsely_page_authors = array_filter( $parsely_page_authors, array( $this, 'filter_empty_and_not_string_from_array' ) );
 			}
 
@@ -909,16 +909,6 @@ class Parsely {
 		echo '<!-- END Parse.ly -->' . "\n\n";
 
 		return $parsely_page;
-	}
-
-	/**
-	 * Getter function to be used with `array_filter` to fetch the `name` property
-	 *
-	 * @param mixed $var Value to filter from the array.
-	 * @return mixed Value of the name property
-	 */
-	private static function map_extract_author_name( $var ) {
-		return $var['name'];
 	}
 
 	/**

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -909,7 +909,7 @@ class Parsely {
 	/**
 	 * Function to be used in `array_filter` to clean up repeated metas
 	 *
-	 * @param $var mixed Value to filter from the array
+	 * @param mixed $var Value to filter from the array.
 	 * @return bool Returns true if the variable is not empty, and it's a string
 	 */
 	private static function filter_empty_and_not_string_from_array( $var ) {

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -877,6 +877,16 @@ class Parsely {
 				$parsely_page['keywords'] = implode( ',', $parsely_page['keywords'] );
 			}
 
+			$metas = array(
+				"title" => isset( $parsely_page['headline'] ) ? $parsely_page['headline'] : null,
+				"link" => isset( $parsely_page['url'] ) ? $parsely_page['url'] : null,
+				"type" => $parsely_post_type,
+				"image-url" => isset( $parsely_page['thumbnailUrl'] ) ? $parsely_page['thumbnailUrl'] : null,
+				"pub-date" => isset( $parsely_page['datePublished'] ) ? $parsely_page['datePublished'] : null,
+				"section" => isset( $parsely_page['articleSection'] ) ? $parsely_page['articleSection'] : null,
+				"tags" => isset( $parsely_page['keywords'] ) ? $parsely_page['keywords'] : null,
+			);
+
 			include PARSELY_PLUGIN_DIR . 'views/repeated-metas.php';
 		}
 

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -877,14 +877,14 @@ class Parsely {
 				$parsely_page['keywords'] = implode( ',', $parsely_page['keywords'] );
 			}
 
-			$metas = array(
-				"title" => isset( $parsely_page['headline'] ) ? $parsely_page['headline'] : null,
-				"link" => isset( $parsely_page['url'] ) ? $parsely_page['url'] : null,
-				"type" => $parsely_post_type,
-				"image-url" => isset( $parsely_page['thumbnailUrl'] ) ? $parsely_page['thumbnailUrl'] : null,
-				"pub-date" => isset( $parsely_page['datePublished'] ) ? $parsely_page['datePublished'] : null,
-				"section" => isset( $parsely_page['articleSection'] ) ? $parsely_page['articleSection'] : null,
-				"tags" => isset( $parsely_page['keywords'] ) ? $parsely_page['keywords'] : null,
+			$parsely_metas = array(
+				'title'     => isset( $parsely_page['headline'] ) ? $parsely_page['headline'] : null,
+				'link'      => isset( $parsely_page['url'] ) ? $parsely_page['url'] : null,
+				'type'      => $parsely_post_type,
+				'image-url' => isset( $parsely_page['thumbnailUrl'] ) ? $parsely_page['thumbnailUrl'] : null,
+				'pub-date'  => isset( $parsely_page['datePublished'] ) ? $parsely_page['datePublished'] : null,
+				'section'   => isset( $parsely_page['articleSection'] ) ? $parsely_page['articleSection'] : null,
+				'tags'      => isset( $parsely_page['keywords'] ) ? $parsely_page['keywords'] : null,
 			);
 
 			include PARSELY_PLUGIN_DIR . 'views/repeated-metas.php';

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -889,9 +889,14 @@ class Parsely {
 				'pub-date'  => isset( $parsely_page['datePublished'] ) ? $parsely_page['datePublished'] : null,
 				'section'   => isset( $parsely_page['articleSection'] ) ? $parsely_page['articleSection'] : null,
 				'tags'      => isset( $parsely_page['keywords'] ) ? $parsely_page['keywords'] : null,
+				'author'    => isset( $parsely_page['author'] ),
 			);
-
 			$parsely_metas = array_filter( $parsely_metas, array( $this, 'filter_empty_and_not_string_from_array' ) );
+
+			if ( isset( $parsely_page['author'] ) ) {
+				$parsely_page_authors = array_map( array( $this, 'map_extract_author_name' ), $parsely_page['author'] );
+				$parsely_page_authors = array_filter( $parsely_page_authors, array( $this, 'filter_empty_and_not_string_from_array' ) );
+			}
 
 			include PARSELY_PLUGIN_DIR . 'views/repeated-metas.php';
 		}
@@ -904,6 +909,16 @@ class Parsely {
 		echo '<!-- END Parse.ly -->' . "\n\n";
 
 		return $parsely_page;
+	}
+
+	/**
+	 * Getter function to be used with `array_filter` to fetch the `name` property
+	 *
+	 * @param mixed $var Value to filter from the array.
+	 * @return mixed Value of the name property
+	 */
+	private static function map_extract_author_name( $var ) {
+		return $var['name'];
 	}
 
 	/**

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -871,8 +871,9 @@ class Parsely {
 		if ( 'json_ld' === $parsely_options['meta_type'] ) {
 			include PARSELY_PLUGIN_DIR . 'views/json-ld.php';
 		} else {
+			// Assume `meta_type` is `repeated_metas`.
 			$parsely_post_type = $this->convert_jsonld_to_parsely_type( $parsely_page['@type'] );
-			if ( is_array( $parsely_page['keywords'] ) ) {
+			if ( isset( $parsely_page['keywords'] ) && is_array( $parsely_page['keywords'] ) ) {
 				$parsely_page['keywords'] = implode( ',', $parsely_page['keywords'] );
 			}
 

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -891,6 +891,8 @@ class Parsely {
 				'tags'      => isset( $parsely_page['keywords'] ) ? $parsely_page['keywords'] : null,
 			);
 
+			$parsely_metas = array_filter( $parsely_metas, array( $this, 'filter_empty_and_not_string_from_array' ) );
+
 			include PARSELY_PLUGIN_DIR . 'views/repeated-metas.php';
 		}
 
@@ -902,6 +904,16 @@ class Parsely {
 		echo '<!-- END Parse.ly -->' . "\n\n";
 
 		return $parsely_page;
+	}
+
+	/**
+	 * Function to be used in `array_filter` to clean up repeated metas
+	 *
+	 * @param $var mixed Value to filter from the array
+	 * @return bool Returns true if the variable is not empty, and it's a string
+	 */
+	private static function filter_empty_and_not_string_from_array( $var ) {
+		return ! empty( $var ) && is_string( $var );
 	}
 
 	/**

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -9,14 +9,18 @@
  */
 
 ?>
-<meta name="parsely-title" content="<?php echo esc_attr( $parsely_page['headline'] ); ?>" />
-<meta name="parsely-link" content="<?php echo esc_attr( $parsely_page['url'] ); ?>" />
-<meta name="parsely-type" content="<?php echo esc_attr( $parsely_post_type ); ?>" />
-<meta name="parsely-image-url" content="<?php echo esc_attr( $parsely_page['thumbnailUrl'] ); ?>" />
-<meta name="parsely-pub-date" content="<?php echo esc_attr( $parsely_page['datePublished'] ); ?>" />
-<meta name="parsely-section" content="<?php echo esc_attr( $parsely_page['articleSection'] ); ?>" />
-<meta name="parsely-tags" content="<?php echo esc_attr( $parsely_page['keywords'] ); ?>" />
-<?php foreach ( (array) $parsely_page['author'] as $parsely_author ) { ?>
-<meta name="parsely-author" content="<?php echo esc_attr( $parsely_author['name'] ); ?>" />
-	<?php
+<meta name="parsely-title" content="<?php echo esc_attr( isset( $parsely_page['headline'] ) ? $parsely_page['headline'] : '' ); ?>" />
+<meta name="parsely-link" content="<?php echo esc_attr( isset( $parsely_page['url'] ) ? $parsely_page['url'] : '' ); ?>" />
+<meta name="parsely-type" content="<?php echo esc_attr( isset( $parsely_post_type ) ? $parsely_post_type : '' ); ?>" />
+<meta name="parsely-image-url" content="<?php echo esc_attr( isset( $parsely_page['thumbnailUrl'] ) ? $parsely_page['thumbnailUrl'] : '' ); ?>" />
+<meta name="parsely-pub-date" content="<?php echo esc_attr( isset( $parsely_page['datePublished'] ) ? $parsely_page['datePublished'] : '' ); ?>" />
+<meta name="parsely-section" content="<?php echo esc_attr( isset( $parsely_page['articleSection'] ) ? $parsely_page['articleSection'] : '' ); ?>" />
+<meta name="parsely-tags" content="<?php echo esc_attr( isset( $parsely_page['keywords'] ) ? $parsely_page['keywords'] : '' ); ?>" />
+<?php
+if ( isset( $parsely_page['author'] ) ) {
+	foreach ( (array) $parsely_page['author'] as $parsely_author ) {
+		?>
+<meta name="parsely-author" content="<?php echo esc_attr( isset( $parsely_author['name'] ) ? $parsely_author['name'] : '' ); ?>" />
+		<?php
+	}
 }

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -17,13 +17,13 @@ foreach ( $parsely_metas as $parsely_meta_key => $parsely_meta_val ) {
 	);
 }
 
-if ( isset( $parsely_page['author'] ) ) {
-	foreach ( (array) $parsely_page['author'] as $parsely_author ) {
-		if ( empty( $parsely_author['name'] ) || ! is_string( $parsely_author['name'] ) ) {
-			continue;
-		}
-		?>
-<meta name="parsely-author" content="<?php echo esc_attr( $parsely_author['name'] ); ?>" />
-		<?php
+if ( isset( $parsely_page_authors ) ) {
+	foreach ( $parsely_page_authors as $parsely_author_name ) {
+		printf(
+			'<meta name="parsely-author" content="%s" />%s',
+			esc_attr( $parsely_author_name ),
+			PHP_EOL
+		);
 	}
 }
+

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -10,7 +10,11 @@
 
 foreach ( $parsely_metas as $parsely_meta_key => $parsely_meta_val ) {
 	if ( ! empty( $parsely_meta_val ) && is_string( $parsely_meta_val ) ) {
-		echo '<meta name="parsely-' . esc_attr( $parsely_meta_key ) . '" content="' . esc_attr( $parsely_meta_val ) . '" />' . "\n";
+		printf(
+			'<meta name="%s" content="%s" />',
+			esc_attr( 'parsely-' . $parsely_meta_key ),
+			esc_attr( $parsely_meta_val )
+		) . "\n";
 	}
 }
 

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -9,13 +9,12 @@
  */
 
 foreach ( $parsely_metas as $parsely_meta_key => $parsely_meta_val ) {
-	if ( ! empty( $parsely_meta_val ) && is_string( $parsely_meta_val ) ) {
-		printf(
-			'<meta name="%s" content="%s" />',
-			esc_attr( 'parsely-' . $parsely_meta_key ),
-			esc_attr( $parsely_meta_val )
-		) . "\n";
-	}
+	printf(
+		'<meta name="%s" content="%s" />%s',
+		esc_attr( 'parsely-' . $parsely_meta_key ),
+		esc_attr( $parsely_meta_val ),
+		PHP_EOL
+	);
 }
 
 if ( isset( $parsely_page['author'] ) ) {

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -8,9 +8,9 @@
  * @license      GPL-2.0-or-later
  */
 
-foreach ($metas as $key => $val) {
-	if ( ! empty( $val ) && is_string( $val ) ) {
-		echo '<meta name="parsely-' . $key . '" content="' . esc_attr( $val ) .'" />' . "\n";
+foreach ( $parsely_metas as $parsely_meta_key => $parsely_meta_val ) {
+	if ( ! empty( $parsely_meta_val ) && is_string( $parsely_meta_val ) ) {
+		echo '<meta name="parsely-' . esc_attr( $parsely_meta_key ) . '" content="' . esc_attr( $parsely_meta_val ) . '" />' . "\n";
 	}
 }
 
@@ -19,8 +19,8 @@ if ( isset( $parsely_page['author'] ) ) {
 		if ( empty( $parsely_author['name'] ) || ! is_string( $parsely_author['name'] ) ) {
 			continue;
 		}
-?>
+		?>
 <meta name="parsely-author" content="<?php echo esc_attr( $parsely_author['name'] ); ?>" />
-<?php
+		<?php
 	}
 }

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -8,41 +8,11 @@
  * @license      GPL-2.0-or-later
  */
 
-// phpcs:disable Generic.WhiteSpace.ScopeIndent
-if ( ! empty( $parsely_page['headline'] ) && is_string( $parsely_page['headline'] ) ) : ?>
-<meta name="parsely-title" content="<?php echo esc_attr( $parsely_page['headline'] ); ?>" />
-<?php
-endif;
-if ( ! empty( $parsely_page['url'] && is_string( $parsely_page['url'] ) ) ) :
-?>
-<meta name="parsely-link" content="<?php echo esc_attr( isset( $parsely_page['url'] ) ? $parsely_page['url'] : '' ); ?>" />
-<?php
-endif;
-if ( ! empty( $parsely_post_type ) && is_string( $parsely_post_type ) ) :
-?>
-<meta name="parsely-type" content="<?php echo esc_attr( isset( $parsely_post_type ) ? $parsely_post_type : '' ); ?>" />
-<?php
-endif;
-if ( ! empty( $parsely_page['thumbnailUrl'] ) && is_string( $parsely_page['thumbnailUrl'] ) ) :
-?>
-<meta name="parsely-image-url" content="<?php echo esc_attr( isset( $parsely_page['thumbnailUrl'] ) ? $parsely_page['thumbnailUrl'] : '' ); ?>" />
-<?php
-endif;
-if ( ! empty( $parsely_page['datePublished'] ) && is_string( $parsely_page['datePublished'] ) ) :
-?>
-<meta name="parsely-pub-date" content="<?php echo esc_attr( isset( $parsely_page['datePublished'] ) ? $parsely_page['datePublished'] : '' ); ?>" />
-<?php
-endif;
-if ( ! empty( $parsely_page['articleSection'] ) && is_string( $parsely_page['articleSection'] ) ) :
-?>
-<meta name="parsely-section" content="<?php echo esc_attr( isset( $parsely_page['articleSection'] ) ? $parsely_page['articleSection'] : '' ); ?>" />
-<?php
-endif;
-if ( ! empty( $parsely_page['keywords'] ) && is_string( $parsely_page['keywords'] ) ) :
-?>
-<meta name="parsely-tags" content="<?php echo esc_attr( isset( $parsely_page['keywords'] ) ? $parsely_page['keywords'] : '' ); ?>" />
-<?php
-endif;
+foreach ($metas as $key => $val) {
+	if ( ! empty( $val ) && is_string( $val ) ) {
+		echo '<meta name="parsely-' . $key . '" content="' . esc_attr( $val ) .'" />' . "\n";
+	}
+}
 
 if ( isset( $parsely_page['author'] ) ) {
 	foreach ( (array) $parsely_page['author'] as $parsely_author ) {

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -8,19 +8,49 @@
  * @license      GPL-2.0-or-later
  */
 
+// phpcs:disable Generic.WhiteSpace.ScopeIndent
+if ( ! empty( $parsely_page['headline'] ) && is_string( $parsely_page['headline'] ) ) : ?>
+<meta name="parsely-title" content="<?php echo esc_attr( $parsely_page['headline'] ); ?>" />
+<?php
+endif;
+if ( ! empty( $parsely_page['url'] && is_string( $parsely_page['url'] ) ) ) :
 ?>
-<meta name="parsely-title" content="<?php echo esc_attr( isset( $parsely_page['headline'] ) ? $parsely_page['headline'] : '' ); ?>" />
 <meta name="parsely-link" content="<?php echo esc_attr( isset( $parsely_page['url'] ) ? $parsely_page['url'] : '' ); ?>" />
+<?php
+endif;
+if ( ! empty( $parsely_post_type ) && is_string( $parsely_post_type ) ) :
+?>
 <meta name="parsely-type" content="<?php echo esc_attr( isset( $parsely_post_type ) ? $parsely_post_type : '' ); ?>" />
+<?php
+endif;
+if ( ! empty( $parsely_page['thumbnailUrl'] ) && is_string( $parsely_page['thumbnailUrl'] ) ) :
+?>
 <meta name="parsely-image-url" content="<?php echo esc_attr( isset( $parsely_page['thumbnailUrl'] ) ? $parsely_page['thumbnailUrl'] : '' ); ?>" />
+<?php
+endif;
+if ( ! empty( $parsely_page['datePublished'] ) && is_string( $parsely_page['datePublished'] ) ) :
+?>
 <meta name="parsely-pub-date" content="<?php echo esc_attr( isset( $parsely_page['datePublished'] ) ? $parsely_page['datePublished'] : '' ); ?>" />
+<?php
+endif;
+if ( ! empty( $parsely_page['articleSection'] ) && is_string( $parsely_page['articleSection'] ) ) :
+?>
 <meta name="parsely-section" content="<?php echo esc_attr( isset( $parsely_page['articleSection'] ) ? $parsely_page['articleSection'] : '' ); ?>" />
+<?php
+endif;
+if ( ! empty( $parsely_page['keywords'] ) && is_string( $parsely_page['keywords'] ) ) :
+?>
 <meta name="parsely-tags" content="<?php echo esc_attr( isset( $parsely_page['keywords'] ) ? $parsely_page['keywords'] : '' ); ?>" />
 <?php
+endif;
+
 if ( isset( $parsely_page['author'] ) ) {
 	foreach ( (array) $parsely_page['author'] as $parsely_author ) {
-		?>
-<meta name="parsely-author" content="<?php echo esc_attr( isset( $parsely_author['name'] ) ? $parsely_author['name'] : '' ); ?>" />
-		<?php
+		if ( empty( $parsely_author['name'] ) || ! is_string( $parsely_author['name'] ) ) {
+			continue;
+		}
+?>
+<meta name="parsely-author" content="<?php echo esc_attr( $parsely_author['name'] ); ?>" />
+<?php
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

If configured to print repeating metas, any keys that don't exist in the hash map throw PHP notices. This change ensures that values are set for a given index prior to referencing them so as to not trigger the notices.

Further, this prevents printing meta tags that are unpopulated.
fixes #365

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If debugging is enabled, these are pretty noisy and not really actionable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Verify the issue

* Run the `develop` branch
* Browse to Settings | Parse.ly
* Set `Metadata Format` to `repeated_metas`
* Set `define( 'WP_DEBUG', true );` in your wp-config.php
* Browse to the front-end of the site on a route that does not have all the printed meta values -- a sure way to do this is to browse to a blog post listing archive page.
    * Confirm you see `Undefined Index` PHP notice(s)
* View the page source
    * Confirm you see `<meta name="parsely-...` HTML tags with empty values

### Verify the fix

* Switch to this branch
* Reload the page
    * No notices should be printed
* View the page source
    * Confirm you see no `<meta name="parsely-...` HTML tags with empty values
    * Confirm you see `<meta name="parsely-...` HTML tags with populated values for all those that exists in the meta data

## Screenshots (if appropriate):

<img width="704" alt="Screen Shot 2021-09-10 at 10 02 54 PM" src="https://user-images.githubusercontent.com/1587282/132932716-e8ff426a-e1cc-47cc-8e80-a8862a519664.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Bug fix
