### PR TITLE
Split out plugin actions links logic

### DIFF
--- a/src/UI/class-plugins-actions.php
+++ b/src/UI/class-plugins-actions.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Parsely class
+ *
+ * @package Parsely
+ * @since 2.6.0
+ */
+
+namespace Parsely\UI;
+
+use Parsely;
+
+/**
+ * User Interface changes for the plugins actions.
+ *
+ * @since 2.6.0
+ */
+class Plugins_Actions {
+
+	/**
+	 * Register action and filter hook callbacks.
+	 */
+	public function run() {
+		add_filter( 'plugin_action_links_' . PARSELY_PLUGIN_BASENAME, array( $this, 'add_plugin_meta_links' ) );
+	}
+
+	/**
+	 * Adds a 'Settings' action link to the Plugins screen in WP admin.
+	 *
+	 * @param array $actions An array of plugin action links. By default, this can include 'activate',
+	 *                       'deactivate', and 'delete'. With Multisite active this can also include
+	 *                       'network_active' and 'network_only' items.
+	 */
+	public function add_plugin_meta_links( $actions ) {
+		$settings_link = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( Parsely::get_settings_url() ),
+			esc_html__( 'Settings', 'wp-parsely' )
+		);
+
+		$actions['settings'] = $settings_link;
+
+		return $actions;
+	}
+}

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -111,11 +111,6 @@ class Parsely {
 		// display warning when plugin hasn't been configured.
 		add_action( 'admin_footer', array( $this, 'display_admin_warning' ) );
 
-		add_filter(
-			'plugin_action_links_' . PARSELY_PLUGIN_BASENAME,
-			array( $this, 'add_plugin_meta_links' )
-		);
-
 		// phpcs:ignore WordPress.WP.CronInterval.CronSchedulesInterval
 		add_filter( 'cron_schedules', array( $this, 'wpparsely_add_cron_interval' ) );
 
@@ -778,18 +773,6 @@ class Parsely {
 	}
 
 	/**
-	 * Adds a 'Settings' link to the Plugins screen in WP admin
-	 *
-	 * @category   Function
-	 * @package    Parsely
-	 * @param array $links The links to add.
-	 */
-	public function add_plugin_meta_links( $links ) {
-		array_unshift( $links, '<a href="' . esc_url( $this->get_settings_url() ) . '">' . __( 'Settings', 'wp-parsely' ) . '</a>' );
-		return $links;
-	}
-
-	/**
 	 * Display the admin warning if needed
 	 *
 	 * @category   Function
@@ -803,7 +786,7 @@ class Parsely {
 		$message = sprintf(
 				/* translators: %s: Plugin settings page URL */
 			__( '<strong>The Parse.ly plugin is not active.</strong> You need to <a href="%s">provide your Parse.ly Dash Site ID</a> before things get cooking.', 'wp-parsely' ),
-			esc_url( $this->get_settings_url() )
+			esc_url( self::get_settings_url() )
 		);
 		?>
 		<div id="message" class="error"><p><?php echo wp_kses_post( $message ); ?></p></div>
@@ -1972,7 +1955,7 @@ class Parsely {
 	/**
 	 * Get the URL of the plugin settings page
 	 */
-	private function get_settings_url() {
+	public static function get_settings_url() {
 		return admin_url( 'options-general.php?page=' . self::MENU_SLUG );
 	}
 

--- a/tests/UI/PluginsActionsTest.php
+++ b/tests/UI/PluginsActionsTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * UI Tests for the plugin actions
+ *
+ * @package Parsely\Tests\UI
+ */
+
+namespace Parsely\Tests\UI;
+
+use Parsely\Tests\TestCase;
+use Parsely\UI\Plugins_Actions;
+
+/**
+ * UI Tests for the plugin screen.
+ */
+final class PluginsActionsTest extends TestCase {
+	/**
+	 * Check that plugins screen will add a hook to change the plugin action links.
+	 *
+	 * @covers \Parsely\UI\Plugins_Actions::run
+	 * @group ui
+	 */
+	public function test_plugins_screen_has_filter_to_add_a_settings_action_link() {
+		$plugins_screen = new Plugins_Actions();
+		$plugins_screen->run();
+
+		self::assertNotFalse( has_filter( 'plugin_action_links_' . PARSELY_PLUGIN_BASENAME, array( $plugins_screen, 'add_plugin_meta_links' ) ) );
+	}
+
+	/**
+	 * Check that plugins screen will add a hook to change the plugin action links.
+	 *
+	 * @covers \Parsely\UI\Plugins_Actions::run
+	 * @covers \Parsely\UI\Plugins_Actions::add_plugin_meta_links
+	 * @uses \Parsely::get_settings_url
+	 * @group ui
+	 */
+	public function test_plugins_screen_adds_a_settings_action_link() {
+		$actions        = array();
+		$plugins_screen = new Plugins_Actions();
+		$actions        = $plugins_screen->add_plugin_meta_links( $actions );
+
+		self::assertCount( 1, $actions );
+	}
+}

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -52,6 +52,16 @@ require PARSELY_PLUGIN_DIR . 'src/class-parsely.php';
 $GLOBALS['parsely'] = new Parsely();
 $GLOBALS['parsely']->run();
 
+// Until auto-loading happens, we need to include this file for tests as well.
+require PARSELY_PLUGIN_DIR . 'src/UI/class-plugins-actions.php';
+add_action(
+	'admin_init',
+	function() {
+		$GLOBALS['parsely_ui_plugins_actions'] = new Parsely\UI\Plugins_Actions();
+		$GLOBALS['parsely_ui_plugins_actions']->run();
+	}
+);
+
 require PARSELY_PLUGIN_DIR . 'src/class-parsely-recommended-widget.php';
 
 add_action( 'widgets_init', 'parsely_recommended_widget_register' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Moves the logic that adds the plugin action link to its own class.

Adds integration tests.

## Motivation and Context
The main `Parsely` god class is too big, so moving distinct bits of logic to their own class helps to cut this class down.

See #96.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests and visually. 

(e2e tests also written, but coming in a separate PR until I know it works in the CI)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<img width="599" alt="Screenshot 2021-09-25 at 12 01 02" src="https://user-images.githubusercontent.com/88371/134774301-3058261c-35d2-4d03-b348-4e66e7b52bce.png">
<img width="2549" alt="Screenshot 2021-09-25 at 23 28 10" src="https://user-images.githubusercontent.com/88371/134787417-cfc1312e-cf44-481e-8c1a-b1d57022af48.png">

