### PR TITLE
Remove post_has_viewable_type

### DIFF
--- a/src/UI/class-row-actions.php
+++ b/src/UI/class-row-actions.php
@@ -89,7 +89,7 @@ final class Row_Actions {
 	private function cannot_show_parsely_link( $actions, WP_Post $post ) {
 		return ! is_array( $actions ) ||
 			! Parsely::post_has_trackable_status( $post ) ||
-			! Parsely::post_has_viewable_type( $post ) ||
+			! is_post_type_viewable( $post->post_type ) ||
 			$this->parsely->api_key_is_missing();
 	}
 

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -908,27 +908,6 @@ class Parsely {
 	}
 
 	/**
-	 * Check if the post's type is "publicly queryable."
-	 *
-	 * @since 2.6.0
-	 *
-	 * @param int|WP_Post $post Which post object or ID to check.
-	 * @return bool Is the provided post's type considered "public."
-	 */
-	public static function post_has_viewable_type( $post ) {
-		if ( function_exists( 'is_post_type_viewable' ) ) {
-			return is_post_type_viewable( $post->post_type );
-		}
-
-		/**
-		 * `is_post_type_viewable` was added in WordPress 4.4
-		 * The rest of this function approximates it until we bump the plugin min. version above it.
-		 */
-		$post_type = get_post_type_object( $post->post_type );
-		return $post_type->publicly_queryable || ( $post_type->_builtin && $post_type->public );
-	}
-
-	/**
 	 * Creates parsely metadata object from post metadata.
 	 *
 	 * @param array   $parsely_options parsely_options array.

--- a/tests/UI/RowActionsTest.php
+++ b/tests/UI/RowActionsTest.php
@@ -78,7 +78,6 @@ final class RowActionsTest extends TestCase {
 	 * @uses \Parsely::api_key_is_missing
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::post_has_trackable_status
-	 * @uses \Parsely::post_has_viewable_type
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group ui
 	 */
@@ -104,7 +103,6 @@ final class RowActionsTest extends TestCase {
 	 * @uses \Parsely::api_key_is_missing
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::post_has_trackable_status
-	 * @uses \Parsely::post_has_viewable_type
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group ui
 	 */
@@ -133,7 +131,6 @@ final class RowActionsTest extends TestCase {
 	 * @uses \Parsely::api_key_is_missing
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::post_has_trackable_status
-	 * @uses \Parsely::post_has_viewable_type
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group ui
 	 */
@@ -162,7 +159,6 @@ final class RowActionsTest extends TestCase {
 	 * @uses \Parsely::api_key_is_missing
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::post_has_trackable_status
-	 * @uses \Parsely::post_has_viewable_type
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group ui
 	 */
@@ -198,7 +194,6 @@ final class RowActionsTest extends TestCase {
 	 * @uses \Parsely::get_api_key
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::post_has_trackable_status
-	 * @uses \Parsely::post_has_viewable_type
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group ui
 	 */
@@ -235,7 +230,6 @@ final class RowActionsTest extends TestCase {
 	 * @uses \Parsely::get_api_key
 	 * @uses \Parsely::get_options
 	 * @uses \Parsely::post_has_trackable_status
-	 * @uses \Parsely::post_has_viewable_type
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group ui
 	 */


### PR DESCRIPTION
## Description

This is a function that was introduced as a wrapper for WordPress < 4.4. Now that we're requiring 5.0 and above, we can drop it and use the built-in function directly.

Thanks @rinatkhaziev for suggesting this!

## Motivation and Context

https://github.com/Parsely/wp-parsely/issues/381

## How Has This Been Tested?

Quick visual test.

## Types of changes
Breaking change (fix or feature that would cause existing functionality to change)
