### PR TITLE
Testcase: Allow getMethod() to use different class

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -127,12 +127,13 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * Get a method from the Parsely class. This should be used when trying to access a private method for testing.
 	 *
 	 * @param string $method_name Name of the method to get.
+	 * @param string $class       Name of the class the method is in. Can be passed as Foo::class.
 	 *
 	 * @return \ReflectionMethod
 	 * @throws \ReflectionException The method does not exist in the class.
 	 */
-	public static function getMethod( $method_name ) {
-		$class  = new \ReflectionClass( 'Parsely' );
+	public static function getMethod( $method_name, $class = 'Parsely' ) {
+		$class  = new \ReflectionClass( $class );
 		$method = $class->getMethod( $method_name );
 		$method->setAccessible( true );
 		return $method;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -127,13 +127,13 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * Get a method from the Parsely class. This should be used when trying to access a private method for testing.
 	 *
 	 * @param string $method_name Name of the method to get.
-	 * @param string $class       Name of the class the method is in. Can be passed as Foo::class.
+	 * @param string $class_name  Name of the class the method is in. Can be passed as Foo::class.
 	 *
 	 * @return \ReflectionMethod
 	 * @throws \ReflectionException The method does not exist in the class.
 	 */
-	public static function getMethod( $method_name, $class = 'Parsely' ) {
-		$class  = new \ReflectionClass( $class );
+	public static function getMethod( $method_name, $class_name = 'Parsely' ) {
+		$class  = new \ReflectionClass( $class_name );
 		$method = $class->getMethod( $method_name );
 		$method->setAccessible( true );
 		return $method;


### PR DESCRIPTION
## Description
The existing `Testcase::getMethod()` method made the assumption that only non-public methods in the `Parsely` class would need to be made available for testing with Reflection.

This updates the test utility method to allow non-public methods in other source classes to be reflected as well.

## Motivation and Context
As we move more logic out of the `Parsely` class (#96), then we need to be able to use test utility methods with other source classes as well.

## How Has This Been Tested?
Tested with PR #406 for Row_Actions. All existing (and new tests in the new PR) pass correctly.
