### PR TITLE
Add e2e test for the plugin action link

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -16,12 +16,12 @@ See this post for more infomation: https://make.wordpress.org/core/2019/06/27/in
 
 - Provision the back end
 
-  - Make sure [`docker-compose` is installed](https://docs.docker.com/compose/install/).
-  - From the top-level directory, run:
+  - Make sure [`docker` is installed](https://docs.docker.com/engine/install/).
+  - From the `wp-content/plugins/wp-parsely` directory, run:
 
-    `docker-compose -f tests/e2e/docker-compose.yml up`
+    `docker compose -f tests/e2e/docker-compose.yml up`
 
-    Tip: if you `cd` into this directory, you can simply run `docker-compose` and omit the `-f tests/e2e/docker-compose.yml` from these commands
+    Tip: if you `cd` into this directory, you can simply run `docker compose` and omit the `-f tests/e2e/docker-compose.yml` from these commands.
 
   - Once you see a line that says:
 
@@ -35,7 +35,7 @@ See this post for more infomation: https://make.wordpress.org/core/2019/06/27/in
 
     `npm run test:e2e`
 
-    This will run the test suite using a headless browser.
+    ...in a different terminal window. This will run the test suite using a headless browser.
 
   - For debugging purpose, you might want to follow the test visually. You can do so by running the tests in an interactive mode:
 
@@ -49,7 +49,7 @@ See this post for more infomation: https://make.wordpress.org/core/2019/06/27/in
 
   - The tests currently expect a "pristine" WordPress environment, so if you want to run them multiple times, you'll need to recreate the WordPress environment like so:
 
-    `docker-compose -f tests/e2e/docker-compose.yml run cli /var/www/html/wp-content/plugins/wp-parsely/tests/e2e/init-e2e.sh reset`
+    `docker compose -f tests/e2e/docker-compose.yml run cli /var/www/html/wp-content/plugins/wp-parsely/tests/e2e/init-e2e.sh reset`
 
     In the future, this will likely be built into the test suite set up to enable easier test development.
 

--- a/tests/e2e/specs/plugin-action-link.spec.js
+++ b/tests/e2e/specs/plugin-action-link.spec.js
@@ -1,0 +1,24 @@
+import {
+	activatePlugin,
+	loginUser,
+	visitAdminPage,
+} from '@wordpress/e2e-test-utils';
+
+const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
+
+describe( 'Plugin action link', () => {
+	jest.setTimeout( 30000 );
+	it( 'Should link to plugin settings page', async () => {
+		await loginUser();
+		await activatePlugin( 'wp-parsely' );
+		await visitAdminPage( '/plugins.php' );
+
+		await waitForWpAdmin();
+
+		await expect(page).toClick( '[data-slug=wp-parsely] .settings>a', { text: 'Settings' } );
+		await waitForWpAdmin();
+
+		const versionText = await page.$eval( '#wp-parsely_version', ( el ) => el.innerText );
+		await expect( versionText ).toMatch( /^Version \d+.\d+/ );
+	} );
+} );


### PR DESCRIPTION
## Description
Adds an e2e test for the plugin action link.

This based on `feature/extract-plugin-action-link` branch (and so contains the same file changes as it as well as the e2e test and readme file changes). Pulled against the feature branch, as the feature branch adds in a class that the e2e test uses to target an element. PR #401 should be merged first, and then this PR can be rebased on to `develop` as per usual, and only the two relevant changed files will be left.

The test logs in, activates the plugin, goes to the plugin page, looks for and clicks the Settings link in the Parse.ly plugin row, and then checks if the Settings page is loaded by checking for the Version string we have there.

I also updated the e2e test readme, since `docker-composer` is now `docker compose`.

## Motivation and Context
Ideally, all UI-related code should have an e2e test to check the functionality and behaviour is present.

I'll note that we may not consider the ability to click a Settings link on the Plugins page to be a critical user journey, but whilst we're still very light on e2e tests, I think it's worthwhile to get in, even if it's removed later on.

## How Has This Been Tested?
Ran e2e test locally (but had failures - see https://github.com/Parsely/wp-parsely/issues/402) but verified it was actually correct by watching the test interactively and seeing the pass here in the CI.