### PR TITLE
Using npm caching on GitHub Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,19 +33,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-
-      # See: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: "${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}"
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: npm
 
       - name: Install JavaScript dependencies
         run: npm ci


### PR DESCRIPTION
## Description

This PR gets rid of some custom caching that we were doing in the `node`-based actions. We're now instead relying on the `npm` option by the action.

## Motivation and Context

https://github.com/Parsely/wp-parsely/issues/348

## How Has This Been Tested?

Check the GitHub Actions runs in this PR.

## Types of changes

Bug fix (non-breaking change which fixes an issue)