### PR TITLE
Remove unused return_personalized_json function

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -2148,12 +2148,6 @@ class Parsely {
 	}
 
 	/**
-	 * Why is this here?
-	 */
-	public function return_personalized_json() {
-	}
-
-	/**
 	 * Convert JSON-LD type to respective Parse.ly page type.
 	 *
 	 * If the JSON-LD type is one of the types Parse.ly supports as a "post", then "post" will be returned.


### PR DESCRIPTION
## Description

There is a function in the `class-parsely.php` file that is empty and it's not being used anywhere in the project. This PR removes that function.

## How Has This Been Tested?

The plugin works as expected and we have double checked with an IDE that the function is not used anywhere in the project.

## Types of changes

Bug fix (non-breaking change which fixes an issue)