### PR TITLE
API Key: Add utility method for checking it is set

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -2085,4 +2085,17 @@ class Parsely {
 	public function api_key_is_missing() {
 		return ! $this->api_key_is_set();
 	}
+
+	/**
+	 * Get the API key if set.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @return string API key if set, or empty string if not.
+	 */
+	public function get_api_key() {
+		$options = $this->get_options();
+
+		return $this->api_key_is_set() ? $options['apikey'] : '';
+	}
 }

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -2057,4 +2057,32 @@ class Parsely {
 	public function convert_jsonld_to_parsely_type( $type ) {
 		return in_array( $type, $this->supported_jsonld_post_types ) ? 'post' : 'index';
 	}
+
+	/**
+	 * Determine if an API key is saved in the options.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @return bool True is API key is set, false if it is missing.
+	 */
+	public function api_key_is_set() {
+		$options = $this->get_options();
+
+		return (
+				isset( $options['apikey'] ) &&
+				is_string( $options['apikey'] ) &&
+				'' !== $options['apikey']
+		);
+	}
+
+	/**
+	 * Determine if an API key is not saved in the options.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @return bool True if API key is missing, false if it is set.
+	 */
+	public function api_key_is_missing() {
+		return ! $this->api_key_is_set();
+	}
 }

--- a/tests/OtherTest.php
+++ b/tests/OtherTest.php
@@ -622,4 +622,22 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 		$response = $should_display_admin_warning->invoke( self::$parsely );
 		self::assertFalse( $response );
 	}
+
+	/**
+	 * Check that utility methods for checking if the API key is set work correctly.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @covers \Parsely::api_key_is_set
+	 * @covers \Parsely::api_key_is_missing
+	 */
+	public function test_checking_API_key_is_set_or_not() {
+		self::set_options( array( 'apikey' => '' ) );
+		self::assertFalse( self::$parsely->api_key_is_set() );
+		self::assertTrue( self::$parsely->api_key_is_missing() );
+
+		self::set_options( array( 'apikey' => 'somekey' ) );
+		self::assertTrue( self::$parsely->api_key_is_set() );
+		self::assertFalse( self::$parsely->api_key_is_missing() );
+	}
 }

--- a/tests/OtherTest.php
+++ b/tests/OtherTest.php
@@ -587,6 +587,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * Test that test_display_admin_warning action returns a warning when there is no key
 	 *
 	 * @covers \Parsely::should_display_admin_warning
+	 * @uses \Parsely::get_options
 	 */
 	public function test_display_admin_warning_without_key() {
 		$should_display_admin_warning = self::getMethod( 'should_display_admin_warning' );
@@ -630,6 +631,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 *
 	 * @covers \Parsely::api_key_is_set
 	 * @covers \Parsely::api_key_is_missing
+	 * @uses \Parsely::get_options
 	 */
 	public function test_checking_API_key_is_set_or_not() {
 		self::set_options( array( 'apikey' => '' ) );
@@ -639,5 +641,21 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 		self::set_options( array( 'apikey' => 'somekey' ) );
 		self::assertTrue( self::$parsely->api_key_is_set() );
 		self::assertFalse( self::$parsely->api_key_is_missing() );
+	}
+
+	/**
+	 * Test the utility methods for retrieving the API key.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @covers \Parsely::get_api_key
+	 * @uses \Parsely::api_key_is_set
+	 * @uses \Parsely::get_options
+	 */
+	public function test_can_retrieve_API_key() {
+		self::set_options( array( 'apikey' => 'somekey' ) );
+		self::assertSame( 'somekey', self::$parsely->get_api_key() );
+		self::set_options( array( 'apikey' => '' ) );
+		self::assertSame( '', self::$parsely->get_api_key() );
 	}
 }


### PR DESCRIPTION
## Description
Add utility method for checking the API key is saved in the `parsely` options, and a second utility method for checking if it is missing.

Adds a third utility method for retrieving the API key.

Includes unit tests.

In the future, these methods may be moved to a Parsely_Options or similar class.

## Motivation and Context
These methods can be used by various other classes and methods to see if this key trigger of behaviour changes is available, and provides the key as needed.

Closes #395.

## How Has This Been Tested?
Integration tests pass, and work on #406 which utilises the new methods.

## Screenshots (if appropriate):

<img width="358" alt="Screenshot 2021-09-25 at 22 29 04" src="https://user-images.githubusercontent.com/88371/134787006-21202d22-1f9f-423d-a18a-59b6afb27593.png">

<img width="2549" alt="Screenshot 2021-09-26 at 00 02 26" src="https://user-images.githubusercontent.com/88371/134787983-95375900-89c0-4419-810a-a29a298173fa.png">

