### PR TITLE
Add strict_types=1 declaration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,8 @@ To contribute an improvement to this project, fork the repo and open a pull requ
 
 The Parse.ly plugin uses the PHP_CodeSniffer tool that is installed through Composer. This plugin uses a [custom ruleset.](https://github.com/Parsely/wp-parsely/blob/develop/.phpcs.xml.dist)
 
+The plugin aims to use strong types where possible, so be sure to declare `strict_types=1` on new files, and include type definitions for parameters and return types that are compatible with the minimum version of PHP that this plugin supports.
+
 For JavaScript we recommend installing ESLint. This plugin includes a [.eslintrc](https://github.com/Parsely/wp-parsely/blob/develop/.eslintrc) file that defines our coding standards.
 
 ### Linting

--- a/src/Integrations/class-amp.php
+++ b/src/Integrations/class-amp.php
@@ -6,6 +6,8 @@
  * @since 2.6.0
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Integrations;
 
 /**

--- a/src/Integrations/class-facebook-instant-articles.php
+++ b/src/Integrations/class-facebook-instant-articles.php
@@ -6,6 +6,8 @@
  * @since 2.6.0
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Integrations;
 
 /**

--- a/src/Integrations/class-integration.php
+++ b/src/Integrations/class-integration.php
@@ -6,6 +6,8 @@
  * @since 2.6.0
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Integrations;
 
 /**

--- a/src/Integrations/class-integrations.php
+++ b/src/Integrations/class-integrations.php
@@ -6,6 +6,8 @@
  * @since   2.6.0
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Integrations;
 
 /**

--- a/src/UI/class-plugins-actions.php
+++ b/src/UI/class-plugins-actions.php
@@ -6,6 +6,8 @@
  * @since 2.6.0
  */
 
+declare(strict_types=1);
+
 namespace Parsely\UI;
 
 use Parsely;

--- a/src/UI/class-row-actions.php
+++ b/src/UI/class-row-actions.php
@@ -6,6 +6,8 @@
  * @since 2.6.0
  */
 
+declare(strict_types=1);
+
 namespace Parsely\UI;
 
 use Parsely;

--- a/src/class-parsely-recommended-widget.php
+++ b/src/class-parsely-recommended-widget.php
@@ -9,6 +9,8 @@
  * @subpackage Parse.ly
  */
 
+declare(strict_types=1);
+
 /**
  * This is the class for the recommended widget
  *

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -6,6 +6,8 @@
  * @since 2.5.0
  */
 
+declare(strict_types=1);
+
 /**
  * Holds most of the logic for the plugin.
  *

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1930,7 +1930,7 @@ class Parsely {
 	 */
 	public function get_current_url( $parsely_type = 'nonpost', $post_id = 0 ) {
 		if ( 'post' === $parsely_type ) {
-			$permalink = get_permalink( $post_id );
+			$permalink = (string) get_permalink( $post_id );
 
 			/**
 			 * Filters the permalink for a post.

--- a/src/parsely-settings.php
+++ b/src/parsely-settings.php
@@ -9,6 +9,8 @@
  * @subpackage Parse.ly
  */
 
+declare(strict_types=1);
+
 /* translators: %s: Plugin version */
 $parsely_version_string = sprintf( __( 'Version %s', 'wp-parsely' ), $this::VERSION );
 ?>

--- a/tests/Integration/GetCurrentUrlTest.php
+++ b/tests/Integration/GetCurrentUrlTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration;
 
 use Parsely;

--- a/tests/Integration/Integrations/AmpTest.php
+++ b/tests/Integration/Integrations/AmpTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests\Integrations
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration\Integrations;
 
 use Parsely;

--- a/tests/Integration/Integrations/FacebookInstantArticlesTest.php
+++ b/tests/Integration/Integrations/FacebookInstantArticlesTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests\Integrations
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration\Integrations;
 
 use Parsely;

--- a/tests/Integration/Integrations/IntegrationsTest.php
+++ b/tests/Integration/Integrations/IntegrationsTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests\Integrations
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration\Integrations;
 
 use Parsely\Integrations\Integrations;

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -5,6 +5,8 @@
  * @package WordPress
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration;
 
 /**

--- a/tests/Integration/RecommendedApiTest.php
+++ b/tests/Integration/RecommendedApiTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration;
 
 use Parsely_Recommended_Widget;

--- a/tests/Integration/StructuredData/AuthorArchiveTest.php
+++ b/tests/Integration/StructuredData/AuthorArchiveTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration\StructuredData;
 
 /**

--- a/tests/Integration/StructuredData/BlogArchiveTest.php
+++ b/tests/Integration/StructuredData/BlogArchiveTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration\StructuredData;
 
 /**

--- a/tests/Integration/StructuredData/HomePageTest.php
+++ b/tests/Integration/StructuredData/HomePageTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration\StructuredData;
 
 /**

--- a/tests/Integration/StructuredData/NonPostTestCase.php
+++ b/tests/Integration/StructuredData/NonPostTestCase.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration\StructuredData;
 
 use Parsely\Tests\Integration\TestCase;

--- a/tests/Integration/StructuredData/SinglePageTest.php
+++ b/tests/Integration/StructuredData/SinglePageTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration\StructuredData;
 
 /**

--- a/tests/Integration/StructuredData/SinglePostTest.php
+++ b/tests/Integration/StructuredData/SinglePostTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration\StructuredData;
 
 use Parsely\Tests\Integration\TestCase;

--- a/tests/Integration/StructuredData/TermArchiveTest.php
+++ b/tests/Integration/StructuredData/TermArchiveTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration\StructuredData;
 
 /**

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -6,6 +6,8 @@
  * @license GPL-2.0-or-later
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration;
 
 use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;

--- a/tests/Integration/UI/PluginsActionsTest.php
+++ b/tests/Integration/UI/PluginsActionsTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests\UI
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Integration\UI;
 
 use Parsely\Tests\Integration\TestCase;

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -5,6 +5,8 @@
  * @package Parsely
  */
 
+declare(strict_types=1);
+
 use Yoast\WPTestUtils\WPIntegration;
 
 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound

--- a/tests/StructuredData/CustomPostTypeArchiveTest.php
+++ b/tests/StructuredData/CustomPostTypeArchiveTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\StructuredData;
 
 /**

--- a/tests/StructuredData/CustomTaxonomyTermArchiveTest.php
+++ b/tests/StructuredData/CustomTaxonomyTermArchiveTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\StructuredData;
 
 /**

--- a/tests/UI/PluginsActionsTest.php
+++ b/tests/UI/PluginsActionsTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests\UI
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\UI;
 
 use Parsely\Tests\TestCase;

--- a/tests/UI/RowActionsTest.php
+++ b/tests/UI/RowActionsTest.php
@@ -5,6 +5,8 @@
  * @package Parsely
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\UI;
 
 use Parsely;

--- a/tests/Unit/Integrations/IntegrationsTest.php
+++ b/tests/Unit/Integrations/IntegrationsTest.php
@@ -5,6 +5,8 @@
  * @package Parsely\Tests\Unit
  */
 
+declare(strict_types=1);
+
 namespace Parsely\Tests\Unit\Integrations;
 
 use Parsely\Integrations\Integration;

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -5,6 +5,8 @@
  * @package Parsely
  */
 
+declare(strict_types=1);
+
 /**
  * Require BrainMonkey files and autoload the plugin code.
  */

--- a/views/custom-metadata.php
+++ b/views/custom-metadata.php
@@ -8,5 +8,6 @@
  * @license      GPL-2.0-or-later
  */
 
+declare(strict_types=1);
 ?>
 <meta name="parsely-metadata" content="<?php echo esc_attr( $parsely_page['custom_metadata'] ); ?>" />

--- a/views/json-ld.php
+++ b/views/json-ld.php
@@ -8,6 +8,7 @@
  * @license      GPL-2.0-or-later
  */
 
+declare(strict_types=1);
 ?>
 <script type="application/ld+json">
 <?php echo wp_json_encode( $parsely_page ) . "\n"; ?>

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -8,6 +8,8 @@
  * @license      GPL-2.0-or-later
  */
 
+declare(strict_types=1);
+
 foreach ( $parsely_metas as $parsely_meta_key => $parsely_meta_val ) {
 	printf(
 		'<meta name="%s" content="%s" />%s',

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -22,6 +22,8 @@
  * Requires WP:       5.0.0
  */
 
+declare(strict_types=1);
+
 use Parsely\Integrations\Amp;
 use Parsely\Integrations\Facebook_Instant_Articles;
 use Parsely\Integrations\Integrations;


### PR DESCRIPTION
## Description
On its own this doesn't do much, but when more type definitions are added, particularly scalar types, then PHP will handle the types without juggling them.

For choice of positioning below the file-level DocBlock, see https://www.php-fig.org/psr/psr-12/.
For lack of spaces inside the parentheses and around the `=`, see https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/.

## Motivation and Context
See #389.

## How Has This Been Tested?
Ran CI tests and quick visual inspection.
