### PR TITLE
Tests: Stop using deprecated setMethods method

### DIFF
--- a/tests/Unit/Integrations/IntegrationsTest.php
+++ b/tests/Unit/Integrations/IntegrationsTest.php
@@ -52,7 +52,13 @@ final class IntegrationsTest extends TestCase {
 	 * @uses \Parsely\Integrations\Integrations::register
 	 */
 	public function test_registered_integrations_have_their_integrate_method_called(): void {
-		$mock_integration = $this->getMockBuilder( Integration::class )->onlyMethods( array( 'integrate' ) )->getMock();
+		$mock_builder = $this->getMockBuilder( Integration::class );
+		// See https://github.com/Parsely/wp-parsely/issues/426.
+		if ( method_exists( $mock_builder, 'onlyMethods' ) ) {
+			$mock_integration = $mock_builder->onlyMethods( array( 'integrate' ) )->getMock();
+		} else {
+			$mock_integration = $mock_builder->setMethods( array( 'integrate' ) )->getMock();
+		}
 		$mock_integration->expects( $this->once() )->method( 'integrate' );
 
 		$integrations = new Integrations();

--- a/tests/Unit/Integrations/IntegrationsTest.php
+++ b/tests/Unit/Integrations/IntegrationsTest.php
@@ -52,7 +52,7 @@ final class IntegrationsTest extends TestCase {
 	 * @uses \Parsely\Integrations\Integrations::register
 	 */
 	public function test_registered_integrations_have_their_integrate_method_called(): void {
-		$mock_integration = $this->getMockBuilder( Integration::class )->setMethods( array( 'integrate' ) )->getMock();
+		$mock_integration = $this->getMockBuilder( Integration::class )->onlyMethods( array( 'integrate' ) )->getMock();
 		$mock_integration->expects( $this->once() )->method( 'integrate' );
 
 		$integrations = new Integrations();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use a different MockBuilder function for mocking particular SUT methods.

## Motivation and Context
`PHPUnit\Framework\MockObject\MockBuilder::setMethods()` is deprecated from PHPUnit 8, and will be removed in PHPUnit 10. The replacement is `onlyMethods()`, which was added in PHPUnit 8.

Ideally, PHPUnit-Pollyfills would handle this for PHPUnit 7, but right now it's not supported, so this PR includes a simple workaround.

Closes #426.


## How Has This Been Tested?
Ran the CI tests. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
