### PR TITLE
Improving reliability of get_current_url tests

### DIFF
--- a/tests/GetCurrentUrlTest.php
+++ b/tests/GetCurrentUrlTest.php
@@ -22,74 +22,74 @@ final class GetCurrentUrlTest extends TestCase {
 		yield 'Home is http with force HTTPS true' => array(
 			'force_https' => true,
 			'home'        => 'http://example.com',
-			'expected'    => 'https://example.com',
+			'expected'    => 'https://example.com/',
 		);
 
 		yield 'Home is https with force HTTPS true' => array(
 			'force_https' => true,
 			'home'        => 'https://example.com',
-			'expected'    => 'https://example.com',
+			'expected'    => 'https://example.com/',
 		);
 
 		yield 'Home is http with port with force HTTPS true' => array(
 			'force_https' => true,
 			'home'        => 'http://example.com:1234',
-			'expected'    => 'https://example.com:1234',
+			'expected'    => 'https://example.com:1234/',
 		);
 
 		yield 'Home is https with port with force HTTPS true' => array(
 			'force_https' => true,
 			'home'        => 'https://example.com:1234',
-			'expected'    => 'https://example.com:1234',
+			'expected'    => 'https://example.com:1234/',
 		);
 
 		yield 'Home is http with port and path with force HTTPS true' => array(
 			'force_https' => true,
 			'home'        => 'http://example.com:1234/foo/bar',
-			'expected'    => 'https://example.com:1234/foo/bar',
+			'expected'    => 'https://example.com:1234/foo/bar/',
 		);
 
 		yield 'Home is https with port and path with force HTTPS true' => array(
 			'force_https' => true,
 			'home'        => 'https://example.com:1234/foo/bar',
-			'expected'    => 'https://example.com:1234/foo/bar',
+			'expected'    => 'https://example.com:1234/foo/bar/',
 		);
 
 		// Start cases with 'force_https_canonicals' = false.
 		yield 'Home is http with force HTTPS false' => array(
 			'force_https' => false,
 			'home'        => 'http://example.com',
-			'expected'    => 'http://example.com',
+			'expected'    => 'http://example.com/',
 		);
 
 		yield 'Home is https with force HTTPS false' => array(
 			'force_https' => false,
 			'home'        => 'https://example.com',
-			'expected'    => 'http://example.com',
+			'expected'    => 'http://example.com/',
 		);
 
 		yield 'Home is http with port with force HTTPS false' => array(
 			'force_https' => false,
 			'home'        => 'http://example.com:1234',
-			'expected'    => 'http://example.com:1234',
+			'expected'    => 'http://example.com:1234/',
 		);
 
 		yield 'Home is https with port with force HTTPS false' => array(
 			'force_https' => false,
 			'home'        => 'https://example.com:1234',
-			'expected'    => 'http://example.com:1234',
+			'expected'    => 'http://example.com:1234/',
 		);
 
 		yield 'Home is http with port and path with force HTTPS false' => array(
 			'force_https' => false,
 			'home'        => 'http://example.com:1234/foo/bar',
-			'expected'    => 'http://example.com:1234/foo/bar',
+			'expected'    => 'http://example.com:1234/foo/bar/',
 		);
 
 		yield 'Home is https with port and path with force HTTPS false' => array(
 			'force_https' => false,
 			'home'        => 'https://example.com:1234/foo/bar',
-			'expected'    => 'http://example.com:1234/foo/bar',
+			'expected'    => 'http://example.com:1234/foo/bar/',
 		);
 	}
 
