### PR TITLE
Feature/improve test environment

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,6 +44,8 @@ jobs:
             ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
             coverage: pcov
           - php: '8.1'
+            experimental: false
+          - php: '8.2'
             experimental: true
       fail-fast: false
     continue-on-error: ${{ matrix.experimental }}
@@ -65,10 +67,15 @@ jobs:
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-      - name: Install Composer dependencies
+      - name: Install Composer dependencies for PHP < 8.2
+        if: ${{ matrix.php < 8.2 }}
+        uses: ramsey/composer-install@v1
+
+      - name: Install Composer dependencies for PHP >= 8.2
+        if: ${{ matrix.php >= 8.2 }}
         uses: ramsey/composer-install@v1
         with:
-          composer-options: '${{ matrix.composer-options }}'
+          composer-options: --ignore-platform-reqs
 
       - name: Start MySQL Service
         run: sudo systemctl start mysql.service

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,19 +30,23 @@ jobs:
       # PHP 7.4 uses PHPUnit 9.5.10
       # PHP 8.0 uses PHPUnit 9.5.10
       # PHP 8.1 uses PHPUnit 9.5.10
+      # Keys:
+      # - coverage: Whether to run the tests with code coverage.
+      # - experimental: Whether the build is "allowed to fail".
       matrix:
         php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        experimental: [false]
         include:
+          # Separate out PHP 8.0 so it can run with code coverage.
           - php: '8.0'
-            # Ignore platform requirements, so that PHPUnit 7.5 can be installed on PHP 8.0 (and above).
-#            composer-options: '--ignore-platform-reqs'
+            experimental: false
             extensions: pcov
             ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
             coverage: pcov
-          # There is no PHP nightly. Due to https://github.com/sebastianbergmann/phpunit/issues/4575 this is never
-          # going to succeed as WordPress is hard-coded to only support PHPUnit 7.5, and then fix only appears
-          # in PHPUnit 8.5.14.
+          - php: '8.1'
+            experimental: true
       fail-fast: false
+    continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -58,15 +58,6 @@ jobs:
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
-      # Setup PCOV since we're using PHPUnit < 8 which has it integrated. Requires PHP 7.1.
-      # Ignore platform reqs to make it install on PHP 8.
-      # https://github.com/krakjoe/pcov-clobber
-#      - name: Setup PCOV
-#        if: ${{ matrix.php == 8.0 }}
-#        run: |
-#          composer require pcov/clobber --ignore-platform-reqs
-##          vendor/bin/pcov clobber
-
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -86,8 +86,6 @@ jobs:
       - name: Run integration tests (single site)
         if: ${{ matrix.php != 8.0 }}
         run: composer testwp
-      - name: Run integration tests (single site with code coverage)
+      - name: Run integration tests (multisite site with code coverage)
         if: ${{ matrix.php == 8.0 }}
         run: composer coveragewp-ci
-      - name: Run integration tests (multisite)
-        run: composer testwp-ms

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,12 +22,20 @@ jobs:
       WP_VERSION: latest
 
     strategy:
+      # PHP 5.6 uses PHPUnit 5.7.27
+      # PHP 7.0 uses PHPUnit 6.5.14
+      # PHP 7.1 uses PHPUnit 7.5.20
+      # PHP 7.2 uses PHPUnit 8.5.21
+      # PHP 7.3 uses PHPUnit 9.5.10
+      # PHP 7.4 uses PHPUnit 9.5.10
+      # PHP 8.0 uses PHPUnit 9.5.10
+      # PHP 8.1 uses PHPUnit 9.5.10
       matrix:
         php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
         include:
           - php: '8.0'
             # Ignore platform requirements, so that PHPUnit 7.5 can be installed on PHP 8.0 (and above).
-            composer-options: '--ignore-platform-reqs'
+#            composer-options: '--ignore-platform-reqs'
             extensions: pcov
             ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
             coverage: pcov
@@ -53,11 +61,11 @@ jobs:
       # Setup PCOV since we're using PHPUnit < 8 which has it integrated. Requires PHP 7.1.
       # Ignore platform reqs to make it install on PHP 8.
       # https://github.com/krakjoe/pcov-clobber
-      - name: Setup PCOV
-        if: ${{ matrix.php == 8.0 }}
-        run: |
-          composer require pcov/clobber --ignore-platform-reqs
-          vendor/bin/pcov clobber
+#      - name: Setup PCOV
+#        if: ${{ matrix.php == 8.0 }}
+#        run: |
+#          composer require pcov/clobber --ignore-platform-reqs
+##          vendor/bin/pcov clobber
 
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -88,6 +88,6 @@ jobs:
         run: composer testwp
       - name: Run integration tests (single site with code coverage)
         if: ${{ matrix.php == 8.0 }}
