### PR TITLE
Using PHP 7 null coalescing operator

### DIFF
--- a/src/class-parsely-recommended-widget.php
+++ b/src/class-parsely-recommended-widget.php
@@ -119,9 +119,9 @@ class Parsely_Recommended_Widget extends WP_Widget {
 
 		<div class="parsely-recommended-widget"
 			data-parsely-widget-display-author="<?php echo esc_attr( wp_json_encode( isset( $instance['display_author'] ) && $instance['display_author'] ) ); ?>"
-			data-parsely-widget-display-direction="<?php echo esc_attr( isset( $instance['display_direction'] ) ? $instance['display_direction'] : '' ); ?>"
+			data-parsely-widget-display-direction="<?php echo esc_attr( $instance['display_direction'] ?? '' ); ?>"
 			data-parsely-widget-api-url="<?php echo esc_url( $api_url ); ?>"
-			data-parsely-widget-img-display="<?php echo esc_attr( isset( $instance['img_src'] ) ? $instance['img_src'] : '' ); ?>"
+			data-parsely-widget-img-display="<?php echo esc_attr( $instance['img_src'] ?? '' ); ?>"
 			data-parsely-widget-permalink="<?php echo esc_url( get_permalink() ); ?>"
 			data-parsely-widget-personalized="<?php echo esc_attr( wp_json_encode( isset( $instance['personalize_results'] ) && $instance['personalize_results'] ) ); ?>"
 			data-parsely-widget-id="<?php echo esc_attr( $this->id ); ?>"

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -838,13 +838,13 @@ class Parsely {
 			}
 
 			$parsely_metas = array(
-				'title'     => isset( $parsely_page['headline'] ) ? $parsely_page['headline'] : null,
-				'link'      => isset( $parsely_page['url'] ) ? $parsely_page['url'] : null,
+				'title'     => $parsely_page['headline'] ?? null,
+				'link'      => $parsely_page['url'] ?? null,
 				'type'      => $parsely_post_type,
-				'image-url' => isset( $parsely_page['thumbnailUrl'] ) ? $parsely_page['thumbnailUrl'] : null,
-				'pub-date'  => isset( $parsely_page['datePublished'] ) ? $parsely_page['datePublished'] : null,
-				'section'   => isset( $parsely_page['articleSection'] ) ? $parsely_page['articleSection'] : null,
-				'tags'      => isset( $parsely_page['keywords'] ) ? $parsely_page['keywords'] : null,
+				'image-url' => $parsely_page['thumbnailUrl'] ?? null,
+				'pub-date'  => $parsely_page['datePublished'] ?? null,
+				'section'   => $parsely_page['articleSection'] ?? null,
+				'tags'      => $parsely_page['keywords'] ?? null,
 				'author'    => isset( $parsely_page['author'] ),
 			);
 			$parsely_metas = array_filter( $parsely_metas, array( $this, 'filter_empty_and_not_string_from_array' ) );
@@ -1423,12 +1423,8 @@ class Parsely {
 		$options        = $this->get_options();
 		$name           = $args['option_key'];
 		$select_options = $args['select_options'];
-		if ( isset( $args['multiple'] ) ) {
-			$multiple = $args['multiple'];
-		} else {
-			$multiple = false;
-		}
-		$selected = isset( $options[ $name ] ) ? $options[ $name ] : null;
+		$multiple       = $args['multiple'] ?? false;
+		$selected = $options[ $name ] ?? null;
 		$id       = esc_attr( $name );
 		$name     = self::OPTIONS_KEY . "[$id]";
 
@@ -1547,8 +1543,8 @@ class Parsely {
 	public function print_text_tag( $args ) {
 		$options       = $this->get_options();
 		$name          = $args['option_key'];
-		$value         = isset( $options[ $name ] ) ? $options[ $name ] : '';
-		$optional_args = isset( $args['optional_args'] ) ? $args['optional_args'] : array();
+		$value         = $options[ $name ] ?? '';
+		$optional_args = $args['optional_args'] ?? array();
 		$id            = esc_attr( $name );
 		$name          = self::OPTIONS_KEY . "[$id]";
 		$value         = esc_attr( $value );

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1424,9 +1424,9 @@ class Parsely {
 		$name           = $args['option_key'];
 		$select_options = $args['select_options'];
 		$multiple       = $args['multiple'] ?? false;
-		$selected = $options[ $name ] ?? null;
-		$id       = esc_attr( $name );
-		$name     = self::OPTIONS_KEY . "[$id]";
+		$selected       = $options[ $name ] ?? null;
+		$id             = esc_attr( $name );
+		$name           = self::OPTIONS_KEY . "[$id]";
 
 		if ( isset( $args['help_text'] ) ) {
 			echo '<div class="parsely-form-controls" data-has-help-text="true">';


### PR DESCRIPTION
## Description

This PR uses the null coalescing operator `??` [introduced in PHP 7](https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op) in the parts of the code where `isset...` was being used. 

## Motivation and Context

Clearer and more concise code.

## How Has This Been Tested?

Running the plugin normally.

## Screenshots (if appropriate):

## Types of changes
Breaking change (fix or feature that would cause existing functionality to change)