@@ -117,7 +117,7 @@ final class GetCurrentUrlTest extends TestCase {
 		// Test homepage.
 		$this->go_to( '/' );
 		$res = $parsely->get_current_url();
-		self::assertStringStartsWith( $expected, $res );
+		self::assertEquals( $expected, $res );
 
 		// Test a specific post.
 		$post_array = $this->create_test_post_array();

--- a/tests/GetCurrentUrlTest.php
+++ b/tests/GetCurrentUrlTest.php
@@ -118,17 +118,65 @@ final class GetCurrentUrlTest extends TestCase {
 		$this->go_to( '/' );
 		$res = $parsely->get_current_url();
 		self::assertEquals( $expected, $res );
+	}
+
+	/**
+	 * Test the get_current_url() method with a specific post (query parameter).
+	 *
+	 * @testdox Given Force HTTPS is $force_https, when home is $home, then expect $expected.
+	 * @dataProvider data_for_test_get_current_url
+	 * @covers \Parsely::get_current_url
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::update_metadata_endpoint
+	 *
+	 * @param bool   $force_https Force HTTPS Canonical setting value.
+	 * @param string $home        Home URL.
+	 * @param string $expected    Expected current URL.
+	 */
+	public function test_get_current_url_specific_post( $force_https, $home, $expected ) {
+		$parsely                           = new Parsely();
+		$options                           = get_option( Parsely::OPTIONS_KEY );
+		$options['force_https_canonicals'] = $force_https;
+		update_option( Parsely::OPTIONS_KEY, $options );
+
+		update_option( 'home', $home );
 
 		// Test a specific post.
 		$post_array = $this->create_test_post_array();
 		$post_id    = $this->factory->post->create( $post_array );
 		$this->go_to( '/?p=' . $post_id );
 		$res = $parsely->get_current_url( 'post', $post_id );
-		self::assertStringStartsWith( $expected, $res );
+
+		$constructed_expected = $expected . '?p=' . $post_id;
+		self::assertEquals( $constructed_expected, $res );
+	}
+
+	/**
+	 * Test the get_current_url() method with a random URL.
+	 *
+	 * @testdox Given Force HTTPS is $force_https, when home is $home, then expect $expected.
+	 * @dataProvider data_for_test_get_current_url
+	 * @covers \Parsely::get_current_url
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::update_metadata_endpoint
+	 *
+	 * @param bool   $force_https Force HTTPS Canonical setting value.
+	 * @param string $home        Home URL.
+	 * @param string $expected    Expected current URL.
+	 */
+	public function test_get_current_url_random( $force_https, $home, $expected ) {
+		$parsely                           = new Parsely();
+		$options                           = get_option( Parsely::OPTIONS_KEY );
+		$options['force_https_canonicals'] = $force_https;
+		update_option( Parsely::OPTIONS_KEY, $options );
+
+		update_option( 'home', $home );
 
 		// Test a random URL.
 		$this->go_to( '/random-url' );
 		$res = $parsely->get_current_url();
-		self::assertStringStartsWith( $expected, $res );
+
+		$constructed_expected = $expected . 'random-url';
+		self::assertEquals( $constructed_expected, $res );
 	}
 }

