### PR TITLE
Adding filter to toggle registration of scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,7 +335,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for parsely-page and JavaScript on home page and published pages and posts as well as archive pages (date/author/category/tag).
 
 [2.6.1]: https://github.com/Parsely/wp-parsely/compare/2.6.0...2.6.1
-[2.6.0]: https://github.com/Parsely/wp-parsely/compare/2.5.2...2.6.0_
+[2.6.0]: https://github.com/Parsely/wp-parsely/compare/2.5.2...2.6.0
 [2.5.2]: https://github.com/Parsely/wp-parsely/compare/2.5.1...2.5.2
 [2.5.1]: https://github.com/Parsely/wp-parsely/compare/2.5.0...2.5.1
 [2.5.0]: https://github.com/Parsely/wp-parsely/compare/2.4.1...2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.1] - 2021-10-05
+
+### Added
+
+- Adding filters to toggle registration of scripts #432
+
 ## [2.6.0] - 2021-09-29
 
 ### Added
@@ -326,9 +332,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.0] - 2012-07-15
 
 - Initial version.
-- Add sSupport for parsely-page and JavaScript on home page and published pages and posts as well as archive pages (date/author/category/tag).
+- Add support for parsely-page and JavaScript on home page and published pages and posts as well as archive pages (date/author/category/tag).
 
-[2.6.0]: https://github.com/Parsely/wp-parsely/compare/2.5.2...2.6.0
+[2.6.1]: https://github.com/Parsely/wp-parsely/compare/2.6.0...2.6.1
+[2.6.0]: https://github.com/Parsely/wp-parsely/compare/2.5.2...2.6.0_
 [2.5.2]: https://github.com/Parsely/wp-parsely/compare/2.5.1...2.5.2
 [2.5.1]: https://github.com/Parsely/wp-parsely/compare/2.5.0...2.5.1
 [2.5.0]: https://github.com/Parsely/wp-parsely/compare/2.4.1...2.5.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 2.6.0
+Stable tag: 2.6.1
 Requires at least: 4.0  
 Tested up to: 5.8  
 Requires PHP: 5.6  

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -805,7 +805,6 @@ class Parsely {
 		 * By default, the tags are inserted.
 		 *
 		 * @since 2.6.1
-		 *
 		 */
 		if ( ! apply_filters( 'wp_parsely_should_insert_parsely_page', true ) ) {
 			return;
@@ -1282,7 +1281,6 @@ class Parsely {
 		 * By default, scripts are loaded.
 		 *
 		 * @since 2.6.1
-		 *
 		 */
 		if ( ! apply_filters( 'wp_parsely_should_register_js', true ) ) {
 			return;

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1275,17 +1275,6 @@ class Parsely {
 	 * @return void
 	 */
 	public function register_js() {
-		/**
-		 * Filters whether the Parse.ly scripts should be registered (loaded).
-		 *
-		 * By default, scripts are loaded.
-		 *
-		 * @since 2.6.1
-		 */
-		if ( ! apply_filters( 'wp_parsely_should_register_js', true ) ) {
-			return;
-		}
-
 		$parsely_options = $this->get_options();
 
 		if ( $this->api_key_is_missing() ) {

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -118,6 +118,7 @@ class Parsely {
 		add_filter( 'cron_schedules', array( $this, 'wpparsely_add_cron_interval' ) );
 
 		add_action( 'parsely_bulk_metas_update', array( $this, 'bulk_update_posts' ) );
+
 		// inserting parsely code.
 		add_action( 'wp_head', array( $this, 'insert_parsely_page' ) );
 		add_action( 'init', array( $this, 'register_js' ) );
@@ -798,6 +799,18 @@ class Parsely {
 	 * Actually inserts the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
 	 */
 	public function insert_parsely_page() {
+		/**
+		 * Filters whether the Parse.ly meta tags should be inserted in the page.
+		 *
+		 * By default, the tags are inserted.
+		 *
+		 * @since 2.6.1
+		 *
+		 */
+		if ( ! apply_filters( 'wp_parsely_should_insert_parsely_page', true ) ) {
+			return;
+		}
+
 		$parsely_options = $this->get_options();
 
 		if (
@@ -1263,6 +1276,18 @@ class Parsely {
 	 * @return void
 	 */
 	public function register_js() {
+		/**
+		 * Filters whether the Parse.ly scripts should be registered (loaded).
+		 *
+		 * By default, scripts are loaded.
+		 *
+		 * @since 2.6.1
+		 *
+		 */
+		if ( ! apply_filters( 'wp_parsely_should_register_js', true ) ) {
+			return;
+		}
+
 		$parsely_options = $this->get_options();
 
 		if ( $this->api_key_is_missing() ) {

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://www.parse.ly/help/integration/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code to your WordPress blog.
- * Version:           2.6.0
+ * Version:           2.6.1
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -31,7 +31,7 @@ if ( class_exists( 'Parsely' ) ) {
 	return;
 }
 
-define( 'PARSELY_VERSION', '2.6.0' );
+define( 'PARSELY_VERSION', '2.6.1' );
 define( 'PARSELY_FILE', __FILE__ );
 
 require __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
## Description

This PR releases a new version of the plugin, `2.6.1`, that contains an additional hook to control the plugin's behavior:

- `wp_parsely_should_insert_parsely_page`. Whether the Parse.ly metadata should be inserted in the page's HTML.

By default, the meta tags are rendered (the filters return `true`). 

## Motivation and Context

Some of the plugin's users are using it in a slightly custom way, where they don't always want to display the scripts that Parse.ly adds. 

## How Has This Been Tested?

Tested that both hooks indeed toggle the rendering of the scripts.

## Types of changes

New feature (non-breaking change which adds functionality)