### PR TITLE
CI: Specify coverage: none where it is not needed

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,17 +33,20 @@ jobs:
       # - experimental: Whether the build is "allowed to fail".
       matrix:
         php: ['7.1', '7.2', '7.3', '7.4']
+        coverage: [none]
         experimental: [false]
         include:
-          # Separate out PHP 8.0 so it can run with code coverage.
+          # Separate out PHP 8.0, so it can run with code coverage.
           - php: '8.0'
-            experimental: false
+            coverage: pcov
             extensions: pcov
             ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
-            coverage: pcov
+            experimental: false
           - php: '8.1'
+            coverage: none
             experimental: false
           - php: '8.2'
+            coverage: none
             experimental: true
       fail-fast: false
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,17 +33,20 @@ jobs:
       # - experimental: Whether the build is "allowed to fail".
       matrix:
         php: ['7.1', '7.2', '7.3', '7.4']
+        coverage: [none]
         experimental: [false]
         include:
-          # Separate out PHP 8.0 so it can run with code coverage.
+          # Separate out PHP 8.0, so it can run with code coverage.
           - php: '8.0'
-            experimental: false
+            coverage: pcov
             extensions: pcov
             ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
-            coverage: pcov
+            experimental: false
           - php: '8.1'
+            coverage: none
             experimental: false
           - php: '8.2'
+            coverage: none
             experimental: true
       fail-fast: false
     continue-on-error: ${{ matrix.experimental }}


### PR DESCRIPTION
## Description
Include `coverage: none` where code coverage drivers are not needed for CI runs. This ensures that Xdebug and pcov are both disabled, and isn't reliant on the default of the underlying OS.

Re-ordered a couple of the keys to put them in a consistent order.

## Motivation and Context
Closes #418.

## How Has This Been Tested?
Ran the CI jobs and saw they still passed.