--- a/tests/GetCurrentUrlTest.php
+++ b/tests/GetCurrentUrlTest.php
@@ -22,81 +22,83 @@ final class GetCurrentUrlTest extends TestCase {
 		yield 'Home is http with force HTTPS true' => array(
 			'force_https' => true,
 			'home'        => 'http://example.com',
-			'expected'    => 'https://example.com/',
+			'expected'    => 'https://example.com',
 		);
 
 		yield 'Home is https with force HTTPS true' => array(
 			'force_https' => true,
 			'home'        => 'https://example.com',
-			'expected'    => 'https://example.com/',
+			'expected'    => 'https://example.com',
 		);
 
 		yield 'Home is http with port with force HTTPS true' => array(
 			'force_https' => true,
 			'home'        => 'http://example.com:1234',
-			'expected'    => 'https://example.com:1234/',
+			'expected'    => 'https://example.com:1234',
 		);
 
 		yield 'Home is https with port with force HTTPS true' => array(
 			'force_https' => true,
 			'home'        => 'https://example.com:1234',
-			'expected'    => 'https://example.com:1234/',
+			'expected'    => 'https://example.com:1234',
 		);
 
 		yield 'Home is http with port and path with force HTTPS true' => array(
 			'force_https' => true,
 			'home'        => 'http://example.com:1234/foo/bar',
-			'expected'    => 'https://example.com:1234/foo/bar/',
+			'expected'    => 'https://example.com:1234/foo/bar',
 		);
 
 		yield 'Home is https with port and path with force HTTPS true' => array(
 			'force_https' => true,
 			'home'        => 'https://example.com:1234/foo/bar',
-			'expected'    => 'https://example.com:1234/foo/bar/',
+			'expected'    => 'https://example.com:1234/foo/bar',
 		);
 
 		// Start cases with 'force_https_canonicals' = false.
 		yield 'Home is http with force HTTPS false' => array(
 			'force_https' => false,
 			'home'        => 'http://example.com',
-			'expected'    => 'http://example.com/',
+			'expected'    => 'http://example.com',
 		);
 
 		yield 'Home is https with force HTTPS false' => array(
 			'force_https' => false,
 			'home'        => 'https://example.com',
-			'expected'    => 'http://example.com/',
+			'expected'    => 'http://example.com',
 		);
 
 		yield 'Home is http with port with force HTTPS false' => array(
 			'force_https' => false,
 			'home'        => 'http://example.com:1234',
-			'expected'    => 'http://example.com:1234/',
+			'expected'    => 'http://example.com:1234',
 		);
 
 		yield 'Home is https with port with force HTTPS false' => array(
 			'force_https' => false,
 			'home'        => 'https://example.com:1234',
-			'expected'    => 'http://example.com:1234/',
+			'expected'    => 'http://example.com:1234',
 		);
 
 		yield 'Home is http with port and path with force HTTPS false' => array(
 			'force_https' => false,
 			'home'        => 'http://example.com:1234/foo/bar',
-			'expected'    => 'http://example.com:1234/foo/bar/',
+			'expected'    => 'http://example.com:1234/foo/bar',
 		);
 
 		yield 'Home is https with port and path with force HTTPS false' => array(
 			'force_https' => false,
 			'home'        => 'https://example.com:1234/foo/bar',
-			'expected'    => 'http://example.com:1234/foo/bar/',
+			'expected'    => 'http://example.com:1234/foo/bar',
 		);
 	}
 
 	/**
 	 * Test the get_current_url() method.
 	 *
-	 * @testdox Given Force HTTPS is $force_https, when home is $home, then expect $expected.
+	 * Assert that homepage, a specific page, and a random URL return the expected URL.
+	 *
+	 * @testdox Given Force HTTPS is $force_https, when home is $home, then expect URLs starting with $expected.
 	 * @dataProvider data_for_test_get_current_url
 	 * @covers \Parsely::get_current_url
 	 * @uses \Parsely::get_options
@@ -107,76 +109,55 @@ final class GetCurrentUrlTest extends TestCase {
 	 * @param string $expected    Expected current URL.
 	 */
 	public function test_get_current_url( $force_https, $home, $expected ) {
-		$parsely                           = new Parsely();
-		$options                           = get_option( Parsely::OPTIONS_KEY );
-		$options['force_https_canonicals'] = $force_https;
-		update_option( Parsely::OPTIONS_KEY, $options );
-
+		$this->set_options( array( 'force_https_canonicals' => $force_https ) );
 		update_option( 'home', $home );
 
-		// Test homepage.
-		$this->go_to( '/' );
-		$res = $parsely->get_current_url();
-		self::assertEquals( $expected, $res );
+		$this->assertCurrentUrlForHomepage( $expected );
+		$this->assertCurrentUrlForSpecificPostWithId( $expected );
+		$this->assertCurrentUrlForRandomUrl( $expected );
 	}
 
 	/**
-	 * Test the get_current_url() method with a specific post (query parameter).
+	 * Assert the correct current URL for the homepage.
 	 *
-	 * @testdox Given Force HTTPS is $force_https, when home is $home, then expect $expected.
-	 * @dataProvider data_for_test_get_current_url
-	 * @covers \Parsely::get_current_url
-	 * @uses \Parsely::get_options
-	 * @uses \Parsely::update_metadata_endpoint
-	 *
-	 * @param bool   $force_https Force HTTPS Canonical setting value.
-	 * @param string $home        Home URL.
-	 * @param string $expected    Expected current URL.
+	 * @param string $expected Expected start of the URL.
 	 */