-        run: composer coverage-ci
+        run: composer coveragewp-ci
       - name: Run integration tests (multisite)
         run: composer testwp-ms

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -68,8 +68,8 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install Composer dependencies for PHP < 8.2
-          if: ${{ matrix.php < 8.2 }}
-          uses: ramsey/composer-install@v1
+        if: ${{ matrix.php < 8.2 }}
+        uses: ramsey/composer-install@v1
 
       - name: Install Composer dependencies for PHP >= 8.2
         if: ${{ matrix.php >= 8.2 }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -71,5 +71,4 @@ jobs:
           composer-options: '${{ matrix.composer-options }}'
 
       - name: Run unit tests
-        if: ${{ matrix.php != 8.0 }}
         run: composer test

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,6 +44,8 @@ jobs:
             ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
             coverage: pcov
           - php: '8.1'
+            experimental: false
+          - php: '8.2'
             experimental: true
       fail-fast: false
     continue-on-error: ${{ matrix.experimental }}
@@ -65,10 +67,15 @@ jobs:
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-      - name: Install Composer dependencies
+      - name: Install Composer dependencies for PHP < 8.2
+          if: ${{ matrix.php < 8.2 }}
+          uses: ramsey/composer-install@v1
+
+      - name: Install Composer dependencies for PHP >= 8.2
+        if: ${{ matrix.php >= 8.2 }}
         uses: ramsey/composer-install@v1
         with:
-          composer-options: '${{ matrix.composer-options }}'
+          composer-options: --ignore-platform-reqs
 
       - name: Run unit tests
         run: composer test

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: Unit Tests
 
 on:
   # Run on all pushes and on all pull requests.
@@ -70,17 +70,6 @@ jobs:
         with:
           composer-options: '${{ matrix.composer-options }}'
 
-      - name: Start MySQL Service
-        run: sudo systemctl start mysql.service
-
-      - name: Prepare environment for integration tests
-        run: composer prepare-ci
-
-      - name: Run integration tests (single site)
+      - name: Run unit tests
         if: ${{ matrix.php != 8.0 }}
-        run: composer testwp
-      - name: Run integration tests (single site with code coverage)
-        if: ${{ matrix.php == 8.0 }}
-        run: composer coverage-ci
-      - name: Run integration tests (multisite)
-        run: composer testwp-ms
+        run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /build/*.map
 .DS_Store
 .idea
+.phpunit.result.cache
 node_modules
 /build/logs/
 /build/coverage-html/

--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,17 @@
 	"scripts": {
 		"coverage": [
 			"@putenv WP_MULTISITE=1",
-			"@php ./vendor/bin/phpunit --coverage-html ./build/coverage-html"
+			"@php ./vendor/bin/phpunit --coverage-html ./build/coverage-html/unit -v"
+		],
+		"coveragewp": [
+			"@putenv WP_MULTISITE=1",
+			"@php ./vendor/bin/phpunit --coverage-html ./build/coverage-html/integration -c phpunit-integration.xml.dist -v"
 		],
 		"coverage-ci": [
-			"@php ./vendor/bin/phpunit"
+			"@php ./vendor/bin/phpunit -v"
+		],
+		"coveragewp-ci": [
+			"@php ./vendor/bin/phpunit -c phpunit-integration.xml.dist -v"
 		],
 		"cs": [
 			"@php ./vendor/bin/phpcs"

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,13 @@
 		"test-ms": [
 			"@putenv WP_MULTISITE=1",
 			"@composer test"
+		],
+		"testwp": [
+			"@php ./vendor/bin/phpunit --no-coverage -c phpunit-integration.xml.dist"
+		],
+		"testwp-ms": [
+			"@putenv WP_MULTISITE=1",
+			"@composer testwp"
 		]
 	},
 	"scripts-descriptions": {

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,14 @@
 		"wp-coding-standards/wpcs": "^2.3.0",
 		"yoast/wp-test-utils": "^1"
 	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		],
+		"files": [
+			"wp-parsely.php"
+		]
+	},
 	"autoload-dev": {
 		"psr-4": {
 			"Parsely\\Tests\\": "tests/"

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --checkstyle"
 		],
 		"prepare-ci": [
-			"bash bin/install-wp-tests.sh wordpress_test root root localhost latest"
+			"bash bin/install-wp-tests.sh wordpress_test root root localhost trunk"
 		],
 		"test": [
 			"@php ./vendor/bin/phpunit --no-coverage"

--- a/composer.json
+++ b/composer.json
@@ -47,9 +47,11 @@
 			"@php ./vendor/bin/phpunit --coverage-html ./build/coverage-html/integration -c phpunit-integration.xml.dist -v"
 		],
 		"coverage-ci": [
+			"@putenv WP_MULTISITE=1",
 			"@php ./vendor/bin/phpunit -v"
 		],
 		"coveragewp-ci": [
+			"@putenv WP_MULTISITE=1",
 			"@php ./vendor/bin/phpunit -c phpunit-integration.xml.dist -v"
 		],
 		"cs": [

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,9 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
-		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7",
 		"squizlabs/php_codesniffer": "^3.5",
 		"wp-coding-standards/wpcs": "^2.3.0",
-		"yoast/wp-test-utils": "0.2.2"
+		"yoast/wp-test-utils": "^1"
 	},
 	"autoload-dev": {
 		"psr-4": {

--- a/phpunit-integration.xml.dist
+++ b/phpunit-integration.xml.dist
@@ -2,7 +2,7 @@
 <phpunit
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
-	bootstrap="./tests/Unit/bootstrap.php"
+	bootstrap="./tests/Integration/bootstrap.php"
 	backupGlobals="false"
 	beStrictAboutCoversAnnotation="true"
 	beStrictAboutTestsThatDoNotTestAnything="false"
@@ -17,8 +17,8 @@
 		<server name="REMOTE_ADDR" value="127.0.0.1"/>
 	</php>
 	<testsuites>
-		<testsuite name="unit">
-			<directory>./tests/Unit</directory>
+		<testsuite name="integration">
+			<directory>./tests/Integration</directory>
 		</testsuite>
 	</testsuites>
 	<coverage>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
 	bootstrap="./tests/bootstrap.php"
 	backupGlobals="false"
 	beStrictAboutCoversAnnotation="true"
 	beStrictAboutTestsThatDoNotTestAnything="false"
 	colors="true"
 	forceCoversAnnotation="true"
+	testdox="true"
 	>
 	<php>
 		<server name="SERVER_PORT" value="80"/>
@@ -19,15 +20,10 @@
 			<directory>./tests/</directory>
 		</testsuite>
 	</testsuites>
-
-	<filter>
-		<whitelist>
+	<coverage>
+		<include>
 			<directory suffix=".php">src</directory>
 			<file>wp-parsely.php</file>
-		</whitelist>
-	</filter>
-
-	<logging>
-		<log type="coverage-clover" target="build/logs/clover.xml"/>
-	</logging>
+		</include>
+	</coverage>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
 	beStrictAboutCoversAnnotation="true"
 	beStrictAboutTestsThatDoNotTestAnything="false"
 	colors="true"
+	convertDeprecationsToExceptions="true"
 	forceCoversAnnotation="true"
 	testdox="true"
 	>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,5 +25,8 @@
 			<directory suffix=".php">src</directory>
 			<file>wp-parsely.php</file>
 		</include>
+		<report>
+			<clover outputFile="build/logs/clover.xml"/>
+		</report>
 	</coverage>
 </phpunit>

--- a/src/Integrations/class-facebook-instant-articles.php
+++ b/src/Integrations/class-facebook-instant-articles.php
@@ -37,14 +37,14 @@ final class Facebook_Instant_Articles implements Integration {
 	 * @return void
 	 */
 	public function insert_parsely_tracking( &$registry ) {
-		$options = get_option( \Parsely::OPTIONS_KEY );
-		if ( ! ( $options['apikey'] ) ) {
+		$parsely = new \Parsely();
+		if ( $parsely->api_key_is_missing() ) {
 			return;
 		}
 
 		$registry[ self::REGISTRY_IDENTIFIER ] = array(
 			'name'    => self::REGISTRY_DISPLAY_NAME,
-			'payload' => $this->get_embed_code( $options['apikey'] ),
+			'payload' => $this->get_embed_code( $parsely->get_api_key() ),
 		);
 	}
 

--- a/src/UI/class-plugins-actions.php
+++ b/src/UI/class-plugins-actions.php
@@ -21,7 +21,7 @@ class Plugins_Actions {
 	 * Register action and filter hook callbacks.
 	 */
 	public function run() {
-		add_filter( 'plugin_action_links_' . PARSELY_PLUGIN_BASENAME, array( $this, 'add_plugin_meta_links' ) );
+		add_filter( 'plugin_action_links_' . plugin_dir_path( PARSELY_FILE ) , array( $this, 'add_plugin_meta_links' ) );
 	}
 
 	/**

--- a/src/UI/class-plugins-actions.php
+++ b/src/UI/class-plugins-actions.php
@@ -21,7 +21,7 @@ class Plugins_Actions {
 	 * Register action and filter hook callbacks.
 	 */
 	public function run() {
-		add_filter( 'plugin_action_links_' . plugin_dir_path( PARSELY_FILE ) , array( $this, 'add_plugin_meta_links' ) );
+		add_filter( 'plugin_action_links_' . plugin_dir_path( PARSELY_FILE ), array( $this, 'add_plugin_meta_links' ) );
 	}
 
 	/**

--- a/src/UI/class-plugins-actions.php
+++ b/src/UI/class-plugins-actions.php
@@ -21,7 +21,7 @@ class Plugins_Actions {
 	 * Register action and filter hook callbacks.
 	 */
 	public function run() {
-		add_filter( 'plugin_action_links_' . plugin_dir_path( PARSELY_FILE ), array( $this, 'add_plugin_meta_links' ) );
+		add_filter( 'plugin_action_links_' . plugin_basename( PARSELY_FILE ), array( $this, 'add_plugin_meta_links' ) );
 	}
 
 	/**

--- a/src/class-parsely-recommended-widget.php
+++ b/src/class-parsely-recommended-widget.php
@@ -113,7 +113,7 @@ class Parsely_Recommended_Widget extends WP_Widget {
 			$instance['return_limit']
 		);
 
-		$reco_widget_script_asset = require PARSELY_PLUGIN_DIR . 'build/admin-page.asset.php';
+		$reco_widget_script_asset = require plugin_dir_path( PARSELY_FILE ) . 'build/admin-page.asset.php';
 
 		?>
 
@@ -131,7 +131,7 @@ class Parsely_Recommended_Widget extends WP_Widget {
 
 		wp_register_script(
 			'wp-parsely-recommended-widget',
-			PARSELY_PLUGIN_URL . 'build/recommended-widget.js',
+			plugin_dir_url( PARSELY_FILE ) . 'build/recommended-widget.js',
 			$reco_widget_script_asset['dependencies'],
 			PARSELY::get_asset_cache_buster(),
 			true

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -203,7 +203,7 @@ class Parsely {
 	 * Initialize parsely WordPress style
 	 */
 	public function wp_parsely_style_init() {
-		wp_register_style( 'wp-parsely-style', PARSELY_PLUGIN_URL . 'wp-parsely.css', array(), self::VERSION );
+		wp_register_style( 'wp-parsely-style', plugin_dir_url( PARSELY_FILE ) . 'wp-parsely.css', array(), self::VERSION );
 	}
 
 	/**
@@ -220,10 +220,10 @@ class Parsely {
 </style>
 ';
 
-		$admin_script_asset = require PARSELY_PLUGIN_DIR . 'build/admin-page.asset.php';
+		$admin_script_asset = require plugin_dir_path( PARSELY_FILE ) . 'build/admin-page.asset.php';
 		wp_enqueue_script(
 			'wp-parsely-admin',
-			PARSELY_PLUGIN_URL . 'build/admin-page.js',
+			plugin_dir_url( PARSELY_FILE ) . 'build/admin-page.js',
 			$admin_script_asset['dependencies'],
 			self::get_asset_cache_buster(),
 			true
@@ -257,7 +257,7 @@ class Parsely {
 			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-parsely' ) );
 		}
 
-		include PARSELY_PLUGIN_DIR . 'src/parsely-settings.php';
+		include plugin_dir_path( PARSELY_FILE ) . 'src/parsely-settings.php';
 	}
 
 	/**
@@ -863,7 +863,7 @@ class Parsely {
 
 		// Insert JSON-LD or repeated metas.
 		if ( 'json_ld' === $parsely_options['meta_type'] ) {
-			include PARSELY_PLUGIN_DIR . 'views/json-ld.php';
+			include plugin_dir_path( PARSELY_FILE ) . 'views/json-ld.php';
 		} else {
 			// Assume `meta_type` is `repeated_metas`.
 			$parsely_post_type = $this->convert_jsonld_to_parsely_type( $parsely_page['@type'] );
@@ -888,12 +888,12 @@ class Parsely {
 				$parsely_page_authors = array_filter( $parsely_page_authors, array( $this, 'filter_empty_and_not_string_from_array' ) );
 			}
 
-			include PARSELY_PLUGIN_DIR . 'views/repeated-metas.php';
+			include plugin_dir_path( PARSELY_FILE ) . 'views/repeated-metas.php';
 		}
 
 		// Add any custom metadata.
 		if ( isset( $parsely_page['custom_metadata'] ) ) {
-			include PARSELY_PLUGIN_DIR . 'views/custom-metadata.php';
+			include plugin_dir_path( PARSELY_FILE ) . 'views/custom-metadata.php';
 		}
 
 		echo '<!-- END Parse.ly -->' . "\n\n";
@@ -1311,10 +1311,10 @@ class Parsely {
 			true
 		);
 
-		$api_script_asset = require PARSELY_PLUGIN_DIR . 'build/init-api.asset.php';
+		$api_script_asset = require plugin_dir_path( PARSELY_FILE ) . 'build/init-api.asset.php';
 		wp_register_script(
 			'wp-parsely-api',
-			PARSELY_PLUGIN_URL . 'build/init-api.js',
+			plugin_dir_url( PARSELY_FILE ) . 'build/init-api.js',
 			$api_script_asset['dependencies'],
 			self::get_asset_cache_buster(),
 			true

--- a/tests/Integration/GetCurrentUrlTest.php
+++ b/tests/Integration/GetCurrentUrlTest.php
@@ -5,7 +5,7 @@
  * @package Parsely\Tests
  */
 
-namespace Parsely\Tests;
+namespace Parsely\Tests\Integration;
 
 use Parsely;
 

--- a/tests/Integration/Integrations/AmpTest.php
+++ b/tests/Integration/Integrations/AmpTest.php
@@ -5,11 +5,11 @@
  * @package Parsely\Tests\Integrations
  */
 
-namespace Parsely\Tests\Integrations;
+namespace Parsely\Tests\Integration\Integrations;
 
 use Parsely;
-use Parsely\Tests\TestCase;
 use Parsely\Integrations\Amp;
+use Parsely\Tests\Integration\TestCase;
 
 /**
  * Test AMP integration.

--- a/tests/Integration/Integrations/FacebookInstantArticlesTest.php
+++ b/tests/Integration/Integrations/FacebookInstantArticlesTest.php
@@ -5,11 +5,11 @@
  * @package Parsely\Tests\Integrations
  */
 
-namespace Parsely\Tests\Integrations;
+namespace Parsely\Tests\Integration\Integrations;
 
 use Parsely;
 use Parsely\Integrations\Facebook_Instant_Articles;
-use Parsely\Tests\TestCase;
+use Parsely\Tests\Integration\TestCase;
 
 /**
  * Test Facebook Instant Articles integration.

--- a/tests/Integration/Integrations/FacebookInstantArticlesTest.php
+++ b/tests/Integration/Integrations/FacebookInstantArticlesTest.php
@@ -51,7 +51,10 @@ final class FacebookInstantArticlesTest extends TestCase {
 	 *
 	 * @covers \Parsely\Integrations\Facebook_Instant_Articles::insert_parsely_tracking
 	 * @covers \Parsely\Integrations\Facebook_Instant_Articles::get_embed_code
-	 * @uses \Parsely::get_options()
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::api_key_is_set
+	 * @uses \Parsely::get_api_key
+	 * @uses \Parsely::get_options
 	 * @group fbia
 	 */
 	public function test_parsely_is_added_to_FBIA_registry() {

--- a/tests/Integration/Integrations/IntegrationsTest.php
+++ b/tests/Integration/Integrations/IntegrationsTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Integrations collection tests.
+ *
+ * @package Parsely\Tests\Integrations
+ */
+
+namespace Parsely\Tests\Unit\Integrations;
+
+use Parsely\Integrations\Integration;
+use Parsely\Integrations\Integrations;
+use ReflectionClass;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+/**
+ * Test plugin integrations collection class.
+ *
+ * todo: Instantiate and then try to register something that doesn't implement the Integration interface.
+ */
+final class IntegrationsTest extends TestCase {
+	/**
+	 * Check an integration can be added via a filter.
+	 *
+	 * @covers ::parsely_integrations
+	 * @uses \Parsely\Integrations\Amp::integrate
+	 * @uses \Parsely\Integrations\Facebook_Instant_Articles::integrate
+	 * @uses \Parsely\Integrations\Integrations::integrate
+	 * @uses \Parsely\Integrations\Integrations::register
+	 */
+	public function test_an_integration_can_be_registered_via_the_filter() {
+		add_action(
+			'wp_parsely_add_integration',
+			function( $integrations ) {
+				$integrations->register( 'fake', new FakeIntegration2() );
+
+				return $integrations;
+			}
+		);
+
+		$integrations = \parsely_integrations();
+
+		// Use Reflection to look inside the collection.
+		$reflector_property = ( new ReflectionClass( $integrations ) )->getProperty( 'integrations' );
+		$reflector_property->setAccessible( true );
+		$registered_integrations = $reflector_property->getValue( $integrations );
+
+		self::assertCount( 3, $registered_integrations );
+		self::assertSame( array( 'amp', 'fbia', 'fake' ), array_keys( $registered_integrations ) );
+
+		// Use filter to override existing key.
+		add_action(
+			'wp_parsely_add_integration',
+			function( $integrations ) {
+				$integrations->register( 'amp', new FakeIntegration2() );
+
+				return $integrations;
+			}
+		);
+
+		self::assertCount( 3, $registered_integrations );
+		self::assertSame( array( 'amp', 'fbia', 'fake' ), array_keys( $registered_integrations ) );
+	}
+
+}
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+/**
+ * Class FakeIntegration2
+ *
+ * @package Parsely\Tests\Integrations
+ */
+class FakeIntegration2 {
+	/**
+	 * Stub this method to avoid a fatal error.
+	 */
+	public function integrate() {
+	}
+}
+

--- a/tests/Integration/Integrations/IntegrationsTest.php
+++ b/tests/Integration/Integrations/IntegrationsTest.php
@@ -15,7 +15,7 @@ use Yoast\WPTestUtils\BrainMonkey\TestCase;
 /**
  * Test plugin integrations collection class.
  *
- * todo: Instantiate and then try to register something that doesn't implement the Integration interface.
+ * @todo: Instantiate and then try to register something that doesn't implement the Integration interface.
  */
 final class IntegrationsTest extends TestCase {
 	/**

--- a/tests/Integration/Integrations/IntegrationsTest.php
+++ b/tests/Integration/Integrations/IntegrationsTest.php
@@ -5,7 +5,7 @@
  * @package Parsely\Tests\Integrations
  */
 
-namespace Parsely\Tests\Unit\Integrations;
+namespace Parsely\Tests\Integration\Integrations;
 
 use Parsely\Integrations\Integration;
 use Parsely\Integrations\Integrations;

--- a/tests/Integration/Integrations/IntegrationsTest.php
+++ b/tests/Integration/Integrations/IntegrationsTest.php
@@ -7,10 +7,9 @@
 
 namespace Parsely\Tests\Integration\Integrations;
 
-use Parsely\Integrations\Integration;
 use Parsely\Integrations\Integrations;
+use Parsely\Tests\Integration\TestCase;
 use ReflectionClass;
-use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
 /**
  * Test plugin integrations collection class.

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -67,6 +67,8 @@ final class OtherTest extends TestCase {
 	 *
 	 * @covers \Parsely::register_js
 	 * @uses \Parsely::get_asset_cache_buster
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::api_key_is_set
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group insert-js
@@ -111,6 +113,8 @@ final class OtherTest extends TestCase {
 	 *
 	 * @covers \Parsely::load_js_tracker
 	 * @uses \Parsely::get_asset_cache_buster
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::api_key_is_set
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::post_has_trackable_status
 	 * @uses \Parsely::register_js
@@ -151,6 +155,8 @@ final class OtherTest extends TestCase {
 	 * Test the API init script enqueue.
 	 *
 	 * @covers \Parsely::load_js_api
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::api_key_is_set
 	 * @uses \Parsely::get_asset_cache_buster
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::register_js
@@ -190,6 +196,8 @@ final class OtherTest extends TestCase {
 	 * Test the API init script enqueue.
 	 *
 	 * @covers \Parsely::load_js_api
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::api_key_is_set
 	 * @uses \Parsely::get_asset_cache_buster
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::register_js
@@ -293,6 +301,8 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * Make sure users can log in.
 	 *
 	 * @covers \Parsely::load_js_tracker
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::api_key_is_set
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::parsely_is_user_logged_in
 	 * @group insert-js
@@ -447,6 +457,8 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * When it returns false, the tracking script should not be enqueued.
 	 *
 	 * @covers \Parsely::load_js_tracker
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::api_key_is_set
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::post_has_trackable_status
 	 * @uses \Parsely::update_metadata_endpoint
@@ -486,6 +498,8 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * @expectedDeprecated parsely_filter_insert_javascript
 	 *
 	 * @covers \Parsely::load_js_tracker
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::api_key_is_set
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::post_has_trackable_status
 	 * @uses \Parsely::update_metadata_endpoint
@@ -597,6 +611,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * Test that test_display_admin_warning action doesn't return a warning when there is a key
 	 *
 	 * @covers \Parsely::should_display_admin_warning
+	 * @uses \Parsely::get_options
 	 */
 	public function test_display_admin_warning_with_key() {
 		$should_display_admin_warning = self::getMethod( 'should_display_admin_warning' );

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -5,7 +5,7 @@
  * @package WordPress
  */
 
-namespace Parsely\Tests;
+namespace Parsely\Tests\Integration;
 
 /**
  * Catch-all class for testing.
@@ -46,17 +46,8 @@ final class OtherTest extends TestCase {
 	public function test_version_constant_is_a_semantic_version_string() {
 		self::assertMatchesRegularExpression(
 			'/^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/',
-			PARSELY_VERSION
+			\Parsely::VERSION
 		);
-	}
-
-	/**
-	 * Test class version.
-	 *
-	 * @coversNothing
-	 */
-	public function test_class_version() {
-		self::assertSame( PARSELY_VERSION, \Parsely::VERSION );
 	}
 
 	/**
@@ -68,7 +59,7 @@ final class OtherTest extends TestCase {
 	 * @uses \Parsely::get_options
 	 */
 	public function test_cache_buster() {
-		self::assertSame( PARSELY_VERSION, \Parsely::get_asset_cache_buster() );
+		self::assertSame( \Parsely::VERSION, \Parsely::get_asset_cache_buster() );
 	}
 
 	/**
@@ -159,7 +150,7 @@ final class OtherTest extends TestCase {
 		$output = ob_get_clean();
 
 		self::assertSame(
-			"<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=" . PARSELY_VERSION . "' id=\"parsely-cfg\"></script>\n",
+			"<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=" . \Parsely::VERSION . "' id=\"parsely-cfg\"></script>\n",
 			$output,
 			'Failed to confirm script tag was printed correctly'
 		);
@@ -252,7 +243,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 		);
 
 		self::assertStringContainsString(
-			"<script data-cfasync=\"false\" type='text/javascript' src='" . esc_url( PARSELY_PLUGIN_URL ) . 'build/init-api.js?ver=' . PARSELY_VERSION . "' id='wp-parsely-api-js'></script>",
+			"<script data-cfasync=\"false\" type='text/javascript' src='" . esc_url( PARSELY_PLUGIN_URL ) . 'build/init-api.js?ver=' . \Parsely::VERSION . "' id='wp-parsely-api-js'></script>",
 			$output,
 			'Failed to confirm script tag was printed correctly'
 		);
@@ -454,7 +445,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 		$output = ob_get_clean();
 
 		self::assertSame(
-			"<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=" . PARSELY_VERSION . "' id=\"parsely-cfg\"></script>\n",
+			"<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=" . \Parsely::VERSION . "' id=\"parsely-cfg\"></script>\n",
 			$output,
 			'Failed to confirm script tags were printed correctly'
 		);

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -63,15 +63,6 @@ final class OtherTest extends TestCase {
 	}
 
 	/**
-	 * Test plugin URL constant is defined and populated.
-	 *
-	 * @coversNothing
-	 */
-	public function test_plugin_url_constant() {
-		self::assertTrue( defined( 'PARSELY_PLUGIN_URL' ) && is_string( PARSELY_PLUGIN_URL ) && PARSELY_PLUGIN_URL !== '' );
-	}
-
-	/**
 	 * Test JavaScript registrations.
 	 *
 	 * @covers \Parsely::register_js
@@ -243,7 +234,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 		);
 
 		self::assertStringContainsString(
-			"<script data-cfasync=\"false\" type='text/javascript' src='" . esc_url( PARSELY_PLUGIN_URL ) . 'build/init-api.js?ver=' . \Parsely::VERSION . "' id='wp-parsely-api-js'></script>",
+			"<script data-cfasync=\"false\" type='text/javascript' src='" . esc_url( plugin_dir_url( PARSELY_FILE ) ) . 'build/init-api.js?ver=' . \Parsely::VERSION . "' id='wp-parsely-api-js'></script>",
 			$output,
 			'Failed to confirm script tag was printed correctly'
 		);

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -357,6 +357,8 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * Make sure users can log in to more than one site.
 	 *
 	 * @covers \Parsely::load_js_tracker
+	 * @uses \Parsely::api_key_is_missing
+	 * @uses \Parsely::api_key_is_set
 	 * @uses \Parsely::get_asset_cache_buster
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::parsely_is_user_logged_in

--- a/tests/Integration/RecommendedApiTest.php
+++ b/tests/Integration/RecommendedApiTest.php
@@ -14,7 +14,7 @@ use Parsely_Recommended_Widget;
  */
 final class RecommendedApiTest extends TestCase {
 	/**
-	 * Dataprovider for test_recommended_api_url().
+	 * Data provider for test_recommended_api_url().
 	 *
 	 * @return array[]
 	 */

--- a/tests/Integration/RecommendedApiTest.php
+++ b/tests/Integration/RecommendedApiTest.php
@@ -5,14 +5,14 @@
  * @package Parsely\Tests
  */
 
-namespace Parsely\Tests;
+namespace Parsely\Tests\Integration;
 
 use Parsely_Recommended_Widget;
 
 /**
  * Recommended Widget tests.
  */
-final class Recommended_API_Test extends TestCase {
+final class RecommendedApiTest extends TestCase {
 	/**
 	 * Dataprovider for test_recommended_api_url().
 	 *

--- a/tests/Integration/StructuredData/AuthorArchiveTest.php
+++ b/tests/Integration/StructuredData/AuthorArchiveTest.php
@@ -5,7 +5,7 @@
  * @package Parsely\Tests
  */
 
-namespace Parsely\Tests\StructuredData;
+namespace Parsely\Tests\Integration\StructuredData;
 
 /**
  * Structured Data Tests for author archives.

--- a/tests/Integration/StructuredData/BlogArchiveTest.php
+++ b/tests/Integration/StructuredData/BlogArchiveTest.php
@@ -5,7 +5,7 @@
  * @package Parsely\Tests
  */
 
-namespace Parsely\Tests\StructuredData;
+namespace Parsely\Tests\Integration\StructuredData;
 
 /**
  * Structured Data Tests for the blog page (archive).

--- a/tests/Integration/StructuredData/HomePageTest.php
+++ b/tests/Integration/StructuredData/HomePageTest.php
@@ -5,7 +5,7 @@
  * @package Parsely\Tests
  */
 
-namespace Parsely\Tests\StructuredData;
+namespace Parsely\Tests\Integration\StructuredData;
 
 /**
  * Structured Data Tests for the home page.

--- a/tests/Integration/StructuredData/NonPostTestCase.php
+++ b/tests/Integration/StructuredData/NonPostTestCase.php
@@ -5,14 +5,24 @@
  * @package Parsely\Tests
  */
 
-namespace Parsely\Tests\StructuredData;
+namespace Parsely\Tests\Integration\StructuredData;
 
-use Parsely\Tests\TestCase;
+use Parsely\Tests\Integration\TestCase;
 
 /**
  * Create a base class that all Structured Data Tests for non-posts should extend.
  */
 abstract class NonPostTestCase extends TestCase {
+	/**
+	 * The setUp run before each test
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Set the default options prior to each test.
+		TestCase::set_options();
+	}
+
 	/**
 	 * Utility method to check metadata properties correctly set.
 	 *

--- a/tests/Integration/StructuredData/SinglePageTest.php
+++ b/tests/Integration/StructuredData/SinglePageTest.php
@@ -5,7 +5,7 @@
  * @package Parsely\Tests
  */
 
-namespace Parsely\Tests\StructuredData;
+namespace Parsely\Tests\Integration\StructuredData;
 
 /**
  * Structured Data Tests for single Pages.

--- a/tests/Integration/StructuredData/SinglePostTest.php
+++ b/tests/Integration/StructuredData/SinglePostTest.php
@@ -5,9 +5,9 @@
  * @package Parsely\Tests
  */
 
-namespace Parsely\Tests\StructuredData;
+namespace Parsely\Tests\Integration\StructuredData;
 
-use Parsely\Tests\TestCase;
+use Parsely\Tests\Integration\TestCase;
 
 /**
  * Structured Data Tests for posts.
@@ -15,6 +15,16 @@ use Parsely\Tests\TestCase;
  * @see https://www.parse.ly/help/integration/jsonld
  */
 final class SinglePostTest extends TestCase {
+	/**
+	 * The setUp run before each test
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Set the default options prior to each test.
+		TestCase::set_options();
+	}
+
 	/**
 	 * Create a single post, and test the structured data.
 	 *

--- a/tests/Integration/StructuredData/TermArchiveTest.php
+++ b/tests/Integration/StructuredData/TermArchiveTest.php
@@ -5,7 +5,7 @@
  * @package Parsely\Tests
  */
 
-namespace Parsely\Tests\StructuredData;
+namespace Parsely\Tests\Integration\StructuredData;
 
 /**
  * Structured Data Tests for the term archives.

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -6,7 +6,7 @@
  * @license GPL-2.0-or-later
  */
 
-namespace Parsely\Tests;
+namespace Parsely\Tests\Integration;
 
 use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;
 

--- a/tests/Integration/UI/PluginsActionsTest.php
+++ b/tests/Integration/UI/PluginsActionsTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * UI Tests for the plugin actions
+ *
+ * @package Parsely\Tests\UI
+ */
+
+namespace Parsely\Tests\Integration\UI;
+
+use Parsely\Tests\Integration\TestCase;
+use Parsely\UI\Plugins_Actions;
+
+/**
+ * UI Tests for the plugin screen.
+ */
+final class PluginsActionsTest extends TestCase {
+	/**
+	 * Check that plugins screen will add a hook to change the plugin action links.
+	 *
+	 * @covers \Parsely\UI\Plugins_Actions::run
+	 * @group ui
+	 */
+	public function test_plugins_screen_has_filter_to_add_a_settings_action_link() {
+		$plugins_screen = new Plugins_Actions();
+		$plugins_screen->run();
+
+		self::assertNotFalse( has_filter( 'plugin_action_links_' . plugin_basename( PARSELY_FILE ), array( $plugins_screen, 'add_plugin_meta_links' ) ) );
+	}
+
+	/**
+	 * Check that plugins screen will add a hook to change the plugin action links.
+	 *
+	 * @covers \Parsely\UI\Plugins_Actions::run
+	 * @covers \Parsely\UI\Plugins_Actions::add_plugin_meta_links
+	 * @uses \Parsely::get_settings_url
+	 * @group ui
+	 */
+	public function test_plugins_screen_adds_a_settings_action_link() {
+		$actions = array();
+		$actions = ( new Plugins_Actions() )->add_plugin_meta_links( $actions );
+
+		self::assertCount( 1, $actions );
+	}
+}

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * PHPUnit bootstrap file
  *
- * @package wp-parsely
+ * @package Parsely
  */
 
 use Yoast\WPTestUtils\WPIntegration;

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -21,7 +21,7 @@ if ( ! $_tests_dir ) {
 if ( getenv( 'WP_PLUGIN_DIR' ) !== false ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
 } else {
-	define( 'WP_PLUGIN_DIR', dirname( dirname( __DIR__ ) ) );
+	define( 'WP_PLUGIN_DIR', dirname( dirname( dirname( __DIR__ ) ) ) );
 }
 
 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
@@ -29,7 +29,7 @@ $GLOBALS['wp_tests_options'] = array(
 	'active_plugins' => array( 'wp-parsely/wp-parsely.php' ),
 );
 
-require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
+require_once dirname( __DIR__ ) . '/../vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
 
 /*
  * Load WordPress, which will load the Composer autoload file, and load the MockObject autoloader after that.

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -44,3 +44,6 @@ if ( ! defined( 'WP_PLUGIN_DIR' ) || file_exists( WP_PLUGIN_DIR . '/wp-parsely/w
 // Include the Parsely custom test cases.
 require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/StructuredData/NonPostTestCase.php';
+
+define( 'PARSELY_VERSION', '123456.78.9' );
+define( 'PARSELY_FILE', __DIR__ . '/../../wp-parsely.php' );

--- a/tests/OtherTest.php
+++ b/tests/OtherTest.php
@@ -22,10 +22,10 @@ final class OtherTest extends TestCase {
 	/**
 	 * The setUp run before each test
 	 */
-	public function setUp() {
+	public function set_up() {
 		global $wp_scripts;
 
-		parent::setUp();
+		parent::set_up();
 
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wp_scripts    = new \WP_Scripts();
@@ -44,7 +44,7 @@ final class OtherTest extends TestCase {
 	 * @coversNothing
 	 */
 	public function test_version_constant_is_a_semantic_version_string() {
-		self::assertRegExp(
+		self::assertMatchesRegularExpression(
 			'/^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/',
 			PARSELY_VERSION
 		);
@@ -241,7 +241,7 @@ final class OtherTest extends TestCase {
 		$output = ob_get_clean();
 
 
-		self::assertContains(
+		self::assertStringContainsString(
 			"<script type='text/javascript' id='wp-parsely-api-js-extra'>
 /* <![CDATA[ */
 var wpParsely = {\"apikey\":\"blog.parsely.com\"};
@@ -251,7 +251,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 			'Failed to confirm "localized" data were embedded'
 		);
 
-		self::assertContains(
+		self::assertStringContainsString(
 			"<script data-cfasync=\"false\" type='text/javascript' src='" . esc_url( PARSELY_PLUGIN_URL ) . 'build/init-api.js?ver=' . PARSELY_VERSION . "' id='wp-parsely-api-js'></script>",
 			$output,
 			'Failed to confirm script tag was printed correctly'

--- a/tests/StructuredData/HomePageTest.php
+++ b/tests/StructuredData/HomePageTest.php
@@ -17,8 +17,8 @@ final class HomePageTest extends NonPostTestCase {
 	/**
 	 * Runs the routine before each test is executed.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		update_option( 'show_on_front', 'posts' );
 		delete_option( 'page_for_posts' );

--- a/tests/UI/PluginsActionsTest.php
+++ b/tests/UI/PluginsActionsTest.php
@@ -24,7 +24,7 @@ final class PluginsActionsTest extends TestCase {
 		$plugins_screen = new Plugins_Actions();
 		$plugins_screen->run();
 
-		self::assertNotFalse( has_filter( 'plugin_action_links_' . PARSELY_PLUGIN_BASENAME, array( $plugins_screen, 'add_plugin_meta_links' ) ) );
+		self::assertNotFalse( has_filter( 'plugin_action_links_' . plugin_dir_path( PARSELY_FILE ) , array( $plugins_screen, 'add_plugin_meta_links' ) ) );
 	}
 
 	/**

--- a/tests/UI/PluginsActionsTest.php
+++ b/tests/UI/PluginsActionsTest.php
@@ -24,7 +24,7 @@ final class PluginsActionsTest extends TestCase {
 		$plugins_screen = new Plugins_Actions();
 		$plugins_screen->run();
 
-		self::assertNotFalse( has_filter( 'plugin_action_links_' . plugin_dir_path( PARSELY_FILE ) , array( $plugins_screen, 'add_plugin_meta_links' ) ) );
+		self::assertNotFalse( has_filter( 'plugin_action_links_' . plugin_dir_path( PARSELY_FILE ), array( $plugins_screen, 'add_plugin_meta_links' ) ) );
 	}
 
 	/**

--- a/tests/Unit/Integrations/IntegrationsTest.php
+++ b/tests/Unit/Integrations/IntegrationsTest.php
@@ -14,8 +14,6 @@ use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
 /**
  * Test plugin integrations collection class.
- *
- * todo: Instantiate and then try to register something that doesn't implement the Integration interface.
  */
 final class IntegrationsTest extends TestCase {
 	/**

--- a/tests/Unit/Integrations/IntegrationsTest.php
+++ b/tests/Unit/Integrations/IntegrationsTest.php
@@ -2,10 +2,10 @@
 /**
  * Integrations collection tests.
  *
- * @package Parsely\Tests\Integrations
+ * @package Parsely\Tests\Unit
  */
 
-namespace Parsely\Tests\Integrations;
+namespace Parsely\Tests\Unit\Integrations;
 
 use Parsely\Integrations\Integration;
 use Parsely\Integrations\Integrations;
@@ -13,12 +13,9 @@ use ReflectionClass;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
 /**
- * Test integrations collection class.
- *
- * Despite the name, this is a Unit test!
+ * Test plugin integrations collection class.
  *
  * todo: Instantiate and then try to register something that doesn't implement the Integration interface.
- * todo: Check calling integrate will call integrate on all registered integrations.
  */
 final class IntegrationsTest extends TestCase {
 	/**
@@ -26,7 +23,7 @@ final class IntegrationsTest extends TestCase {
 	 *
 	 * @covers \Parsely\Integrations\Integrations::register
 	 */
-	public function test_an_integration_can_be_registered_to_new_integrations_object() {
+	public function test_an_integration_can_be_registered_to_a_new_Integrations_object() {
 		$integrations = new Integrations();
 
 		$integrations->register( 'class', FakeIntegration::class );
@@ -46,49 +43,6 @@ final class IntegrationsTest extends TestCase {
 
 		self::assertCount( 2, $registered_integrations );
 		self::assertSame( array( 'class', 'object' ), array_keys( $registered_integrations ) );
-	}
-
-	/**
-	 * Check an integration can be added via a filter.
-	 *
-	 * @covers ::parsely_integrations
-	 * @uses \Parsely\Integrations\Amp::integrate
-	 * @uses \Parsely\Integrations\Facebook_Instant_Articles::integrate
-	 * @uses \Parsely\Integrations\Integrations::integrate
-	 * @uses \Parsely\Integrations\Integrations::register
-	 */
-	public function test_an_integration_can_be_registered_via_the_filter() {
-		add_action(
-			'wp_parsely_add_integration',
-			function( $integrations ) {
-				$integrations->register( 'fake', new FakeIntegration2() );
-
-				return $integrations;
-			}
-		);
-
-		$integrations = parsely_integrations();
-
-		// Use Reflection to look inside the collection.
-		$reflector_property = ( new ReflectionClass( $integrations ) )->getProperty( 'integrations' );
-		$reflector_property->setAccessible( true );
-		$registered_integrations = $reflector_property->getValue( $integrations );
-
-		self::assertCount( 3, $registered_integrations );
-		self::assertSame( array( 'amp', 'fbia', 'fake' ), array_keys( $registered_integrations ) );
-
-		// Use filter to override existing key.
-		add_action(
-			'wp_parsely_add_integration',
-			function( $integrations ) {
-				$integrations->register( 'amp', new FakeIntegration2() );
-
-				return $integrations;
-			}
-		);
-
-		self::assertCount( 3, $registered_integrations );
-		self::assertSame( array( 'amp', 'fbia', 'fake' ), array_keys( $registered_integrations ) );
 	}
 
 	/**
@@ -112,7 +66,7 @@ final class IntegrationsTest extends TestCase {
 /**
  * Class FakeIntegration
  *
- * @package Parsely\Tests\Integrations
+ * @package Parsely\Tests\Unit
  */
 class FakeIntegration {
 }
@@ -120,7 +74,7 @@ class FakeIntegration {
 /**
  * Class FakeIntegration2
  *
- * @package Parsely\Tests\Integrations
+ * @package Parsely\Tests\Unit
  */
 class FakeIntegration2 {
 	/**

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+require_once dirname( __DIR__ ) . '/../vendor/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';
+require_once dirname( __DIR__ ) . '/../vendor/autoload.php';

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * PHPUnit bootstrap file
+ *
+ * @package Parsely
+ */
 
+/**
+ * Require BrainMonkey files and autoload the plugin code.
+ */
 require_once dirname( __DIR__ ) . '/../vendor/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';
 require_once dirname( __DIR__ ) . '/../vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,11 +33,11 @@ require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration
 
 // These two classes needed to satisfy code coverage checks with PHP 8.
 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound,Squiz.Commenting.ClassComment.Missing
-class PHP_Token_NAME_QUALIFIED extends PHP_Token {
-}
-// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound,Squiz.Commenting.ClassComment.Missing,Generic.Files.OneObjectStructurePerFile.MultipleFound
-class PHP_Token_NAME_FULLY_QUALIFIED extends PHP_Token {
-}
+//class PHP_Token_NAME_QUALIFIED extends PHP_Token {
+//}
+//// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound,Squiz.Commenting.ClassComment.Missing,Generic.Files.OneObjectStructurePerFile.MultipleFound
+//class PHP_Token_NAME_FULLY_QUALIFIED extends PHP_Token {
+//}
 
 /*
  * Load WordPress, which will load the Composer autoload file, and load the MockObject autoloader after that.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,14 +31,6 @@ $GLOBALS['wp_tests_options'] = array(
 
 require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
 
-// These two classes needed to satisfy code coverage checks with PHP 8.
-// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound,Squiz.Commenting.ClassComment.Missing
-//class PHP_Token_NAME_QUALIFIED extends PHP_Token {
-//}
-//// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound,Squiz.Commenting.ClassComment.Missing,Generic.Files.OneObjectStructurePerFile.MultipleFound
-//class PHP_Token_NAME_FULLY_QUALIFIED extends PHP_Token {
-//}
-
 /*
  * Load WordPress, which will load the Composer autoload file, and load the MockObject autoloader after that.
  */

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -42,6 +42,16 @@ add_action(
 	}
 );
 
+// Until auto-loading happens, we need to include this file for tests as well.
+require __DIR__ . '/src/UI/class-plugins-actions.php';
+add_action(
+	'admin_init',
+	function() {
+		$GLOBALS['parsely_ui_plugins_actions'] = new Parsely\UI\Plugins_Actions();
+		$GLOBALS['parsely_ui_plugins_actions']->run();
+	}
+);
+
 require __DIR__ . '/src/class-parsely-recommended-widget.php';
 
 add_action( 'widgets_init', 'parsely_recommended_widget_register' );

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -26,43 +26,23 @@ use Parsely\Integrations\Amp;
 use Parsely\Integrations\Facebook_Instant_Articles;
 use Parsely\Integrations\Integrations;
 
-// If this file is called directly, abort.
-if ( ! defined( 'WPINC' ) ) {
-	die;
-}
-
 if ( class_exists( 'Parsely' ) ) {
 	return;
 }
 
 define( 'PARSELY_VERSION', '2.6.0-alpha' );
+define( 'PARSELY_FILE', __FILE__ );
 
-if ( ! defined( 'PARSELY_PLUGIN_BASENAME' ) ) {
-	define( 'PARSELY_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
-}
-if ( ! defined( 'PARSELY_PLUGIN_DIR' ) ) {
-	define( 'PARSELY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-}
-if ( ! defined( 'PARSELY_PLUGIN_URL' ) ) {
-	define( 'PARSELY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-}
-
-require PARSELY_PLUGIN_DIR . 'src/class-parsely.php';
-
-$GLOBALS['parsely'] = new Parsely();
-$GLOBALS['parsely']->run();
-
-// Until auto-loading happens, we need to include this file for tests as well.
-require PARSELY_PLUGIN_DIR . 'src/UI/class-plugins-actions.php';
+require __DIR__ . '/src/class-parsely.php';
 add_action(
-	'admin_init',
+	'plugins_loaded',
 	function() {
-		$GLOBALS['parsely_ui_plugins_actions'] = new Parsely\UI\Plugins_Actions();
-		$GLOBALS['parsely_ui_plugins_actions']->run();
+		$GLOBALS['parsely'] = new Parsely();
+		$GLOBALS['parsely']->run();
 	}
 );
 
-require PARSELY_PLUGIN_DIR . 'src/class-parsely-recommended-widget.php';
+require __DIR__ . '/src/class-parsely-recommended-widget.php';
 
 add_action( 'widgets_init', 'parsely_recommended_widget_register' );
 /**


### PR DESCRIPTION
Apologies in advance - this has been a battle, so the commit granularity and scope of work is not up the desired standard, but the end result is worth it. I've left the mess of commits in the PR, but I **strongly** suggest that the PR be squashed during the merge so that it becomes a single commit.

## Description

- Uses WP trunk (soon to be 5.9) for integration tests. As per the [dev-note](https://make.wordpress.org/core/2021/09/27/changes-to-the-wordpress-core-php-test-suite/), the WP tests library has been updated.
- The update includes removing the restriction on PHPUnit 7.5 and supporting the latest PHPUnit (9.5).
- This in turns means that PHP 8.0 and later can now be safely tested against.
- The plugin was already using [PHPUnit-Polyfills](https://github.com/Yoast/PHPUnit-Polyfills/) via the [WP Test Utils](https://github.com/Yoast/wp-test-utils) package.
- An issue was discovered with testing against PHP 7.2, which meant the unit tests (based on `Yoast\WPTestUtils\BrainMonkey\TestCase`) needed to be separated out from the integration tests so that it could be run without requiring WordPress. This was done and fixes #179.
- The unit and integration tests both must also pass in PHP 8.1, and are allowed to fail (but still pass) in PHP 8.2 (nightly).
- Since WordPress isn't available for unit tests, then constants defined in the root plugin file can't use functions from WordPress (e.g. `plugin_path_dir()`, etc.), so the constants have been simplified in this and the files where they were being used.
- `convertDeprecationsToExceptions="true"` has been added to the PHPUnit configs which ensures it is even more stricter when it comes to PHP native deprecation notices (counts as a test fail), and lots of those were added to PHP 8.1. All the items highlighted by this have been fixed, but the small code coverage means it's likely that more will be found as new tests are added which call other parts of the plugin source files.
- The PHPUnit output now defaults to TestDox, which means that each test method is converted to English, making for some Agile documentation.
- Missing code coverage annotations from recent merges have been added.
- Assertions that are marked as deprecated for removal in future versions of PHPUnit have been replaced with their non-deprecated equivalents.
- A hack that was needed for running PHPUnit 7.5 with PHP 8 has been removed, as PHP 8 will now use PHPUnit 9.5.

## Motivation and Context
Being able to run tests on PHP 8.0 is essential, and to have them running on PHP 8.1 in preparation for the release is really useful. Not being restricted to PHPUnit 7.5 is wonderful.

## How Has This Been Tested?
Running local and CI tests.

## Screenshots (if appropriate):
We only have two unit tests, but now the structure is there to use BrainMonkey and mock PHP and WP functions, then we can try to add more unit tests that are quicker to run because they don't require an environment with a database and WordPress to be installed:
<img width="1406" alt="Screenshot 2021-09-27 at 23 47 52" src="https://user-images.githubusercontent.com/88371/134996679-329a48a1-5da9-4ecd-9a7d-6a62f9f0cef6.png">

Integration tests are run with code coverage (pcov) under PHP 8.0. Also note the use of testdox format which makes it more descriptive instead of a row of Pacman's favourite food...
<img width="1431" alt="Screenshot 2021-09-27 at 23 48 43" src="https://user-images.githubusercontent.com/88371/134996799-259b4778-cced-4aab-90ec-a043c1c8c13b.png">
