### PR TITLE
Simplifying get_options function

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1706,17 +1706,13 @@ class Parsely {
 
 	/**
 	 * Safely returns options for the plugin by assigning defaults contained in optionDefaults.  As soon as actual
-	 * options are saved, they override the defaults.  This prevents us from having to do a lot of isset() checking
+	 * options are saved, they override the defaults. This prevents us from having to do a lot of isset() checking
 	 * on variables.
 	 *
 	 * @return array
 	 */
 	private function get_options() {
-		$options = get_option( self::OPTIONS_KEY );
-		if ( false === $options ) {
-			return $this->option_defaults;
-		}
-
+		$options = get_option( self::OPTIONS_KEY, $this->option_defaults );
 		return array_merge( $this->option_defaults, $options );
 	}
 


### PR DESCRIPTION
## Description

We are changing the `get_options` function to have a simpler implementation.

## Motivation and Context

The `get_options` function tries to fetch a WP option and if that is not found, it returns the default options. We have a custom logic for that, but the same can be achieved by passing the defaults to the `get_option` WP function: https://developer.wordpress.org/reference/functions/get_option/

Props to @rinatkhaziev for pointing this out.

## Types of changes

Bug fix (non-breaking change which fixes an issue)