### PR TITLE
Remove unused default logo variable

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -393,8 +393,6 @@ class Parsely {
 
 		$h = __( 'If you want to specify the url for your logo, you can do so here.', 'wp-parsely' );
 
-		$option_defaults['logo'] = $this->get_logo_default();
-
 		$field_args = array(
 			'option_key' => 'logo',
 			'help_text'  => $h,


### PR DESCRIPTION
## Description

This PR removes a variable that was defined that wasn't used anywhere. This line is related with the default logo configuration, but removing it does not affect its behavior.

## Motivation and Context

https://github.com/Parsely/wp-parsely/issues/330

## How Has This Been Tested?

Tested on a WP environment to check that the logo is correctly referenced in the HTML code created by Parse.ly. Also, used the ID to double check that the image wasn't used anywhere.

## Types of changes

Bug fix (non-breaking change which fixes an issue)