### PR TITLE
Split out row action link logic

### DIFF
--- a/src/UI/class-row-actions.php
+++ b/src/UI/class-row-actions.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Parsely row actions class
+ *
+ * @package Parsely
+ * @since 2.6.0
+ */
+
+namespace Parsely\UI;
+
+use Parsely;
+use WP_Post;
+
+/**
+ * Handle the post/page row actions.
+ *
+ * @since 2.6.0
+ */
+final class Row_Actions {
+	/**
+	 * Instance of Parsely class.
+	 *
+	 * @var Parsely
+	 */
+	private $parsely;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Parsely $parsely Instance of Parsely class.
+	 */
+	public function __construct( Parsely $parsely ) {
+		$this->parsely = $parsely;
+	}
+
+	/**
+	 * Register action and filter hook callbacks.
+	 *
+	 * @since 2.6.0
+	 */
+	public function run() {
+		/**
+		 * Filter whether row action links are enabled or not.
+		 *
+		 * @since 2.6.0
+		 *
+		 * @param bool $enabled True if enabled, false if not.
+		 */
+		if ( apply_filters( 'wp_parsely_enable_row_action_links', false ) ) {
+			add_filter( 'post_row_actions', array( $this, 'row_actions_add_parsely_link' ), 10, 2 );
+			add_filter( 'page_row_actions', array( $this, 'row_actions_add_parsely_link' ), 10, 2 );
+		}
+	}
+
+	/**
+	 * Include a link to the statistics page for an article in the wp-admin Posts List.
+	 *
+	 * If the post object is the "front page," this will include the main dashboard link instead.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @see https://developer.wordpress.org/reference/hooks/page_row_actions/
+	 * @see https://developer.wordpress.org/reference/hooks/post_row_actions/
+	 *
+	 * @param array<string, string> $actions The existing list of actions.
+	 * @param WP_Post               $post    The individual post object the actions apply to.
+	 *
+	 * @return array<string, string> The amended list of actions.
+	 */
+	public function row_actions_add_parsely_link( $actions, WP_Post $post ) {
+		if ( $this->cannot_show_parsely_link( $actions, $post ) ) {
+			return $actions;
+		}
+
+		$actions['find_in_parsely'] = $this->generate_link_to_parsely( $post );
+
+		return $actions;
+	}
+
+	/**
+	 * Determine whether Parse.ly row action link should be shown or not.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @param array   $actions Existing row actions.
+	 * @param WP_Post $post    Which post object or ID to check.
+	 * @return bool True if the link cannot be shown, false if the link can be shown.
+	 */
+	private function cannot_show_parsely_link( $actions, WP_Post $post ) {
+		return ! is_array( $actions ) ||
+			! Parsely::post_has_trackable_status( $post ) ||
+			! Parsely::post_has_viewable_type( $post ) ||
+			$this->parsely->api_key_is_missing();
+	}
+
+	/**
+	 * Generate the HTML link to Parse.ly.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @param WP_Post $post Which post object or ID to add link to.
+	 * @return string The HTML for the link to Parse.ly.
+	 */
+	private function generate_link_to_parsely( WP_Post $post ) {
+		return sprintf(
+			'<a href="%1$s" aria-label="%2$s">%3$s</a>',
+			esc_url( $this->generate_url( $post, $this->parsely->get_api_key() ) ),
+			esc_attr( $this->generate_aria_label_for_post( $post ) ),
+			esc_html__( 'Parse.ly&nbsp;Stats', 'wp-parsely' )
+		);
+	}
+
+	/**
+	 * Generate the URL for the link.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @param WP_Post $post   Which post object or ID to check.
+	 * @param string  $apikey API key or empty string.
+	 * @return string
+	 */
+	private function generate_url( WP_Post $post, $apikey ) {
+		$query_args = array(
+			'url'          => rawurlencode( get_permalink( $post ) ),
+			'utm_campaign' => 'wp-admin-posts-list',
+			'utm_medium'   => 'wp-parsely',
+			'utm_source'   => 'wp-admin',
+		);
+
+		$base_url = trailingslashit( 'https://dash.parsely.com/' . $apikey ) . 'find';
+
+		return add_query_arg( $query_args, $base_url );
+	}
+
+	/**
+	 * Generate ARIA label content.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @param WP_Post $post Which post object or ID to generate the ARIA label for.
+	 * @return string ARIA label content.
+	 */
+	private function generate_aria_label_for_post( $post ) {
+		return sprintf(
+			/* translators: Post title */
+			__( 'Go to Parse.ly stats for "%s"', 'wp-parsely' ),
+			$post->post_title
+		);
+	}
+}

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -117,11 +117,6 @@ class Parsely {
 		// phpcs:ignore WordPress.WP.CronInterval.CronSchedulesInterval
 		add_filter( 'cron_schedules', array( $this, 'wpparsely_add_cron_interval' ) );
 
-		if ( apply_filters( 'wp_parsely_enable_row_action_links', false ) ) {
-			add_filter( 'post_row_actions', array( $this, 'row_actions_add_parsely_link' ), 10, 2 );
-			add_filter( 'page_row_actions', array( $this, 'row_actions_add_parsely_link' ), 10, 2 );
-		}
-
 		add_action( 'parsely_bulk_metas_update', array( $this, 'bulk_update_posts' ) );
 		// inserting parsely code.
 		add_action( 'wp_head', array( $this, 'insert_parsely_page' ) );
@@ -136,61 +131,7 @@ class Parsely {
 	}
 
 	/**
-	 * Include a link to the statistics page for an article in the wp-admin Posts List.
-	 * If the post object is the "front page," this will include the main dashboard link instead.
-	 *
-	 * @see https://developer.wordpress.org/reference/hooks/page_row_actions/
-	 * @see https://developer.wordpress.org/reference/hooks/post_row_actions/
-	 * @param array<string, string> $actions The existing list of actions.
-	 * @param WP_Post               $post    The individual post object the actions apply to.
-	 * @return array<string, string> The amended list of actions.
-	 */
-	public function row_actions_add_parsely_link( $actions, $post ) {
-		if ( ! is_array( $actions ) ) {
-			return $actions;
-		}
-
-		if ( ! self::post_has_trackable_status( $post ) ) {
-			return $actions;
-		}
-
-		if ( ! self::post_has_viewable_type( $post ) ) {
-			return $actions;
-		}
-
-		$options = $this->get_options();
-		if ( $this->api_key_is_missing() ) {
-			return $actions;
-		}
-
-		$parsely_url = add_query_arg(
-			array(
-				'url'          => rawurlencode( get_permalink( $post ) ),
-				'utm_campaign' => 'wp-admin-posts-list',
-				'utm_medium'   => 'wp-parsely',
-				'utm_source'   => 'wp-admin',
-			),
-			trailingslashit( 'https://dash.parsely.com/' . $options['apikey'] ) . 'find'
-		);
-
-		$aria_label = sprintf(
-				/* translators: Post title */
-			__( 'Go to Parse.ly stats for "%s"', 'wp-parsely' ),
-			$post->post_title
-		);
-
-		$actions['find_in_parsely'] = sprintf(
-			'<a href="%1$s" aria-label="%2$s">%3$s</a>',
-			esc_url( $parsely_url ),
-			esc_attr( $aria_label ),
-			esc_html__( 'Parse.ly&nbsp;Stats', 'wp-parsely' )
-		);
-
-		return $actions;
-	}
-
-	/**
-	 * Adds 10 minute cron interval
+	 * Adds 10 minute cron interval.
 	 *
 	 * @param array $schedules WP schedules array.
 	 */
@@ -795,7 +736,7 @@ class Parsely {
 	/**
 	 * Display a dismissible admin warning if the current WordPress or PHP versions are below the required minimum for the 3.0 release of wp-parsely
 	 * We should get rid of this warning when we release 3.0
-	 * 
+	 *
 	 * @since 2.6.0
 	 */
 	public function display_admin_upgrade_warning() {

--- a/tests/UI/RowActionsTest.php
+++ b/tests/UI/RowActionsTest.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Row actions tests.
+ *
+ * @package Parsely
+ */
+
+namespace Parsely\Tests\UI;
+
+use Parsely;
+use Parsely\Tests\TestCase;
+use Parsely\UI\Row_Actions;
+
+/**
+ * Row actions tests.
+ *
+ * @since 2.6.0
+ */
+final class RowActionsTest extends TestCase {
+	/**
+	 * Internal variable.
+	 *
+	 * @var string $row_actions Holds the Row_Actions object.
+	 */
+	private static $row_actions;
+
+	/**
+	 * The setUp run before each test
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		self::$row_actions = new Row_Actions( new Parsely() );
+	}
+
+	/**
+	 * Check that run() method will not add hooks to add the row action links by default.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @covers \Parsely\UI\Row_Actions::__construct
+	 * @covers \Parsely\UI\Row_Actions::run
+	 * @group ui
+	 */
+	public function test_row_actions_class_will_not_add_row_actions_filter_when_enabling_filter_returns_false() {
+		// wp_parsely_enable_row_action_links is false by default.
+		self::$row_actions->run();
+
+		self::assertFalse( has_filter( 'post_row_actions', array( self::$row_actions, 'row_actions_add_parsely_link' ) ) );
+		self::assertFalse( has_filter( 'page_row_actions', array( self::$row_actions, 'row_actions_add_parsely_link' ) ) );
+	}
+
+	/**
+	 * Check that run() method will add hooks to add the row action links.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @covers \Parsely\UI\Row_Actions::__construct
+	 * @covers \Parsely\UI\Row_Actions::run
+	 * @group ui
+	 */
+	public function test_row_actions_class_will_add_row_actions_filter_when_enabling_filter_returns_true() {
+		add_filter( 'wp_parsely_enable_row_action_links', '__return_true' );
+		self::$row_actions->run();
+
+		self::assertNotFalse( has_filter( 'post_row_actions', array( self::$row_actions, 'row_actions_add_parsely_link' ) ) );
+		self::assertNotFalse( has_filter( 'page_row_actions', array( self::$row_actions, 'row_actions_add_parsely_link' ) ) );
+	}
+
+	/**
+	 * Test if logic for showing Parse.ly row action accounts for actions not being an array.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @covers \Parsely\UI\Row_Actions::cannot_show_parsely_link
+	 * @uses \Parsely\UI\Row_Actions::__construct
+	 * @uses \Parsely::api_key_is_set
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::post_has_viewable_type
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group ui
+	 */
+	public function test_can_correctly_determine_if_Parsely_link_can_be_shown_when_actions_are_an_array_or_not() {
+		$cannot_show_parsely_link = self::getMethod( 'cannot_show_parsely_link', Row_Actions::class );
+
+		$published_post = self::factory()->post->create_and_get();
+		self::set_options( array( 'apikey' => 'somekey' ) );
+
+		// Test if $actions are not an array.
+		self::assertTrue( $cannot_show_parsely_link->invokeArgs( self::$row_actions, array( 'not_on_array', $published_post ) ) );
+		self::assertFalse( $cannot_show_parsely_link->invokeArgs( self::$row_actions, array( array(), $published_post ) ) );
+	}
+
+	/**
+	 * Test if logic for showing Parse.ly row action accounts for post having trackable status.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @covers \Parsely\UI\Row_Actions::cannot_show_parsely_link
+	 * @uses \Parsely\UI\Row_Actions::__construct
+	 * @uses \Parsely::api_key_is_set
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::post_has_viewable_type
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group ui
+	 */
+	public function test_can_correctly_determine_if_Parsely_link_can_be_shown_when_post_has_trackable_status_or_not() {
+		$cannot_show_parsely_link = self::getMethod( 'cannot_show_parsely_link', Row_Actions::class );
+
+		$draft_post     = self::factory()->post->create_and_get( array( 'post_status' => 'draft' ) );
+		$published_post = self::factory()->post->create_and_get();
+
+		$actions = array();
+		self::set_options( array( 'apikey' => 'somekey' ) );
+
+		// Test if post does not have trackable status - only published posts are tracked by default.
+		self::assertTrue( $cannot_show_parsely_link->invokeArgs( self::$row_actions, array( $actions, $draft_post ) ) );
+		self::assertFalse( $cannot_show_parsely_link->invokeArgs( self::$row_actions, array( $actions, $published_post ) ) );
+	}
+
+	/**
+	 * Test if logic for showing Parse.ly row action accounts for post not having a viewable type.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @covers \Parsely\UI\Row_Actions::cannot_show_parsely_link
+	 * @uses \Parsely\UI\Row_Actions::__construct
+	 * @uses \Parsely::api_key_is_set
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::post_has_viewable_type
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group ui
+	 */
+	public function test_can_correctly_determine_if_Parsely_link_can_be_shown_when_post_is_viewable_or_not() {
+		$cannot_show_parsely_link = self::getMethod( 'cannot_show_parsely_link', Row_Actions::class );
+
+		$non_publicly_queryable_post = self::factory()->post->create_and_get( array( 'post_type' => 'parsely_tests_pt' ) );
+		$published_post              = self::factory()->post->create_and_get();
+
+		$actions = array();
+		self::set_options( array( 'apikey' => 'somekey' ) );
+
+		// Test if post is not viewable status.
+		self::assertTrue( $cannot_show_parsely_link->invokeArgs( self::$row_actions, array( $actions, $non_publicly_queryable_post ) ) );
+		self::assertFalse( $cannot_show_parsely_link->invokeArgs( self::$row_actions, array( $actions, $published_post ) ) );
+	}
+
+	/**
+	 * Test if logic for showing Parse.ly row action accounts for API key option being saved or not.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @covers \Parsely\UI\Row_Actions::cannot_show_parsely_link
+	 * @uses \Parsely\UI\Row_Actions::__construct
+	 * @uses \Parsely::api_key_is_set
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::post_has_viewable_type
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group ui
+	 */
+	public function test_can_correctly_determine_if_Parsely_link_can_be_shown_when_api_key_is_set_or_missing() {
+		$cannot_show_parsely_link = self::getMethod( 'cannot_show_parsely_link', Row_Actions::class );
+
+		$published_post = self::factory()->post->create_and_get();
+
+		$actions = array();
+
+		// Test if API key is not set.
+		self::set_options( array( 'apikey' => '' ) );
+		self::assertTrue( $cannot_show_parsely_link->invokeArgs( self::$row_actions, array( $actions, $published_post ) ) );
+
+		// Test with API key set.
+		self::set_options( array( 'apikey' => 'somekey' ) );
+		self::assertFalse( $cannot_show_parsely_link->invokeArgs( self::$row_actions, array( $actions, $published_post ) ) );
+	}
+
+	/**
+	 * Test if a row action is correctly not added when conditions are not good.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @covers \Parsely\UI\Row_Actions::__construct
+	 * @covers \Parsely\UI\Row_Actions::row_actions_add_parsely_link
+	 * @covers \Parsely\UI\Row_Actions::generate_aria_label_for_post
+	 * @covers \Parsely\UI\Row_Actions::generate_link_to_parsely
+	 * @covers \Parsely\UI\Row_Actions::generate_url
+	 * @uses \Parsely\UI\Row_Actions::cannot_show_parsely_link
+	 * @uses \Parsely::api_key_is_set
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::get_api_key
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::post_has_viewable_type
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group ui
+	 */
+	public function test_link_to_Parsely_is_not_added_to_row_actions_when_conditions_fail() {
+		// Insert a single post and set as global post.
+		// This post is a viewable type, with a trackable status (published).
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Foo1' ) );
+		$post    = get_post( $post_id );
+
+		// Existing actions is an array.
+		$existing_actions = array();
+
+		// Unset API key.
+		self::set_options( array( 'apikey' => '' ) );
+
+		// Guard clause catches, and original $actions is returned.
+		$actions = self::$row_actions->row_actions_add_parsely_link( $existing_actions, $post );
+		self::assertSame( $existing_actions, $actions );
+	}
+
+	/**
+	 * Test if a row action is correctly added.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @covers \Parsely\UI\Row_Actions::__construct
+	 * @covers \Parsely\UI\Row_Actions::row_actions_add_parsely_link
+	 * @covers \Parsely\UI\Row_Actions::generate_aria_label_for_post
+	 * @covers \Parsely\UI\Row_Actions::generate_link_to_parsely
+	 * @covers \Parsely\UI\Row_Actions::generate_url
+	 * @uses \Parsely\UI\Row_Actions::cannot_show_parsely_link
+	 * @uses \Parsely::api_key_is_set
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::get_api_key
+	 * @uses \Parsely::get_options
+	 * @uses \Parsely::post_has_trackable_status
+	 * @uses \Parsely::post_has_viewable_type
+	 * @uses \Parsely::update_metadata_endpoint
+	 * @group ui
+	 */
+	public function test_link_to_Parsely_is_added_to_row_actions() {
+		// Insert a single post and set as global post.
+		// This post is a viewable type, with a trackable status (published).
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Foo2' ) );
+		$post    = get_post( $post_id );
+
+		// Existing actions is an array.
+		$existing_actions = array();
+
+		// Set the API key.
+		self::set_options( array( 'apikey' => 'somekey' ) );
+
+		// All conditions for the guard clause have been met.
+		$actions = self::$row_actions->row_actions_add_parsely_link( $existing_actions, $post );
+		self::assertCount( 1, $actions );
+		self::assertArrayHasKey( 'find_in_parsely', $actions );
+
+		$url        = 'https://dash.parsely.com/somekey/find?url=http%3A%2F%2Fexample.org%2F%3Fp%3D' . $post_id . '&#038;utm_campaign=wp-admin-posts-list&#038;utm_medium=wp-parsely&#038;utm_source=wp-admin';
+		$aria_label = 'Go to Parse.ly stats for &quot;Foo2&quot;';
+		self::assertSame(
+			'<a href="' . $url . '" aria-label="' . $aria_label . '">Parse.ly&nbsp;Stats</a>',
+			$actions['find_in_parsely']
+		);
+	}
+}

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -25,6 +25,7 @@
 use Parsely\Integrations\Amp;
 use Parsely\Integrations\Facebook_Instant_Articles;
 use Parsely\Integrations\Integrations;
+use Parsely\UI\Row_Actions;
 
 if ( class_exists( 'Parsely' ) ) {
 	return;
@@ -44,11 +45,15 @@ add_action(
 
 // Until auto-loading happens, we need to include this file for tests as well.
 require __DIR__ . '/src/UI/class-plugins-actions.php';
+require __DIR__ . '/src/UI/class-row-actions.php';
 add_action(
 	'admin_init',
 	function() {
 		$GLOBALS['parsely_ui_plugins_actions'] = new Parsely\UI\Plugins_Actions();
 		$GLOBALS['parsely_ui_plugins_actions']->run();
+
+		$row_actions = new Row_Actions( $GLOBALS['parsely'] );
+		$row_actions->run();
 	}
 );
 


### PR DESCRIPTION
## Description
Splits out the logic that handles the row action logic that adds the "Parse.ly Stats" link on the list of posts and pages screens.

Builds upon #405 (which should also be merged before this one) which improves a test utility class to make it more flexible, which is then used in this PR.

Also builds upon the `feature/api_key_is_set_or_missing` branch which introduces some utility methods around the API key, which are used in this PR.

As such, #404 and #405 should both be merged first (either order of those two is fine), and when this PR is rebased on to `develop`, only the relevant code changes will be shown.

## Motivation and Context
The `Parsely` god class is too big, so moving logic to its own class makes it easier to maintain. The logic in the new class can be made into more granular methods and tests applied more easily.

See #96.

## How Has This Been Tested?
Visual checks and integration tests.

## Screenshots (if appropriate):
<img width="953" alt="Screenshot 2021-09-25 at 22 15 24" src="https://user-images.githubusercontent.com/88371/134786826-844ce03d-2bbf-4d16-99fb-146e6e989ff2.png">
<img width="2549" alt="Screenshot 2021-09-25 at 23 26 33" src="https://user-images.githubusercontent.com/88371/134787387-0725aa97-2c6c-4725-8cf8-df4129a90f7c.png">
