### PR TITLE
Increase minimum PHP and WP versions to 7.1 and 5.0

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,8 +13,8 @@ on:
 jobs:
   test:
     name: PHP ${{ matrix.php }}
-    # ubuntu-20.04 / ubuntu-latest includes MySQL 8, which has issues with older versions of PHP.
-    # ubuntu-18.04 includes PHP versions 7.1-8.0, but 5.6-7.1 are cached, so setup is about 5 seconds.
+    # ubuntu-20.04 / ubuntu-latest includes MySQL 8, which has issues with PHP < 7.4. Has PHP 7.4-8.0
+    # ubuntu-18.04 includes PHP versions 7.1-8.0.
     # See https://setup-php.com/i/452
     runs-on: ubuntu-18.04
 
@@ -22,8 +22,6 @@ jobs:
       WP_VERSION: latest
 
     strategy:
-      # PHP 5.6 uses PHPUnit 5.7.27
-      # PHP 7.0 uses PHPUnit 6.5.14
       # PHP 7.1 uses PHPUnit 7.5.20
       # PHP 7.2 uses PHPUnit 8.5.21
       # PHP 7.3 uses PHPUnit 9.5.10
@@ -34,7 +32,7 @@ jobs:
       # - coverage: Whether to run the tests with code coverage.
       # - experimental: Whether the build is "allowed to fail".
       matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php: ['7.1', '7.2', '7.3', '7.4']
         experimental: [false]
         include:
           # Separate out PHP 8.0 so it can run with code coverage.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,8 +13,8 @@ on:
 jobs:
   test:
     name: PHP ${{ matrix.php }}
-    # ubuntu-20.04 / ubuntu-latest includes MySQL 8, which has issues with older versions of PHP.
-    # ubuntu-18.04 includes PHP versions 7.1-8.0, but 5.6-7.1 are cached, so setup is about 5 seconds.
+    # ubuntu-20.04 / ubuntu-latest includes MySQL 8, which has issues with PHP < 7.4. Has PHP 7.4-8.0
+    # ubuntu-18.04 includes PHP versions 7.1-8.0.
     # See https://setup-php.com/i/452
     runs-on: ubuntu-18.04
 
@@ -22,8 +22,6 @@ jobs:
       WP_VERSION: latest
 
     strategy:
-      # PHP 5.6 uses PHPUnit 5.7.27
-      # PHP 7.0 uses PHPUnit 6.5.14
       # PHP 7.1 uses PHPUnit 7.5.20
       # PHP 7.2 uses PHPUnit 8.5.21
       # PHP 7.3 uses PHPUnit 9.5.10
@@ -34,7 +32,7 @@ jobs:
       # - coverage: Whether to run the tests with code coverage.
       # - experimental: Whether the build is "allowed to fail".
       matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php: ['7.1', '7.2', '7.3', '7.4']
         experimental: [false]
         include:
           # Separate out PHP 8.0 so it can run with code coverage.

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -32,7 +32,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 	<!-- For help in understanding this testVersion:
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.1-"/>
 
 	<!-- Rules: WordPress Coding Standards - see
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
@@ -41,7 +41,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="4.0"/>
+	<config name="minimum_supported_wp_version" value="5.0"/>
 
 	<!-- Rules: WordPress VIP - see
 		https://github.com/Automattic/VIP-Coding-Standards -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ When creating a new issue, please add specific steps to reproduce the problem, u
 
   This is important to maintain the integrity of the `package-lock.json` file (we use [`lockfileVersion` 2](https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json#lockfileversion)).
 
-- PHP - 5.6–8.0
+- PHP - 7.1–8.0
 
   There are multiple ways to install PHP on your operating system. You can check out the [official installation instructions from the PHP project's website.](https://www.php.net/manual/en/install.php)
 
@@ -40,7 +40,7 @@ When creating a new issue, please add specific steps to reproduce the problem, u
 
   The Parse.ly plugin includes several packages that require Composer, the PHP package manager. You can view the [composer.json](https://github.com/Parsely/wp-parsely/blob/develop/composer.json) file for a full list of packages. You can install Composer through Homebrew on macOS: `brew install composer`. If you don't have access to Homebrew you can view instructions for how to install Composer on the [Composer website](https://getcomposer.org/download/).
 
-- WordPress - 4.0
+- WordPress - 5.0
 
 ### Installing Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Parse.ly
 
 Stable tag: 3.0.0-alpha
-Requires at least: 4.0  
+Requires at least: 5.0  
 Tested up to: 5.8  
-Requires PHP: 5.6  
+Requires PHP: 7.1  
 License: GPLv2 or later  
 Tags: analytics, parse.ly, parsely, parsley  
 Contributors: parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, pauarge

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6",
+		"php": ">=7.1",
 		"composer/installers": "^1"
 	},
 	"require-dev": {

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -18,8 +18,8 @@
  * License:           GPL-2.0-or-later
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * GitHub Plugin URI: https://github.com/Parsely/wp-parsely
- * Requires PHP:      5.6
- * Requires WP:       4.0.0
+ * Requires PHP:      7.1
+ * Requires WP:       5.0.0
  */
 
 use Parsely\Integrations\Amp;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
We're increasing the minimum supported versions of PHP and WordPress. Version 3.0.0 of this plugin will require PHP 7.1 to work. It will also only work with WordPress 5.0.0 and above.

Other changes, like removal of admin notice, documentation about the increase, and syntax changes that are now permitted, will come in other PRs.

## Motivation and Context
See #390. Since this is a major version release, then backwards-incompatible changes around the expected environment are fine.

## How Has This Been Tested?
No change in CI result, other than fewer jobs now running.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)
