### PR TITLE
Add return type declarations

### DIFF
--- a/src/Integrations/class-amp.php
+++ b/src/Integrations/class-amp.php
@@ -20,8 +20,10 @@ class Amp implements Integration {
 	 * Apply the hooks that integrate the plugin or theme with the Parse.ly plugin.
 	 *
 	 * @since 2.6.0
+	 *
+	 * @return void
 	 */
-	public function integrate() {
+	public function integrate(): void {
 		if ( defined( 'AMP__VERSION' ) ) {
 			add_action( 'template_redirect', array( $this, 'add_actions' ) );
 		}
@@ -38,7 +40,7 @@ class Amp implements Integration {
 	 *
 	 * @return bool True is an AMP request, false otherwise.
 	 */
-	public function is_amp_request() {
+	public function is_amp_request(): bool {
 		return function_exists( 'amp_is_request' ) && amp_is_request();
 	}
 
@@ -49,7 +51,7 @@ class Amp implements Integration {
 	 *
 	 * @return bool True is an AMP request and not disabled, false otherwise.
 	 */
-	public function can_handle_amp_request() {
+	public function can_handle_amp_request(): bool {
 		$options = get_option( \Parsely::OPTIONS_KEY );
 
 		return $this->is_amp_request() && is_array( $options ) && ! $options['disable_amp'];
@@ -59,8 +61,10 @@ class Amp implements Integration {
 	 * Add AMP actions.
 	 *
 	 * @since 2.6.0
+	 *
+	 * @return void
 	 */
-	public function add_actions() {
+	public function add_actions(): void {
 		if ( $this->can_handle_amp_request() ) {
 			add_filter( 'amp_post_template_analytics', array( $this, 'register_parsely_for_amp_analytics' ) );
 			add_filter( 'amp_analytics_entries', array( $this, 'register_parsely_for_amp_native_analytics' ) );
@@ -75,7 +79,7 @@ class Amp implements Integration {
 	 * @param array $analytics The analytics registry.
 	 * @return array The analytics registry.
 	 */
-	public function register_parsely_for_amp_analytics( $analytics ) {
+	public function register_parsely_for_amp_analytics( $analytics ): array {
 		$options = get_option( \Parsely::OPTIONS_KEY );
 
 		if ( empty( $options['apikey'] ) ) {
@@ -103,7 +107,7 @@ class Amp implements Integration {
 	 * @param array $analytics The analytics registry.
 	 * @return array The analytics registry.
 	 */
-	public function register_parsely_for_amp_native_analytics( $analytics ) {
+	public function register_parsely_for_amp_native_analytics( $analytics ): array {
 		$options = get_option( \Parsely::OPTIONS_KEY );
 
 		if ( ! empty( $options['disable_amp'] ) && true === $options['disable_amp'] ) {

--- a/src/Integrations/class-facebook-instant-articles.php
+++ b/src/Integrations/class-facebook-instant-articles.php
@@ -23,8 +23,10 @@ final class Facebook_Instant_Articles implements Integration {
 	 * Apply the hooks that integrate the plugin or theme with the Parse.ly plugin.
 	 *
 	 * @since 2.6.0
+	 *
+	 * @return void
 	 */
-	public function integrate() {
+	public function integrate(): void {
 		if ( defined( 'IA_PLUGIN_VERSION' ) ) {
 			add_action( 'instant_articles_compat_registry_analytics', array( $this, 'insert_parsely_tracking' ) );
 		}

--- a/src/Integrations/class-integration.php
+++ b/src/Integrations/class-integration.php
@@ -21,5 +21,5 @@ interface Integration {
 	 *
 	 * @since 2.6.0
 	 */
-	public function integrate();
+	public function integrate(): void;
 }

--- a/src/Integrations/class-integrations.php
+++ b/src/Integrations/class-integrations.php
@@ -33,8 +33,9 @@ class Integrations {
 	 * @param string        $key             A unique identifier for the integration.
 	 * @param string|object $class_or_object Fully-qualified class name, or an instantiated object.
 	 *                             If a class name is passed, it will be instantiated.
+	 * @return void
 	 */
-	public function register( $key, $class_or_object ) {
+	public function register( $key, $class_or_object ): void {
 		// If a Foo::class or other FQCN is passed, instantiate it.
 		if ( ! is_object( $class_or_object ) ) {
 			$class_or_object = new $class_or_object();
@@ -46,8 +47,10 @@ class Integrations {
 	 * Integrate each integration by calling the method that does the add_action() and add_filter() calls.
 	 *
 	 * @since 2.6.0
+	 *
+	 * @return void
 	 */
-	public function integrate() {
+	public function integrate(): void {
 		foreach ( $this->integrations as $integration ) {
 			$integration->integrate();
 		}

--- a/src/UI/class-plugins-actions.php
+++ b/src/UI/class-plugins-actions.php
@@ -21,8 +21,10 @@ class Plugins_Actions {
 
 	/**
 	 * Register action and filter hook callbacks.
+	 *
+	 * @return void
 	 */
-	public function run() {
+	public function run(): void {
 		add_filter( 'plugin_action_links_' . plugin_basename( PARSELY_FILE ), array( $this, 'add_plugin_meta_links' ) );
 	}
 
@@ -32,8 +34,9 @@ class Plugins_Actions {
 	 * @param array $actions An array of plugin action links. By default, this can include 'activate',
 	 *                       'deactivate', and 'delete'. With Multisite active this can also include
 	 *                       'network_active' and 'network_only' items.
+	 * @return array
 	 */
-	public function add_plugin_meta_links( $actions ) {
+	public function add_plugin_meta_links( $actions ): array {
 		$settings_link = sprintf(
 			'<a href="%s">%s</a>',
 			esc_url( Parsely::get_settings_url() ),

--- a/src/UI/class-row-actions.php
+++ b/src/UI/class-row-actions.php
@@ -39,8 +39,10 @@ final class Row_Actions {
 	 * Register action and filter hook callbacks.
 	 *
 	 * @since 2.6.0
+	 *
+	 * @return void
 	 */
-	public function run() {
+	public function run(): void {
 		/**
 		 * Filter whether row action links are enabled or not.
 		 *
@@ -69,7 +71,7 @@ final class Row_Actions {
 	 *
 	 * @return array<string, string> The amended list of actions.
 	 */
-	public function row_actions_add_parsely_link( $actions, WP_Post $post ) {
+	public function row_actions_add_parsely_link( $actions, WP_Post $post ): array {
 		if ( $this->cannot_show_parsely_link( $actions, $post ) ) {
 			return $actions;
 		}
@@ -88,7 +90,7 @@ final class Row_Actions {
 	 * @param WP_Post $post    Which post object or ID to check.
 	 * @return bool True if the link cannot be shown, false if the link can be shown.
 	 */
-	private function cannot_show_parsely_link( $actions, WP_Post $post ) {
+	private function cannot_show_parsely_link( $actions, WP_Post $post ): bool {
 		return ! is_array( $actions ) ||
 			! Parsely::post_has_trackable_status( $post ) ||
 			! is_post_type_viewable( $post->post_type ) ||
@@ -103,7 +105,7 @@ final class Row_Actions {
 	 * @param WP_Post $post Which post object or ID to add link to.
 	 * @return string The HTML for the link to Parse.ly.
 	 */
-	private function generate_link_to_parsely( WP_Post $post ) {
+	private function generate_link_to_parsely( WP_Post $post ): string {
 		return sprintf(
 			'<a href="%1$s" aria-label="%2$s">%3$s</a>',
 			esc_url( $this->generate_url( $post, $this->parsely->get_api_key() ) ),
@@ -121,7 +123,7 @@ final class Row_Actions {
 	 * @param string  $apikey API key or empty string.
 	 * @return string
 	 */
-	private function generate_url( WP_Post $post, $apikey ) {
+	private function generate_url( WP_Post $post, $apikey ): string {
 		$query_args = array(
 			'url'          => rawurlencode( get_permalink( $post ) ),
 			'utm_campaign' => 'wp-admin-posts-list',
@@ -142,7 +144,7 @@ final class Row_Actions {
 	 * @param WP_Post $post Which post object or ID to generate the ARIA label for.
 	 * @return string ARIA label content.
 	 */
-	private function generate_aria_label_for_post( $post ) {
+	private function generate_aria_label_for_post( $post ): string {
 		return sprintf(
 			/* translators: Post title */
 			__( 'Go to Parse.ly stats for "%s"', 'wp-parsely' ),

--- a/src/class-parsely-recommended-widget.php
+++ b/src/class-parsely-recommended-widget.php
@@ -19,11 +19,7 @@ declare(strict_types=1);
  */
 class Parsely_Recommended_Widget extends WP_Widget {
 	/**
-	 * This is the constructor function
-	 *
-	 * @category   Function
-	 * @package    WordPress
-	 * @subpackage Parse.ly
+	 * This is the constructor function.
 	 */
 	public function __construct() {
 		parent::__construct(
@@ -56,7 +52,7 @@ class Parsely_Recommended_Widget extends WP_Widget {
 	 * @param int    $return_limit     Number of records to retrieve; defaults to "10".
 	 * @return string API URL.
 	 */
-	public function get_api_url( $api_key, $published_within, $sort, $boost, $return_limit ) {
+	public function get_api_url( $api_key, $published_within, $sort, $boost, $return_limit ): string {
 		$related_api_endpoint = 'https://api.parsely.com/v2/related';
 
 		$query_args = array(
@@ -79,13 +75,11 @@ class Parsely_Recommended_Widget extends WP_Widget {
 	/**
 	 * This is the widget function
 	 *
-	 * @category   Function
-	 * @package    WordPress
-	 * @subpackage Parse.ly
 	 * @param array $args Widget Arguments.
 	 * @param array $instance Values saved to the db.
+	 * @return void
 	 */
-	public function widget( $args, $instance ) {
+	public function widget( $args, $instance ): void {
 		if ( ! $this->api_key_and_secret_are_populated() ) {
 			return;
 		}
@@ -147,12 +141,10 @@ class Parsely_Recommended_Widget extends WP_Widget {
 	/**
 	 * Migrates previous display_options settings
 	 *
-	 * @category   Function
-	 * @package    WordPress
-	 * @subpackage Parse.ly
 	 * @param array $instance Values saved to the db.
+	 * @return void
 	 */
-	private function migrate_old_fields( $instance ) {
+	private function migrate_old_fields( $instance ): void {
 		if ( ! empty( $instance['display_options'] ) && is_array( $instance['display_options'] ) ) {
 			if ( empty( $instance['img_src'] ) ) {
 				$instance['img_src'] = in_array( 'display_thumbnail', $instance['display_options'], true ) ? 'parsely_thumb' : 'none';
@@ -167,12 +159,9 @@ class Parsely_Recommended_Widget extends WP_Widget {
 	/**
 	 * This is the form function
 	 *
-	 * @category   Function
-	 * @package    WordPress
-	 * @subpackage Parse.ly
 	 * @param array $instance Values saved to the db.
 	 */
-	public function form( $instance ) {
+	public function form( $instance ): void {
 		$this->migrate_old_fields( $instance );
 
 		if ( ! $this->api_key_and_secret_are_populated() ) {
@@ -278,13 +267,11 @@ class Parsely_Recommended_Widget extends WP_Widget {
 	/**
 	 * This is the update function
 	 *
-	 * @category   Function
-	 * @package    WordPress
-	 * @subpackage Parse.ly
 	 * @param array $new_instance The new values for the db.
 	 * @param array $old_instance Values saved to the db.
+	 * @return array
 	 */
-	public function update( $new_instance, $old_instance ) {
+	public function update( $new_instance, $old_instance ): array {
 		$instance                        = $old_instance;
 		$instance['title']               = trim( wp_kses_post( $new_instance['title'] ) );
 		$instance['published_within']    = (int) trim( $new_instance['published_within'] );
@@ -305,7 +292,7 @@ class Parsely_Recommended_Widget extends WP_Widget {
 	 *
 	 * @return array Boost parameters values and labels.
 	 */
-	private function get_boost_params() {
+	private function get_boost_params(): array {
 		return array(
 			'no-boost'              => __( 'No boost', 'wp-parsely' ),
 			'views'                 => __( 'Page views', 'wp-parsely' ),
@@ -339,7 +326,7 @@ class Parsely_Recommended_Widget extends WP_Widget {
 	 *
 	 * @return bool True if apikey and api_secret settings are not empty strings. False otherwise.
 	 */
-	private function api_key_and_secret_are_populated() {
+	private function api_key_and_secret_are_populated(): bool {
 		$options = get_option( 'parsely' );
 
 		// No options are saved, so API key is not available.

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -90,9 +90,11 @@ class Parsely {
 	/**
 	 * Register action and filter hook callbacks.
 	 *
-	 * Also immediately upgrade options if needed.
+	 * Also, immediately upgrade options if needed.
+	 *
+	 * @return void
 	 */
-	public function run() {
+	public function run(): void {
 		// Run upgrade options if they exist for the version currently defined.
 		$options = $this->get_options();
 		if ( empty( $options['plugin_version'] ) || self::VERSION !== $options['plugin_version'] ) {
@@ -133,8 +135,9 @@ class Parsely {
 	 * Adds 10 minute cron interval.
 	 *
 	 * @param array $schedules WP schedules array.
+	 * @return array
 	 */
-	public function wpparsely_add_cron_interval( $schedules ) {
+	public function wpparsely_add_cron_interval( array $schedules ): array {
 		$schedules['everytenminutes'] = array(
 			'interval' => 600, // time in seconds.
 			'display'  => __( 'Every 10 Minutes', 'wp-parsely' ),
@@ -143,19 +146,20 @@ class Parsely {
 	}
 
 	/**
-	 * Initialize parsely WordPress style
+	 * Initialize Parse.ly WordPress style.
+	 *
+	 * @return void
 	 */
-	public function wp_parsely_style_init() {
+	public function wp_parsely_style_init(): void {
 		wp_register_style( 'wp-parsely-style', plugin_dir_url( PARSELY_FILE ) . 'wp-parsely.css', array(), self::VERSION );
 	}
 
 	/**
-	 * Include the parsely admin header
+	 * Include the Parse.ly admin header.
 	 *
-	 * @category   Function
-	 * @package    Parsely
+	 * @return void
 	 */
-	public function add_admin_header() {
+	public function add_admin_header(): void {
 		echo '
 <style>
 #wp-parsely_version { color: #777; font-size: 12px; margin-left: 1em; }
@@ -174,12 +178,11 @@ class Parsely {
 	}
 
 	/**
-	 * Parsely settings page in WordPress settings menu.
+	 * Parse.ly settings page in WordPress settings menu.
 	 *
-	 * @category   Function
-	 * @package    Parsely
+	 * @return void
 	 */
-	public function add_settings_sub_menu() {
+	public function add_settings_sub_menu(): void {
 		add_options_page(
 			__( 'Parse.ly Settings', 'wp-parsely' ),
 			__( 'Parse.ly', 'wp-parsely' ),
@@ -190,12 +193,11 @@ class Parsely {
 	}
 
 	/**
-	 * Parse.ly settings screen ( options-general.php?page=[MENU_SLUG] )
+	 * Parse.ly settings screen ( options-general.php?page=[MENU_SLUG] ).
 	 *
-	 * @category   Function
-	 * @package    Parsely
+	 * @return void
 	 */
-	public function display_settings() {
+	public function display_settings(): void {
 		if ( ! current_user_can( self::CAPABILITY ) ) {
 			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-parsely' ) );
 		}
@@ -204,12 +206,11 @@ class Parsely {
 	}
 
 	/**
-	 * Initialize the settings for Parsely
+	 * Initialize the settings for Parsely.
 	 *
-	 * @category   Function
-	 * @package    Parsely
+	 * @return void
 	 */
-	public function initialize_settings() {
+	public function initialize_settings(): void {
 		// All our options are actually stored in one single array to reduce
 		// DB queries.
 		register_setting(
@@ -535,14 +536,13 @@ class Parsely {
 	}
 
 	/**
-	 * Validate options from an array
+	 * Validate options from an array.
 	 *
-	 * @category   Function
-	 * @package    Parsely
 	 * @param array  $array Array of options to be sanitized.
-	 * @param string $name Unused?.
+	 * @param string $name  Unused?.
+	 * @return array
 	 */
-	public function validate_option_array( $array, $name ) {
+	public function validate_option_array( $array, $name ): array {
 		$new_array = $array;
 		foreach ( $array as $key => $val ) {
 			$new_array[ $key ] = sanitize_text_field( $val );
@@ -556,9 +556,9 @@ class Parsely {
 	 * @category   Function
 	 * @package    Parsely
 	 * @param array $input Options from the settings page.
-	 * @return array $input list of validated input settings.
+	 * @return array List of validated input settings.
 	 */
-	public function validate_options( $input ) {
+	public function validate_options( $input ): array {
 		if ( empty( $input['apikey'] ) ) {
 			add_settings_error(
 				self::OPTIONS_KEY,
@@ -690,34 +690,31 @@ class Parsely {
 	}
 
 	/**
-	 * Not doing anything here
+	 * Not doing anything here.
 	 *
-	 * @category   Function
-	 * @package    Parsely
+	 * @return void
 	 */
-	public function print_required_settings() {
+	public function print_required_settings(): void {
 		// We can optionally print some text here in the future, but we don't
 		// need to now.
 	}
 
 	/**
-	 * Not doing anything here
+	 * Not doing anything here.
 	 *
-	 * @category   Function
-	 * @package    Parsely
+	 * @return void
 	 */
-	public function print_optional_settings() {
+	public function print_optional_settings(): void {
 		// We can optionally print some text here in the future, but we don't
 		// need to now.
 	}
 
 	/**
-	 * Display the admin warning if needed
+	 * Display the admin warning if needed.
 	 *
-	 * @category   Function
-	 * @package    Parsely
+	 * @return void
 	 */
-	public function display_admin_warning() {
+	public function display_admin_warning(): void {
 		if ( ! $this->should_display_admin_warning() ) {
 			return;
 		}
@@ -735,12 +732,11 @@ class Parsely {
 	/**
 	 * Decide whether the admin display warning should be displayed
 	 *
-	 * @category Function
-	 * @package Parsely
+	 * @since 2.6.0
 	 *
 	 * @return bool True if the admin warning should be displayed
 	 */
-	private function should_display_admin_warning() {
+	private function should_display_admin_warning(): bool {
 		if ( is_network_admin() ) {
 			return false;
 		}
@@ -750,12 +746,11 @@ class Parsely {
 	}
 
 	/**
-	 * Show our note about dynamic tracking
+	 * Show our note about dynamic tracking.
 	 *
-	 * @category   Function
-	 * @package    Parsely
+	 * @return void
 	 */
-	public function print_dynamic_tracking_note() {
+	public function print_dynamic_tracking_note(): void {
 		printf(
 			/* translators: 1: Documentation URL 2: Documentation URL */
 			wp_kses_post( __( 'This plugin does not currently support dynamic tracking ( the tracking of multiple pageviews on a single page). Some common use-cases for dynamic tracking are slideshows or articles loaded via AJAX calls in single-page applications -- situations in which new content is loaded without a full page refresh. Tracking these events requires manually implementing additional JavaScript above <a href="%1$s">the standard Parse.ly include</a> that the plugin injects into your page source. Please consult <a href="%2$s">the Parse.ly documentation on dynamic tracking</a> for instructions on implementing dynamic tracking, or contact Parse.ly support (<a href="%3$s">support@parsely.com</a> ) for additional assistance.', 'wp-parsely' ) ),
@@ -766,13 +761,15 @@ class Parsely {
 	}
 
 	/**
-	 * End the code coverage ignore
+	 * End the code coverage ignore.
 	 *
 	 * @codeCoverageIgnoreEnd
 	 */
 
 	/**
 	 * Actually inserts the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
+	 *
+	 * @return string|null|array
 	 */
 	public function insert_parsely_page() {
 		$parsely_options = $this->get_options();
@@ -850,7 +847,7 @@ class Parsely {
 	 * @param mixed $var Value to filter from the array.
 	 * @return bool Returns true if the variable is not empty, and it's a string
 	 */
-	private static function filter_empty_and_not_string_from_array( $var ) {
+	private static function filter_empty_and_not_string_from_array( $var ): bool {
 		return ! empty( $var ) && is_string( $var );
 	}
 
@@ -862,7 +859,7 @@ class Parsely {
 	 * @param int|WP_Post $post Which post object or ID to check.
 	 * @return bool Should the post status be tracked for the provided post's post_type. By default, only 'publish' is allowed.
 	 */
-	public static function post_has_trackable_status( $post ) {
+	public static function post_has_trackable_status( $post ): bool {
 		static $cache = array();
 		$post_id      = is_int( $post ) ? $post : $post->ID;
 		if ( isset( $cache[ $post_id ] ) ) {
@@ -885,13 +882,14 @@ class Parsely {
 	}
 
 	/**
+
 	 * Creates parsely metadata object from post metadata.
 	 *
 	 * @param array   $parsely_options parsely_options array.
 	 * @param WP_Post $post object.
-	 * @return mixed|void
+	 * @return array
 	 */
-	public function construct_parsely_metadata( array $parsely_options, $post ) {
+	public function construct_parsely_metadata( array $parsely_options, $post ): array {
 		$parsely_page      = array(
 			'@context' => 'http://schema.org',
 			'@type'    => 'WebPage',
@@ -1083,9 +1081,7 @@ class Parsely {
 		 * @param WP_Post $post            Post object.
 		 * @param array   $parsely_options The Parsely options.
 		 */
-		$parsely_page = apply_filters( 'wp_parsely_metadata', $parsely_page, $post, $parsely_options );
-
-		return $parsely_page;
+		return apply_filters( 'wp_parsely_metadata', $parsely_page, $post, $parsely_options );
 	}
 
 
@@ -1095,7 +1091,7 @@ class Parsely {
 	 * @param int $post_id id of the post to update.
 	 * @return string
 	 */
-	public function update_metadata_endpoint( $post_id ) {
+	public function update_metadata_endpoint( $post_id ): string {
 		$parsely_options = $this->get_options();
 
 		if ( $this->api_key_is_missing() || empty( $parsely_options['metadata_secret'] ) ) {
@@ -1145,8 +1141,10 @@ class Parsely {
 
 	/**
 	 * Updates posts with Parsely metadata api in bulk.
+	 *
+	 * @return void
 	 */
-	public function bulk_update_posts() {
+	public function bulk_update_posts(): void {
 		global $wpdb;
 		$parsely_options      = $this->get_options();
 		$allowed_types        = array_merge( $parsely_options['track_post_types'], $parsely_options['track_page_types'] );
@@ -1191,9 +1189,9 @@ class Parsely {
 	 *
 	 * @since 2.5.0
 	 *
-	 * @return int|string Random number or plugin version string.
+	 * @return string Random number string or plugin version string.
 	 */
-	public static function get_asset_cache_buster() {
+	public static function get_asset_cache_buster(): string {
 		static $cache_buster;
 		if ( isset( $cache_buster ) ) {
 			return $cache_buster;
@@ -1208,7 +1206,7 @@ class Parsely {
 		 *
 		 * @param string $cache_buster Plugin version, unless WP_DEBUG is defined and truthy, and tests are not running.
 		 */
-		return apply_filters( 'wp_parsely_cache_buster', $cache_buster );
+		return apply_filters( 'wp_parsely_cache_buster', (string) $cache_buster );
 	}
 
 	/**
@@ -1218,7 +1216,7 @@ class Parsely {
 	 *
 	 * @return void
 	 */
-	public function register_js() {
+	public function register_js(): void {
 		$parsely_options = $this->get_options();
 
 		if ( $this->api_key_is_missing() ) {
@@ -1255,8 +1253,10 @@ class Parsely {
 	 * Enqueues the JavaScript code required to send off beacon requests.
 	 *
 	 * @since 2.5.0 Rename from insert_parsely_javascript
+	 *
+	 * @return void
 	 */
-	public function load_js_tracker() {
+	public function load_js_tracker(): void {
 		$parsely_options = $this->get_options();
 		if ( $this->api_key_is_missing() || $parsely_options['disable_javascript'] ) {
 			return;
@@ -1317,8 +1317,10 @@ class Parsely {
 	 * Load JavaScript for Parse.ly API.
 	 *
 	 * @since 2.5.0
+	 *
+	 * @return void
 	 */
-	public function load_js_api() {
+	public function load_js_api(): void {
 		$parsely_options = $this->get_options();
 
 		// If we don't have an API secret, there's no need to proceed.
@@ -1343,7 +1345,7 @@ class Parsely {
 	 * @param string $src    The script's source URL.
 	 * @return string Amended `script` tag.
 	 */
-	public function script_loader_tag( $tag, $handle, $src ) {
+	public function script_loader_tag( $tag, $handle, $src ): string {
 		$parsely_options = $this->get_options();
 		if ( in_array(
 			$handle,
@@ -1374,8 +1376,9 @@ class Parsely {
 	 * Print out the select tags
 	 *
 	 * @param array $args The arguments for the select drop downs.
+	 * @return void
 	 */
-	public function print_select_tag( $args ) {
+	public function print_select_tag( $args ): void {
 		$options        = $this->get_options();
 		$name           = $args['option_key'];
 		$select_options = $args['select_options'];
@@ -1429,8 +1432,9 @@ class Parsely {
 	 * Print out the radio buttons
 	 *
 	 * @param array $args The arguments for the radio buttons.
+	 * @return void
 	 */
-	public function print_binary_radio_tag( $args ) {
+	public function print_binary_radio_tag( $args ): void {
 		$options = $this->get_options();
 		$name    = $args['option_key'];
 		$value   = $options[ $name ];
@@ -1466,8 +1470,9 @@ class Parsely {
 	 * Prints a checkbox tag in the settings page.
 	 *
 	 * @param array $args Arguments to print to checkbox tag.
+	 * @return void
 	 */
-	public function print_checkbox_tag( $args ) {
+	public function print_checkbox_tag( $args ): void {
 		$options = $this->get_options();
 		$name    = $args['option_key'];
 		$value   = $options[ $name ];
@@ -1492,11 +1497,12 @@ class Parsely {
 	}
 
 	/**
-	 * Print out the radio buttons
+	 * Print out the radio buttons.
 	 *
 	 * @param array $args The arguments for text tags.
+	 * @return void
 	 */
-	public function print_text_tag( $args ) {
+	public function print_text_tag( $args ): void {
 		$options       = $this->get_options();
 		$name          = $args['option_key'];
 		$value         = $options[ $name ] ?? '';
@@ -1540,9 +1546,11 @@ class Parsely {
 	}
 
 	/**
-	 * Returns default logo if one can be found
+	 * Returns default logo if one can be found.
+	 *
+	 * @return string
 	 */
-	private function get_logo_default() {
+	private function get_logo_default(): string {
 		$custom_logo_id = get_theme_mod( 'custom_logo' );
 		if ( $custom_logo_id ) {
 			$logo_attrs = wp_get_attachment_image_src( $custom_logo_id, 'full' );
@@ -1562,7 +1570,7 @@ class Parsely {
 	 * @param string $url The url of the host.
 	 * @return string $url The host of the url…
 	 */
-	private function get_host_from_url( $url ) {
+	private function get_host_from_url( $url ): string {
 		if ( preg_match( '/^https?:\/\/( [^\/]+ )\/.*$/', $url, $matches ) ) {
 			return $matches[1];
 		}
@@ -1574,9 +1582,9 @@ class Parsely {
 	 * Returns the tags associated with this page or post
 	 *
 	 * @param string $post_id The id of the post you're trying to get tags for.
-	 * @return array $tags The tags of the post represented by the post id.
+	 * @return array The tags of the post represented by the post id.
 	 */
-	private function get_tags( $post_id ) {
+	private function get_tags( $post_id ): array {
 		$tags    = array();
 		$wp_tags = wp_get_post_tags( $post_id );
 		foreach ( $wp_tags as $wp_tag ) {
@@ -1591,9 +1599,9 @@ class Parsely {
 	 *
 	 * @param string $post_id The id of the post you're trying to get categories for.
 	 * @param string $delimiter What character will delimit the categories.
-	 * @return array $tags all the child categories of the current post.
+	 * @return array All the child categories of the current post.
 	 */
-	private function get_categories( $post_id, $delimiter = '/' ) {
+	private function get_categories( $post_id, $delimiter = '/' ): array {
 		$tags       = array();
 		$categories = get_the_category( $post_id );
 		foreach ( $categories as $category ) {
@@ -1616,7 +1624,7 @@ class Parsely {
 	 *
 	 * @return array
 	 */
-	private function get_options() {
+	private function get_options(): array {
 		$options = get_option( self::OPTIONS_KEY, $this->option_defaults );
 		return array_merge( $this->option_defaults, $options );
 	}
@@ -1627,9 +1635,9 @@ class Parsely {
 	 *
 	 * @param WP_Post $post_obj The object for the post.
 	 * @param array   $parsely_options The parsely options.
-	 * @return string $category Cleaned category name for for post in question.
+	 * @return string Cleaned category name for the post in question.
 	 */
-	private function get_category_name( $post_obj, $parsely_options ) {
+	private function get_category_name( $post_obj, $parsely_options ): string {
 		$taxonomy_dropdown_choice = get_the_terms( $post_obj->ID, $parsely_options['custom_taxonomy_section'] );
 		// Get top-level taxonomy name for chosen taxonomy and assign to $parent_name; it will be used
 		// as the category value if 'use_top_level_cats' option is checked.
@@ -1658,8 +1666,8 @@ class Parsely {
 		 * @param array   $parsely_options The Parsely options.
 		 */
 		$category = apply_filters( 'wp_parsely_post_category', $category, $post_obj, $parsely_options );
-		$category = $this->get_clean_parsely_page_value( $category );
-		return $category;
+
+		return $this->get_clean_parsely_page_value( $category );
 	}
 
 	/**
@@ -1670,7 +1678,7 @@ class Parsely {
 	 * @param string $taxonomy_name The name of the taxonomy.
 	 * @return string $parent The top level name of the category / taxonomy.
 	 */
-	private function get_top_level_term( $term_id, $taxonomy_name ) {
+	private function get_top_level_term( $term_id, $taxonomy_name ): string {
 		$parent = get_term_by( 'id', $term_id, $taxonomy_name );
 		while ( false !== $parent && 0 !== $parent->parent ) {
 			$parent = get_term_by( 'id', $parent->parent, $taxonomy_name );
@@ -1684,9 +1692,9 @@ class Parsely {
 	 *
 	 * @param string $post_id The post id you're interested in.
 	 * @param string $taxonomy_name The name of the taxonomy.
-	 * @return string name of the custom taxonomy.
+	 * @return string Name of the custom taxonomy.
 	 */
-	private function get_bottom_level_term( $post_id, $taxonomy_name ) {
+	private function get_bottom_level_term( $post_id, $taxonomy_name ): string {
 		$terms    = get_the_terms( $post_id, $taxonomy_name );
 		$term_ids = is_array( $terms ) ? wp_list_pluck( $terms, 'term_id' ) : null;
 		$parents  = is_array( $terms ) ? array_filter( wp_list_pluck( $terms, 'parent' ) ) : null;
@@ -1709,8 +1717,9 @@ class Parsely {
 	 *
 	 * @param WP_Post $post_obj The post object.
 	 * @param array   $parsely_options The pparsely options.
+	 * @return array
 	 */
-	private function get_custom_taxonomy_values( $post_obj, $parsely_options ) {
+	private function get_custom_taxonomy_values( $post_obj, $parsely_options ): array {
 		// filter out default WordPress taxonomies.
 		$all_taxonomies = array_diff( get_taxonomies(), array( 'post_tag', 'nav_menu', 'author', 'link_category', 'post_format' ) );
 		$all_values     = array();
@@ -1734,8 +1743,9 @@ class Parsely {
 	 * https://github.com/Automattic/Co-Authors-Plus/blob/master/template-tags.php#L3-35
 	 *
 	 * @param string $post_id The id of the post.
+	 * @return array
 	 */
-	private function get_coauthor_names( $post_id ) {
+	private function get_coauthor_names( $post_id ): array {
 		$coauthors = array();
 		if ( class_exists( 'coauthors_plus' ) ) {
 			global $post, $post_ID, $coauthors_plus, $wpdb;
@@ -1779,8 +1789,9 @@ class Parsely {
 	 * lastname, then nickname and finally the nicename.
 	 *
 	 * @param WP_User $author The author of the post.
+	 * @return string
 	 */
-	private function get_author_name( $author ) {
+	private function get_author_name( $author ): string {
 		// gracefully handle situation where no author is available.
 		if ( empty( $author ) || ! is_object( $author ) ) {
 			return '';
@@ -1810,7 +1821,7 @@ class Parsely {
 	 * @param WP_Post $post The post object.
 	 * @return array
 	 */
-	private function get_author_names( $post ) {
+	private function get_author_names( $post ): array {
 		$authors = $this->get_coauthor_names( $post->ID );
 		if ( empty( $authors ) ) {
 			$authors = array( get_user_by( 'id', $post->post_author ) );
@@ -1849,7 +1860,7 @@ class Parsely {
 	 * @param string $val The content you'd like sanitized.
 	 * @return string
 	 */
-	public function get_clean_parsely_page_value( $val ) {
+	public function get_clean_parsely_page_value( $val ): string {
 		if ( is_string( $val ) ) {
 			$val = str_replace( "\n", '', $val );
 			$val = str_replace( "\r", '', $val );
@@ -1863,9 +1874,11 @@ class Parsely {
 
 
 	/**
-	 * Get the URL of the plugin settings page
+	 * Get the URL of the plugin settings page.
+	 *
+	 * @return string
 	 */
-	public static function get_settings_url() {
+	public static function get_settings_url(): string {
 		return admin_url( 'options-general.php?page=' . self::MENU_SLUG );
 	}
 
@@ -1876,9 +1889,9 @@ class Parsely {
 	 *
 	 * @param string $parsely_type Optional. Parse.ly post type you're interested in, either 'post' or 'nonpost'. Default is 'nonpost'.
 	 * @param int    $post_id      Optional. ID of the post you want to get the URL for. Default is 0, which means the global `$post` is used.
-	 * @return string|void
+	 * @return string
 	 */
-	public function get_current_url( $parsely_type = 'nonpost', $post_id = 0 ) {
+	public function get_current_url( $parsely_type = 'nonpost', $post_id = 0 ): string {
 		if ( 'post' === $parsely_type ) {
 			$permalink = (string) get_permalink( $post_id );
 
@@ -1913,9 +1926,9 @@ class Parsely {
 	 * https://css-tricks.com/snippets/wordpress/get-the-first-image-from-a-post/
 	 *
 	 * @param WP_Post $post The post object you're interested in.
-	 * @return mixed|string
+	 * @return string
 	 */
-	public function get_first_image( $post ) {
+	public function get_first_image( $post ): string {
 		ob_start();
 		ob_end_clean();
 		if ( preg_match_all( '/<img.+src=[\'"]( [^\'"]+ )[\'"].*>/i', $post->post_content, $matches ) ) {
@@ -1925,9 +1938,11 @@ class Parsely {
 	}
 
 	/**
-	 * Check to see if parsely user is logged in
+	 * Check to see if parsely user is logged in.
+	 *
+	 * @return bool
 	 */
-	public function parsely_is_user_logged_in() {
+	public function parsely_is_user_logged_in(): bool {
 		// can't use $blog_id here because it futzes with the global $blog_id.
 		$current_blog_id = get_current_blog_id();
 		$current_user_id = get_current_user_id();
@@ -1947,7 +1962,7 @@ class Parsely {
 	 * @param string $type JSON-LD type.
 	 * @return string "post" or "index".
 	 */
-	public function convert_jsonld_to_parsely_type( $type ) {
+	public function convert_jsonld_to_parsely_type( $type ): string {
 		return in_array( $type, $this->supported_jsonld_post_types ) ? 'post' : 'index';
 	}
 
@@ -1958,7 +1973,7 @@ class Parsely {
 	 *
 	 * @return bool True is API key is set, false if it is missing.
 	 */
-	public function api_key_is_set() {
+	public function api_key_is_set(): bool {
 		$options = $this->get_options();
 
 		return (
@@ -1975,7 +1990,7 @@ class Parsely {
 	 *
 	 * @return bool True if API key is missing, false if it is set.
 	 */
-	public function api_key_is_missing() {
+	public function api_key_is_missing(): bool {
 		return ! $this->api_key_is_set();
 	}
 
@@ -1986,7 +2001,7 @@ class Parsely {
 	 *
 	 * @return string API key if set, or empty string if not.
 	 */
-	public function get_api_key() {
+	public function get_api_key(): string {
 		$options = $this->get_options();
 
 		return $this->api_key_is_set() ? $options['apikey'] : '';

--- a/tests/Integration/GetCurrentUrlTest.php
+++ b/tests/Integration/GetCurrentUrlTest.php
@@ -110,7 +110,7 @@ final class GetCurrentUrlTest extends TestCase {
 	 * @param string $home        Home URL.
 	 * @param string $expected    Expected current URL.
 	 */
-	public function test_get_current_url( $force_https, $home, $expected ) {
+	public function test_get_current_url( $force_https, $home, $expected ): void {
 		$this->set_options( array( 'force_https_canonicals' => $force_https ) );
 		update_option( 'home', $home );
 
@@ -124,7 +124,7 @@ final class GetCurrentUrlTest extends TestCase {
 	 *
 	 * @param string $expected Expected start of the URL.
 	 */
-	private function assertCurrentUrlForHomepage( $expected ) {
+	private function assertCurrentUrlForHomepage( $expected ): void {
 		$this->go_to( '/' );
 
 		$parsely = new Parsely();
@@ -138,7 +138,7 @@ final class GetCurrentUrlTest extends TestCase {
 	 *
 	 * @param string $expected Expected start of the URL.
 	 */
-	private function assertCurrentUrlForSpecificPostWithId( $expected ) {
+	private function assertCurrentUrlForSpecificPostWithId( $expected ): void {
 		$post_array = $this->create_test_post_array();
 		$post_id    = $this->factory->post->create( $post_array );
 		$this->go_to( '/?p=' . $post_id );
@@ -154,7 +154,7 @@ final class GetCurrentUrlTest extends TestCase {
 	 *
 	 * @param string $expected Expected start of the URL.
 	 */
-	private function assertCurrentUrlForRandomUrl( $expected ) {
+	private function assertCurrentUrlForRandomUrl( $expected ): void {
 		$parsely = new Parsely();
 		$this->go_to( '/random/url/' );
 		$res = $parsely->get_current_url();

--- a/tests/Integration/Integrations/AmpTest.php
+++ b/tests/Integration/Integrations/AmpTest.php
@@ -22,7 +22,7 @@ final class AmpTest extends TestCase {
 	 *
 	 * @covers \Parsely\Integrations\Amp::integrate
 	 */
-	public function test_integration_only_runs_when_AMP_plugin_is_active() {
+	public function test_integration_only_runs_when_AMP_plugin_is_active(): void {
 		$amp = new Amp();
 
 		// By default, the integration will not happen if the condition has not been met.
@@ -43,7 +43,7 @@ final class AmpTest extends TestCase {
 	 * @uses \Parsely::get_options()
 	 * @group amp
 	 */
-	public function test_integration_only_runs_if_we_can_handle_an_AMP_request() {
+	public function test_integration_only_runs_if_we_can_handle_an_AMP_request(): void {
 		// Mock the Amp class, but only the can_handle_amp_request() method. This leaves
 		// the other methods unmocked, and therefore testable.
 
@@ -68,7 +68,7 @@ final class AmpTest extends TestCase {
 	 * @uses \Parsely::get_options()
 	 * @group amp
 	 */
-	public function test_AMP_request_is_not_handled_when_support_is_disabled() {
+	public function test_AMP_request_is_not_handled_when_support_is_disabled(): void {
 		// Mock the Amp class, but only the is_amp_request() method. This leaves
 		// the other methods unmocked, and therefore testable.
 
@@ -97,7 +97,7 @@ final class AmpTest extends TestCase {
 	 * @group amp
 	 * @group settings
 	 */
-	public function test_can_register_Parsely_for_AMP_analytics() {
+	public function test_can_register_Parsely_for_AMP_analytics(): void {
 		$amp       = new Parsely\Integrations\Amp();
 		$analytics = array();
 
@@ -122,7 +122,7 @@ final class AmpTest extends TestCase {
 	 * @group amp
 	 * @group settings
 	 */
-	public function test_can_register_Parsely_for_AMP_native_analytics() {
+	public function test_can_register_Parsely_for_AMP_native_analytics(): void {
 		$amp       = new Parsely\Integrations\Amp();
 		$analytics = array();
 

--- a/tests/Integration/Integrations/FacebookInstantArticlesTest.php
+++ b/tests/Integration/Integrations/FacebookInstantArticlesTest.php
@@ -24,7 +24,7 @@ final class FacebookInstantArticlesTest extends TestCase {
 	 *
 	 * @covers \Parsely\Integrations\Facebook_Instant_Articles::integrate
 	 */
-	public function test_integration_only_runs_when_FBIA_plugin_is_active() {
+	public function test_integration_only_runs_when_FBIA_plugin_is_active(): void {
 		$fbia = new Facebook_Instant_Articles();
 
 		// By default, the integration will not happen if the condition has not been met.
@@ -59,7 +59,7 @@ final class FacebookInstantArticlesTest extends TestCase {
 	 * @uses \Parsely::get_options
 	 * @group fbia
 	 */
-	public function test_parsely_is_added_to_FBIA_registry() {
+	public function test_parsely_is_added_to_FBIA_registry(): void {
 		// We use our own registry here, but the integration with the FBIA plugin provides its own.
 		$registry = array();
 		$fbia     = new Facebook_Instant_Articles();
@@ -85,7 +85,7 @@ final class FacebookInstantArticlesTest extends TestCase {
 	 * @param array  $registry Representation of Facebook Instant Articles registry.
 	 * @param string $api_key  API key.
 	 */
-	public static function assertParselyWasAddedToRegistryCorrectly( $registry, $api_key ) {
+	public static function assertParselyWasAddedToRegistryCorrectly( $registry, $api_key ): void {
 		self::assertArrayHasKey( Facebook_Instant_Articles::REGISTRY_IDENTIFIER, $registry );
 		self::assertSame( Facebook_Instant_Articles::REGISTRY_DISPLAY_NAME, $registry[ Facebook_Instant_Articles::REGISTRY_IDENTIFIER ]['name'] );
 

--- a/tests/Integration/Integrations/IntegrationsTest.php
+++ b/tests/Integration/Integrations/IntegrationsTest.php
@@ -28,7 +28,7 @@ final class IntegrationsTest extends TestCase {
 	 * @uses \Parsely\Integrations\Integrations::integrate
 	 * @uses \Parsely\Integrations\Integrations::register
 	 */
-	public function test_an_integration_can_be_registered_via_the_filter() {
+	public function test_an_integration_can_be_registered_via_the_filter(): void {
 		add_action(
 			'wp_parsely_add_integration',
 			function( $integrations ) {
@@ -73,7 +73,7 @@ class FakeIntegration2 {
 	/**
 	 * Stub this method to avoid a fatal error.
 	 */
-	public function integrate() {
+	public function integrate(): void {
 	}
 }
 

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -24,7 +24,7 @@ final class OtherTest extends TestCase {
 	/**
 	 * The setUp run before each test
 	 */
-	public function set_up() {
+	public function set_up(): void {
 		global $wp_scripts;
 
 		parent::set_up();
@@ -45,7 +45,7 @@ final class OtherTest extends TestCase {
 	 *
 	 * @coversNothing
 	 */
-	public function test_version_constant_is_a_semantic_version_string() {
+	public function test_version_constant_is_a_semantic_version_string(): void {
 		self::assertMatchesRegularExpression(
 			'/^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/',
 			\Parsely::VERSION
@@ -60,7 +60,7 @@ final class OtherTest extends TestCase {
 	 * @covers \Parsely::get_asset_cache_buster
 	 * @uses \Parsely::get_options
 	 */
-	public function test_cache_buster() {
+	public function test_cache_buster(): void {
 		self::assertSame( \Parsely::VERSION, \Parsely::get_asset_cache_buster() );
 	}
 
@@ -75,7 +75,7 @@ final class OtherTest extends TestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group insert-js
 	 */
-	public function test_parsely_register_js() {
+	public function test_parsely_register_js(): void {
 		ob_start();
 		$post_array = $this->create_test_post_array();
 		$post       = $this->factory->post->create( $post_array );
@@ -124,7 +124,7 @@ final class OtherTest extends TestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group insert-js
 	 */
-	public function test_load_js_tracker() {
+	public function test_load_js_tracker(): void {
 		ob_start();
 		$post_array = $this->create_test_post_array();
 		$post       = $this->factory->post->create( $post_array );
@@ -165,7 +165,7 @@ final class OtherTest extends TestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group insert-js
 	 */
-	public function test_load_js_api_no_secret() {
+	public function test_load_js_api_no_secret(): void {
 		ob_start();
 		$post_array = $this->create_test_post_array();
 		$post       = $this->factory->post->create( $post_array );
@@ -207,7 +207,7 @@ final class OtherTest extends TestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group insert-js
 	 */
-	public function test_load_js_api_with_secret() {
+	public function test_load_js_api_with_secret(): void {
 		ob_start();
 		$post_array = $this->create_test_post_array();
 		$post       = $this->factory->post->create( $post_array );
@@ -270,7 +270,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * @group metadata
 	 * @group filters
 	 */
-	public function test_parsely_page_filter() {
+	public function test_parsely_page_filter(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
@@ -310,7 +310,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * @group insert-js
 	 * @group settings
 	 */
-	public function test_user_logged_in() {
+	public function test_user_logged_in(): void {
 		TestCase::set_options( array( 'track_authenticated_users' => false ) );
 		$new_user = $this->create_test_user( 'bill_brasky' );
 		wp_set_current_user( $new_user );
@@ -371,7 +371,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * @group insert-js
 	 * @group settings
 	 */
-	public function test_user_logged_in_multisite() {
+	public function test_user_logged_in_multisite(): void {
 		if ( ! is_multisite() ) {
 			self::markTestSkipped( "this test can't run without multisite" );
 		}
@@ -467,7 +467,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * @uses \Parsely::post_has_trackable_status
 	 * @uses \Parsely::update_metadata_endpoint
 	 */
-	public function test_load_js_tracker_filter() {
+	public function test_load_js_tracker_filter(): void {
 		add_filter( 'wp_parsely_load_js_tracker', '__return_false' );
 
 		ob_start();
@@ -508,7 +508,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * @uses \Parsely::post_has_trackable_status
 	 * @uses \Parsely::update_metadata_endpoint
 	 */
-	public function test_deprecated_insert_javascript_filter() {
+	public function test_deprecated_insert_javascript_filter(): void {
 		add_filter( 'parsely_filter_insert_javascript', '__return_false' );
 
 		ob_start();
@@ -551,7 +551,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * @uses \Parsely::post_has_trackable_status
 	 * @uses \Parsely::update_metadata_endpoint
 	 */
-	public function test_filter_wp_parsely_post_type() {
+	public function test_filter_wp_parsely_post_type(): void {
 		$options = get_option( \Parsely::OPTIONS_KEY );
 
 		$post_array = $this->create_test_post_array();
@@ -589,7 +589,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * @covers \Parsely::should_display_admin_warning
 	 * @uses \Parsely::get_options
 	 */
-	public function test_display_admin_warning_without_key() {
+	public function test_display_admin_warning_without_key(): void {
 		$should_display_admin_warning = self::getMethod( 'should_display_admin_warning' );
 		$this->set_options( array( 'apikey' => '' ) );
 
@@ -602,7 +602,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 *
 	 * @covers \Parsely::should_display_admin_warning
 	 */
-	public function test_display_admin_warning_network_admin() {
+	public function test_display_admin_warning_network_admin(): void {
 		$should_display_admin_warning = self::getMethod( 'should_display_admin_warning' );
 		$this->set_options( array( 'apikey' => '' ) );
 		set_current_screen( 'dashboard-network' );
@@ -617,7 +617,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * @covers \Parsely::should_display_admin_warning
 	 * @uses \Parsely::get_options
 	 */
-	public function test_display_admin_warning_with_key() {
+	public function test_display_admin_warning_with_key(): void {
 		$should_display_admin_warning = self::getMethod( 'should_display_admin_warning' );
 		$this->set_options( array( 'apikey' => 'somekey' ) );
 
@@ -634,7 +634,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * @covers \Parsely::api_key_is_missing
 	 * @uses \Parsely::get_options
 	 */
-	public function test_checking_API_key_is_set_or_not() {
+	public function test_checking_API_key_is_set_or_not(): void {
 		self::set_options( array( 'apikey' => '' ) );
 		self::assertFalse( self::$parsely->api_key_is_set() );
 		self::assertTrue( self::$parsely->api_key_is_missing() );
@@ -653,7 +653,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	 * @uses \Parsely::api_key_is_set
 	 * @uses \Parsely::get_options
 	 */
-	public function test_can_retrieve_API_key() {
+	public function test_can_retrieve_API_key(): void {
 		self::set_options( array( 'apikey' => 'somekey' ) );
 		self::assertSame( 'somekey', self::$parsely->get_api_key() );
 		self::set_options( array( 'apikey' => '' ) );

--- a/tests/Integration/RecommendedApiTest.php
+++ b/tests/Integration/RecommendedApiTest.php
@@ -20,7 +20,7 @@ final class RecommendedApiTest extends TestCase {
 	 *
 	 * @return array[]
 	 */
-	public function data_recommended_api_url() {
+	public function data_recommended_api_url(): array {
 		return array(
 			'Basic (Expected data)'                   => array(
 				'my-key',
@@ -76,7 +76,7 @@ final class RecommendedApiTest extends TestCase {
 	 * @param int    $return_limit     Number of records to retrieve; defaults to "10".
 	 * @param string $url              Expected generated URL.
 	 */
-	public function test_recommended_api_url( $api_key, $published_within, $sort, $boost, $return_limit, $url ) {
+	public function test_recommended_api_url( $api_key, $published_within, $sort, $boost, $return_limit, $url ): void {
 		$recommended_widget = new Parsely_Recommended_Widget();
 
 		self::assertEquals( $url, $recommended_widget->get_api_url( $api_key, $published_within, $sort, $boost, $return_limit ) );

--- a/tests/Integration/StructuredData/AuthorArchiveTest.php
+++ b/tests/Integration/StructuredData/AuthorArchiveTest.php
@@ -34,7 +34,7 @@ final class AuthorArchiveTest extends NonPostTestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group metadata
 	 */
-	public function test_author_archive() {
+	public function test_author_archive(): void {
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
 		// See https://github.com/Parsely/wp-parsely/issues/151.
 		$this->set_permalink_structure( '/%postname%/' );

--- a/tests/Integration/StructuredData/BlogArchiveTest.php
+++ b/tests/Integration/StructuredData/BlogArchiveTest.php
@@ -34,7 +34,7 @@ final class BlogArchiveTest extends NonPostTestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group metadata
 	 */
-	public function test_blog_page_for_posts_paged() {
+	public function test_blog_page_for_posts_paged(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );

--- a/tests/Integration/StructuredData/HomePageTest.php
+++ b/tests/Integration/StructuredData/HomePageTest.php
@@ -19,7 +19,7 @@ final class HomePageTest extends NonPostTestCase {
 	/**
 	 * Runs the routine before each test is executed.
 	 */
-	public function set_up() {
+	public function set_up(): void {
 		parent::set_up();
 
 		update_option( 'show_on_front', 'posts' );
@@ -45,7 +45,7 @@ final class HomePageTest extends NonPostTestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group metadata
 	 */
-	public function test_home_page_for_posts() {
+	public function test_home_page_for_posts(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
@@ -91,7 +91,7 @@ final class HomePageTest extends NonPostTestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group metadata
 	 */
-	public function test_home_page_for_posts_paged() {
+	public function test_home_page_for_posts_paged(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
@@ -142,7 +142,7 @@ final class HomePageTest extends NonPostTestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group metadata
 	 */
-	public function test_home_page_on_front() {
+	public function test_home_page_on_front(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
@@ -194,7 +194,7 @@ final class HomePageTest extends NonPostTestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group metadata
 	 */
-	public function test_home_for_misconfigured_settings() {
+	public function test_home_for_misconfigured_settings(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );

--- a/tests/Integration/StructuredData/NonPostTestCase.php
+++ b/tests/Integration/StructuredData/NonPostTestCase.php
@@ -18,7 +18,7 @@ abstract class NonPostTestCase extends TestCase {
 	/**
 	 * The setUp run before each test
 	 */
-	public function set_up() {
+	public function set_up(): void {
 		parent::set_up();
 
 		// Set the default options prior to each test.
@@ -30,7 +30,7 @@ abstract class NonPostTestCase extends TestCase {
 	 *
 	 * @param array $structured_data Array of metadata to check.
 	 */
-	public function assert_data_has_required_properties( $structured_data ) {
+	public function assert_data_has_required_properties( $structured_data ): void {
 		$required_properties = $this->get_required_properties();
 
 		array_walk(
@@ -46,7 +46,7 @@ abstract class NonPostTestCase extends TestCase {
 	 *
 	 * @return string[]
 	 */
-	private function get_required_properties() {
+	private function get_required_properties(): array {
 		return array(
 			'@context',
 			'@type',

--- a/tests/Integration/StructuredData/SinglePageTest.php
+++ b/tests/Integration/StructuredData/SinglePageTest.php
@@ -35,7 +35,7 @@ final class SinglePageTest extends NonPostTestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group metadata
 	 */
-	public function test_single_page() {
+	public function test_single_page(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );

--- a/tests/Integration/StructuredData/SinglePostTest.php
+++ b/tests/Integration/StructuredData/SinglePostTest.php
@@ -20,7 +20,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * The setUp run before each test
 	 */
-	public function set_up() {
+	public function set_up(): void {
 		parent::set_up();
 
 		// Set the default options prior to each test.
@@ -45,7 +45,7 @@ final class SinglePostTest extends TestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group metadata
 	 */
-	public function test_single_post() {
+	public function test_single_post(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
@@ -84,7 +84,7 @@ final class SinglePostTest extends TestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group metadata
 	 */
-	public function test_category_data_for_single_post() {
+	public function test_category_data_for_single_post(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
@@ -120,7 +120,7 @@ final class SinglePostTest extends TestCase {
 	 * @group metadata
 	 * @group settings
 	 */
-	public function test_tag_data_assigned_to_a_post_are_lowercase() {
+	public function test_tag_data_assigned_to_a_post_are_lowercase(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
@@ -167,7 +167,7 @@ final class SinglePostTest extends TestCase {
 	 * @group metadata
 	 * @group settings
 	 */
-	public function test_parsely_categories_as_tags_in_single_post() {
+	public function test_parsely_categories_as_tags_in_single_post(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
@@ -214,7 +214,7 @@ final class SinglePostTest extends TestCase {
 	 * @group metadata
 	 * @group settings
 	 */
-	public function test_custom_taxonomy_as_tags_in_single_post() {
+	public function test_custom_taxonomy_as_tags_in_single_post(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
@@ -272,7 +272,7 @@ final class SinglePostTest extends TestCase {
 	 * @group metadata
 	 * @group settings
 	 */
-	public function test_use_top_level_cats_in_single_post() {
+	public function test_use_top_level_cats_in_single_post(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
@@ -329,7 +329,7 @@ final class SinglePostTest extends TestCase {
 	 * @group metadata
 	 * @group settings
 	 */
-	public function test_custom_taxonomy_as_section_in_single_post() {
+	public function test_custom_taxonomy_as_section_in_single_post(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
@@ -396,7 +396,7 @@ final class SinglePostTest extends TestCase {
 	 * @group metadata
 	 * @group settings
 	 */
-	public function test_http_canonicals_for_single_post() {
+	public function test_http_canonicals_for_single_post(): void {
 		// Setup Parsley object.
 		$parsely         = new \Parsely();
 		$parsely_options = get_option( \Parsely::OPTIONS_KEY );
@@ -433,7 +433,7 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @param array $structured_data Array of metadata to check.
 	 */
-	public function assert_data_has_required_properties( $structured_data ) {
+	public function assert_data_has_required_properties( $structured_data ): void {
 		$required_properties = $this->get_required_properties();
 
 		array_walk(
@@ -449,7 +449,7 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @return string[]
 	 */
-	private function get_required_properties() {
+	private function get_required_properties(): array {
 		return array(
 			'@context',
 			'@type',

--- a/tests/Integration/StructuredData/TermArchiveTest.php
+++ b/tests/Integration/StructuredData/TermArchiveTest.php
@@ -34,7 +34,7 @@ final class TermArchiveTest extends NonPostTestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group metadata
 	 */
-	public function test_term_archive() {
+	public function test_term_archive(): void {
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
 		// See https://github.com/Parsely/wp-parsely/issues/151.
 		$this->set_permalink_structure( '/%postname%/' );

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Parsely\Tests\Integration;
 
+use WP_Error;
 use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;
 
 /**
@@ -36,7 +37,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 *
 	 * @param array $custom_options Associative array of option keys and values that should be saved.
 	 */
-	public static function set_options( $custom_options = array() ) {
+	public static function set_options( $custom_options = array() ): void {
 		update_option( \Parsely::OPTIONS_KEY, array_merge( self::DEFAULT_OPTIONS, $custom_options ) );
 	}
 
@@ -46,7 +47,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * @param string $post_type Optional. Post type. Default is 'post'.
 	 * @return array An array of WP_Post fields.
 	 */
-	public function create_test_post_array( $post_type = 'post' ) {
+	public function create_test_post_array( $post_type = 'post' ): array {
 		return array(
 			'post_title'   => 'Sample Parsely Post',
 			'post_author'  => 1,
@@ -134,7 +135,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * @return \ReflectionMethod
 	 * @throws \ReflectionException The method does not exist in the class.
 	 */
-	public static function getMethod( $method_name, $class_name = 'Parsely' ) {
+	public static function getMethod( $method_name, $class_name = 'Parsely' ): \ReflectionMethod {
 		$class  = new \ReflectionClass( $class_name );
 		$method = $class->getMethod( $method_name );
 		$method->setAccessible( true );

--- a/tests/Integration/UI/PluginsActionsTest.php
+++ b/tests/Integration/UI/PluginsActionsTest.php
@@ -22,7 +22,7 @@ final class PluginsActionsTest extends TestCase {
 	 * @covers \Parsely\UI\Plugins_Actions::run
 	 * @group ui
 	 */
-	public function test_plugins_screen_has_filter_to_add_a_settings_action_link() {
+	public function test_plugins_screen_has_filter_to_add_a_settings_action_link(): void {
 		$plugins_screen = new Plugins_Actions();
 		$plugins_screen->run();
 
@@ -37,7 +37,7 @@ final class PluginsActionsTest extends TestCase {
 	 * @uses \Parsely::get_settings_url
 	 * @group ui
 	 */
-	public function test_plugins_screen_adds_a_settings_action_link() {
+	public function test_plugins_screen_adds_a_settings_action_link(): void {
 		$actions = array();
 		$actions = ( new Plugins_Actions() )->add_plugin_meta_links( $actions );
 

--- a/tests/StructuredData/CustomPostTypeArchiveTest.php
+++ b/tests/StructuredData/CustomPostTypeArchiveTest.php
@@ -35,7 +35,7 @@ final class CustomPostTypeArchiveTest extends NonPostTestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group metadata
 	 */
-	public function test_metadata_is_correctly_constructed_for_custom_post_type_archive() {
+	public function test_metadata_is_correctly_constructed_for_custom_post_type_archive(): void {
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
 		// See https://github.com/Parsely/wp-parsely/issues/151.
 		$this->set_permalink_structure( '/%postname%/' );

--- a/tests/StructuredData/CustomTaxonomyTermArchiveTest.php
+++ b/tests/StructuredData/CustomTaxonomyTermArchiveTest.php
@@ -35,7 +35,7 @@ class CustomTaxonomyTermArchiveTest extends NonPostTestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group metadata
 	 */
-	public function test_metadata_is_correctly_constructed_for_custom_taxonomy_term_archive() {
+	public function test_metadata_is_correctly_constructed_for_custom_taxonomy_term_archive(): void {
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL property.
 		// See https://github.com/Parsely/wp-parsely/issues/151.
 		$this->set_permalink_structure( '/%postname%/' );

--- a/tests/UI/PluginsActionsTest.php
+++ b/tests/UI/PluginsActionsTest.php
@@ -22,7 +22,7 @@ final class PluginsActionsTest extends TestCase {
 	 * @covers \Parsely\UI\Plugins_Actions::run
 	 * @group ui
 	 */
-	public function test_plugins_screen_has_filter_to_add_a_settings_action_link() {
+	public function test_plugins_screen_has_filter_to_add_a_settings_action_link(): void {
 		$plugins_screen = new Plugins_Actions();
 		$plugins_screen->run();
 
@@ -37,7 +37,7 @@ final class PluginsActionsTest extends TestCase {
 	 * @uses \Parsely::get_settings_url
 	 * @group ui
 	 */
-	public function test_plugins_screen_adds_a_settings_action_link() {
+	public function test_plugins_screen_adds_a_settings_action_link(): void {
 		$actions        = array();
 		$plugins_screen = new Plugins_Actions();
 		$actions        = $plugins_screen->add_plugin_meta_links( $actions );

--- a/tests/UI/RowActionsTest.php
+++ b/tests/UI/RowActionsTest.php
@@ -29,8 +29,8 @@ final class RowActionsTest extends TestCase {
 	/**
 	 * The setUp run before each test
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up(): void {
+		parent::set_up();
 
 		self::$row_actions = new Row_Actions( new Parsely() );
 	}
@@ -44,7 +44,7 @@ final class RowActionsTest extends TestCase {
 	 * @covers \Parsely\UI\Row_Actions::run
 	 * @group ui
 	 */
-	public function test_row_actions_class_will_not_add_row_actions_filter_when_enabling_filter_returns_false() {
+	public function test_row_actions_class_will_not_add_row_actions_filter_when_enabling_filter_returns_false(): void {
 		// wp_parsely_enable_row_action_links is false by default.
 		self::$row_actions->run();
 
@@ -61,7 +61,7 @@ final class RowActionsTest extends TestCase {
 	 * @covers \Parsely\UI\Row_Actions::run
 	 * @group ui
 	 */
-	public function test_row_actions_class_will_add_row_actions_filter_when_enabling_filter_returns_true() {
+	public function test_row_actions_class_will_add_row_actions_filter_when_enabling_filter_returns_true(): void {
 		add_filter( 'wp_parsely_enable_row_action_links', '__return_true' );
 		self::$row_actions->run();
 
@@ -83,7 +83,7 @@ final class RowActionsTest extends TestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group ui
 	 */
-	public function test_can_correctly_determine_if_Parsely_link_can_be_shown_when_actions_are_an_array_or_not() {
+	public function test_can_correctly_determine_if_Parsely_link_can_be_shown_when_actions_are_an_array_or_not(): void {
 		$cannot_show_parsely_link = self::getMethod( 'cannot_show_parsely_link', Row_Actions::class );
 
 		$published_post = self::factory()->post->create_and_get();
@@ -108,7 +108,7 @@ final class RowActionsTest extends TestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group ui
 	 */
-	public function test_can_correctly_determine_if_Parsely_link_can_be_shown_when_post_has_trackable_status_or_not() {
+	public function test_can_correctly_determine_if_Parsely_link_can_be_shown_when_post_has_trackable_status_or_not(): void {
 		$cannot_show_parsely_link = self::getMethod( 'cannot_show_parsely_link', Row_Actions::class );
 
 		$draft_post     = self::factory()->post->create_and_get( array( 'post_status' => 'draft' ) );
@@ -136,7 +136,7 @@ final class RowActionsTest extends TestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group ui
 	 */
-	public function test_can_correctly_determine_if_Parsely_link_can_be_shown_when_post_is_viewable_or_not() {
+	public function test_can_correctly_determine_if_Parsely_link_can_be_shown_when_post_is_viewable_or_not(): void {
 		$cannot_show_parsely_link = self::getMethod( 'cannot_show_parsely_link', Row_Actions::class );
 
 		$non_publicly_queryable_post = self::factory()->post->create_and_get( array( 'post_type' => 'parsely_tests_pt' ) );
@@ -164,7 +164,7 @@ final class RowActionsTest extends TestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group ui
 	 */
-	public function test_can_correctly_determine_if_Parsely_link_can_be_shown_when_api_key_is_set_or_missing() {
+	public function test_can_correctly_determine_if_Parsely_link_can_be_shown_when_api_key_is_set_or_missing(): void {
 		$cannot_show_parsely_link = self::getMethod( 'cannot_show_parsely_link', Row_Actions::class );
 
 		$published_post = self::factory()->post->create_and_get();
@@ -199,7 +199,7 @@ final class RowActionsTest extends TestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group ui
 	 */
-	public function test_link_to_Parsely_is_not_added_to_row_actions_when_conditions_fail() {
+	public function test_link_to_Parsely_is_not_added_to_row_actions_when_conditions_fail(): void {
 		// Insert a single post and set as global post.
 		// This post is a viewable type, with a trackable status (published).
 		$post_id = self::factory()->post->create( array( 'post_title' => 'Foo1' ) );
@@ -235,7 +235,7 @@ final class RowActionsTest extends TestCase {
 	 * @uses \Parsely::update_metadata_endpoint
 	 * @group ui
 	 */
-	public function test_link_to_Parsely_is_added_to_row_actions() {
+	public function test_link_to_Parsely_is_added_to_row_actions(): void {
 		// Insert a single post and set as global post.
 		// This post is a viewable type, with a trackable status (published).
 		$post_id = self::factory()->post->create( array( 'post_title' => 'Foo2' ) );

--- a/tests/Unit/Integrations/IntegrationsTest.php
+++ b/tests/Unit/Integrations/IntegrationsTest.php
@@ -23,7 +23,7 @@ final class IntegrationsTest extends TestCase {
 	 *
 	 * @covers \Parsely\Integrations\Integrations::register
 	 */
-	public function test_an_integration_can_be_registered_to_a_new_Integrations_object() {
+	public function test_an_integration_can_be_registered_to_a_new_Integrations_object(): void {
 		$integrations = new Integrations();
 
 		$integrations->register( 'class', FakeIntegration::class );
@@ -51,7 +51,7 @@ final class IntegrationsTest extends TestCase {
 	 * @covers \Parsely\Integrations\Integrations::integrate
 	 * @uses \Parsely\Integrations\Integrations::register
 	 */
-	public function test_registered_integrations_have_their_integrate_method_called() {
+	public function test_registered_integrations_have_their_integrate_method_called(): void {
 		$mock_integration = $this->getMockBuilder( Integration::class )->setMethods( array( 'integrate' ) )->getMock();
 		$mock_integration->expects( $this->once() )->method( 'integrate' );
 
@@ -80,7 +80,7 @@ class FakeIntegration2 {
 	/**
 	 * Stub this method to avoid a fatal error.
 	 */
-	public function integrate() {
+	public function integrate(): void {
 	}
 }
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -39,7 +39,7 @@ define( 'PARSELY_FILE', __FILE__ );
 require __DIR__ . '/src/class-parsely.php';
 add_action(
 	'plugins_loaded',
-	function() {
+	function(): void {
 		$GLOBALS['parsely'] = new Parsely();
 		$GLOBALS['parsely']->run();
 	}
@@ -50,7 +50,7 @@ require __DIR__ . '/src/UI/class-plugins-actions.php';
 require __DIR__ . '/src/UI/class-row-actions.php';
 add_action(
 	'admin_init',
-	function() {
+	function(): void {
 		$GLOBALS['parsely_ui_plugins_actions'] = new Parsely\UI\Plugins_Actions();
 		$GLOBALS['parsely_ui_plugins_actions']->run();
 
@@ -64,8 +64,10 @@ require __DIR__ . '/src/class-parsely-recommended-widget.php';
 add_action( 'widgets_init', 'parsely_recommended_widget_register' );
 /**
  * Register the Parse.ly Recommended widget.
+ *
+ * @return void
  */
-function parsely_recommended_widget_register() {
+function parsely_recommended_widget_register(): void {
 	register_widget( 'Parsely_Recommended_Widget' );
 }
 
@@ -80,8 +82,10 @@ add_action( 'init', 'parsely_load_textdomain' );
  * This can be removed once minimum supported WordPress is 4.6 or later.
  *
  * @since 2.5.0
+ *
+ * @return void
  */
-function parsely_load_textdomain() {
+function parsely_load_textdomain(): void {
 	load_plugin_textdomain( 'wp-parsely' );
 }
 
@@ -95,8 +99,10 @@ add_action( 'init', 'parsely_integrations' );
  * Instantiate Integrations collection and register built-in integrations.
  *
  * @since 2.6.0
+ *
+ * @return Integrations
  */
-function parsely_integrations() {
+function parsely_integrations(): Integrations {
 	$parsely_integrations = new Integrations();
 	$parsely_integrations->register( 'amp', Amp::class );
 	$parsely_integrations->register( 'fbia', Facebook_Instant_Articles::class );


### PR DESCRIPTION
## Description
Add return types to functions and methods, and add/update `@return` DocBlocks as needed.

## Motivation and Context
It allows us to work in a more strongly-typed codebase, which reduces the chances of bugs that happen through silent type coercion. See #389.

## How Has This Been Tested?
Run the CI tests.