### PR TITLE
Tests: Improve the get_current_url data provider

### DIFF
--- a/tests/GetCurrentUrlTest.php
+++ b/tests/GetCurrentUrlTest.php
@@ -16,78 +16,87 @@ final class GetCurrentUrlTest extends TestCase {
 	/**
 	 * Data provider for test_get_current_url
 	 *
-	 * @return array[]
+	 * @return iterable
 	 */
 	public function data_for_test_get_current_url() {
-		return array(
-			// Start cases with 'force_https_canonicals' = true.
-			array(
-				true,
-				'http://example.com',
-				'https://example.com',
-			),
-			array(
-				true,
-				'https://example.com',
-				'https://example.com',
-			),
-			array(
-				true,
-				'http://example.com:1234',
-				'https://example.com:1234',
-			),
-			array(
-				true,
-				'https://example.com:1234',
-				'https://example.com:1234',
-			),
-			array(
-				true,
-				'http://example.com:1234/foo/bar',
-				'https://example.com:1234/foo/bar',
-			),
-			array(
-				true,
-				'https://example.com:1234/foo/bar',
-				'https://example.com:1234/foo/bar',
-			),
-			// Start cases with 'force_https_canonicals' = false.
-			array(
-				false,
-				'http://example.com',
-				'http://example.com',
-			),
-			array(
-				false,
-				'https://example.com',
-				'http://example.com',
-			),
-			array(
-				false,
-				'http://example.com:1234',
-				'http://example.com:1234',
-			),
-			array(
-				false,
-				'https://example.com:1234',
-				'http://example.com:1234',
-			),
-			array(
-				false,
-				'http://example.com:1234/foo/bar',
-				'http://example.com:1234/foo/bar',
-			),
-			array(
-				false,
-				'https://example.com:1234/foo/bar',
-				'http://example.com:1234/foo/bar',
-			),
+		yield 'Home is http with force HTTPS true' => array(
+			'force_https' => true,
+			'home'        => 'http://example.com',
+			'expected'    => 'https://example.com',
+		);
+
+		yield 'Home is https with force HTTPS true' => array(
+			'force_https' => true,
+			'home'        => 'https://example.com',
+			'expected'    => 'https://example.com',
+		);
+
+		yield 'Home is http with port with force HTTPS true' => array(
+			'force_https' => true,
+			'home'        => 'http://example.com:1234',
+			'expected'    => 'https://example.com:1234',
+		);
+
+		yield 'Home is https with port with force HTTPS true' => array(
+			'force_https' => true,
+			'home'        => 'https://example.com:1234',
+			'expected'    => 'https://example.com:1234',
+		);
+
+		yield 'Home is http with port and path with force HTTPS true' => array(
+			'force_https' => true,
+			'home'        => 'http://example.com:1234/foo/bar',
+			'expected'    => 'https://example.com:1234/foo/bar',
+		);
+
+		yield 'Home is https with port and path with force HTTPS true' => array(
+			'force_https' => true,
+			'home'        => 'https://example.com:1234/foo/bar',
+			'expected'    => 'https://example.com:1234/foo/bar',
+		);
+
+		// Start cases with 'force_https_canonicals' = false.
+		yield 'Home is http with force HTTPS false' => array(
+			'force_https' => false,
+			'home'        => 'http://example.com',
+			'expected'    => 'http://example.com',
+		);
+
+		yield 'Home is https with force HTTPS false' => array(
+			'force_https' => false,
+			'home'        => 'https://example.com',
+			'expected'    => 'http://example.com',
+		);
+
+		yield 'Home is http with port with force HTTPS false' => array(
+			'force_https' => false,
+			'home'        => 'http://example.com:1234',
+			'expected'    => 'http://example.com:1234',
+		);
+
+		yield 'Home is https with port with force HTTPS false' => array(
+			'force_https' => false,
+			'home'        => 'https://example.com:1234',
+			'expected'    => 'http://example.com:1234',
+		);
+
+		yield 'Home is http with port and path with force HTTPS false' => array(
+			'force_https' => false,
+			'home'        => 'http://example.com:1234/foo/bar',
+			'expected'    => 'http://example.com:1234/foo/bar',
+		);
+
+		yield 'Home is https with port and path with force HTTPS false' => array(
+			'force_https' => false,
+			'home'        => 'https://example.com:1234/foo/bar',
+			'expected'    => 'http://example.com:1234/foo/bar',
 		);
 	}
 
 	/**
 	 * Test the get_current_url() method.
 	 *
+	 * @testdox Given Force HTTPS is $force_https, when home is $home, then expect $expected.
 	 * @dataProvider data_for_test_get_current_url
 	 * @covers \Parsely::get_current_url
 	 * @uses \Parsely::get_options


### PR DESCRIPTION
## Description

Data providers actually provide an iterator rather than just an array, so we can build up the data using `yield` instead.

As per https://peakd.com/hive-168588/@crell/fun-with-phpunit-data-providers (hat tip @crell) this has several advantages:

1. It's easier to read, making it better for future you to understand the code.
1. It's less indented, which gives you more room for longer lines for each value.
1. Because each test set is syntactically independent, it's easier to add new ones, reorder them, or temporarily comment out a single test set.
1. If a given test set needs more setup than just a static list, it's simple to put that setup before the `yield` statement for which it is relevant.

As per the follow-up article https://peakd.com/hive-168588/@crell/advanced-phpunit-shenanigans, I've also included a `@testdox` annotation on the test method. When this contains at least one method parameter, it completely overrides the sentence that appears when the `--testdox` flag is called when running PHPUnit.

## Motivation and Context

Here's what the tests looked like with `--testdox` before the change (not descriptive):

<img width="758" alt="Screenshot 2021-09-17 at 10 06 29" src="https://user-images.githubusercontent.com/88371/133762072-e8154b72-8c40-43b9-a20a-cc042864818a.png">
(The names of some of the other test methods could be improved to be more descriptive about what is actually being tested, but that's outside the scope of this PR.)

----

Here's the view when the `yield` keys (same as what associative arrays would look like) only are used (more descriptive, but clunky):
<img width="1555" alt="Screenshot 2021-09-17 at 10 12 52" src="https://user-images.githubusercontent.com/88371/133762248-21536d7e-4523-4a4e-8274-fd0156d19605.png">

----

And here's what they look like with the complete change, including `@testdox` with parameter names:

<img width="1246" alt="Screenshot 2021-09-17 at 10 52 48" src="https://user-images.githubusercontent.com/88371/133764134-d12dd17f-eece-49e5-b28c-e27af8840ff5.png">


## How Has This Been Tested?
Run the test suite before and after - all green, no change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Maintenance
