### PR TITLE
Displaying Open on Parse.ly links by default

### DIFF
--- a/src/UI/class-row-actions.php
+++ b/src/UI/class-row-actions.php
@@ -48,7 +48,7 @@ final class Row_Actions {
 		 *
 		 * @param bool $enabled True if enabled, false if not.
 		 */
-		if ( apply_filters( 'wp_parsely_enable_row_action_links', false ) ) {
+		if ( apply_filters( 'wp_parsely_enable_row_action_links', true ) ) {
 			add_filter( 'post_row_actions', array( $this, 'row_actions_add_parsely_link' ), 10, 2 );
 			add_filter( 'page_row_actions', array( $this, 'row_actions_add_parsely_link' ), 10, 2 );
 		}


### PR DESCRIPTION
## Description

This PR changes the default behavior of the filter that controls whether or not to display the _Open on Parse.ly_ links on posts and pages in `wp-admin`. With this changes, the links will display by default. We are keeping the filter in case the functionality needs to be disabled or displayed only in certain cases.

## Motivation and Context

Making the feature widely available.

## How Has This Been Tested?

Running the plugin's default configuration and by manually setting the filter to `false`.

## Screenshots (if appropriate):

<img width="422" alt="Screen Shot 2021-10-05 at 4 14 19 PM" src="https://user-images.githubusercontent.com/7188409/136040672-68b1b986-648e-4bc0-a26c-852570d811d8.png">

## Types of changes

New feature (non-breaking change which adds functionality)