-	public function test_get_current_url_specific_post( $force_https, $home, $expected ) {
-		$parsely                           = new Parsely();
-		$options                           = get_option( Parsely::OPTIONS_KEY );
-		$options['force_https_canonicals'] = $force_https;
-		update_option( Parsely::OPTIONS_KEY, $options );
+	private function assertCurrentUrlForHomepage( $expected ) {
+		$this->go_to( '/' );
 
-		update_option( 'home', $home );
+		$parsely = new Parsely();
+		$res     = $parsely->get_current_url();
 
-		// Test a specific post.
+		self::assertEquals( $expected . '/', $res, 'Homepage page does not match.' );
+	}
+
+	/**
+	 * Assert the correct current URL for a post by ID.
+	 *
+	 * @param string $expected Expected start of the URL.
+	 */
+	private function assertCurrentUrlForSpecificPostWithId( $expected ) {
 		$post_array = $this->create_test_post_array();
 		$post_id    = $this->factory->post->create( $post_array );
 		$this->go_to( '/?p=' . $post_id );
-		$res = $parsely->get_current_url( 'post', $post_id );
 
-		$constructed_expected = $expected . '?p=' . $post_id;
-		self::assertEquals( $constructed_expected, $res );
+		$parsely = new Parsely();
+		$res     = $parsely->get_current_url( 'post', $post_id );
+
+		self::assertEquals( $expected . '/?p=' . $post_id, $res, 'Specific post by ID does not match.' );
 	}
 
 	/**
-	 * Test the get_current_url() method with a random URL.
+	 * Assert the correct current URL for a random URL with trailing slash.
 	 *
-	 * @testdox Given Force HTTPS is $force_https, when home is $home, then expect $expected.
-	 * @dataProvider data_for_test_get_current_url
-	 * @covers \Parsely::get_current_url
-	 * @uses \Parsely::get_options
-	 * @uses \Parsely::update_metadata_endpoint
-	 *
-	 * @param bool   $force_https Force HTTPS Canonical setting value.
-	 * @param string $home        Home URL.
-	 * @param string $expected    Expected current URL.
+	 * @param string $expected Expected start of the URL.
 	 */
-	public function test_get_current_url_random( $force_https, $home, $expected ) {
-		$parsely                           = new Parsely();
-		$options                           = get_option( Parsely::OPTIONS_KEY );
-		$options['force_https_canonicals'] = $force_https;
-		update_option( Parsely::OPTIONS_KEY, $options );
-
-		update_option( 'home', $home );
-
-		// Test a random URL.
-		$this->go_to( '/random-url' );
+	private function assertCurrentUrlForRandomUrl( $expected ) {
+		$parsely = new Parsely();
+		$this->go_to( '/random/url/' );
 		$res = $parsely->get_current_url();
 
-		$constructed_expected = $expected . 'random-url';
-		self::assertEquals( $constructed_expected, $res );
+		$constructed_expected = $expected . '/random/url/';
+		self::assertEquals( $constructed_expected, $res, 'Random URL does not match.' );
 	}
 }


### PR DESCRIPTION
## Description

This PR improves the tests on the `get_current_url` function. Concretely, we're changing how we check the results, from `assertStringStartsWith` to the stricter `assertEquals`.

With this PR, we have tests to prove that if a query parameter, such as `?p=1` gets added to the URL, the function will correctly catch it. This closes an issue (linked below) that pointed to this function not working correctly.

## Motivation and Context

https://github.com/Parsely/wp-parsely/issues/151

## How Has This Been Tested?

Ran PHPUnit tests locally and in CI.

## Types of changes

New feature (non-breaking change which adds functionality)