### PR TITLE
Adding E2E test to check for available recommended widget

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -61,6 +61,14 @@ When you're finished testing, the back end containers and storage can be dispatc
 
 Please note: the **mysql database storage is not persisted** to a docker volume, so its contents will be lost even if you omit the `-v` flag.
 
+### E2E test utilities
+
+Some utilities for the end-to-end tests are available in the [utils.js](utils.js) file. The purpose of that file is to implement some common functionalities used in the tests. 
+
+We currently have:
+
+- `waitForWpAdmin`. Halts the execution of the test until wp-admin is fully loaded.
+
 ### CI / Automated Testing
 
 These tests are hooked in to a Github workflow called [End-to-end (e2e) Tests](../../.github/workflows/e2e-tests.yml). It uses the same The [docker-compose configuration](./docker-compose.yml) mentioned above to spin up a WordPress environment to test against.

--- a/tests/e2e/specs/activation-flow.spec.js
+++ b/tests/e2e/specs/activation-flow.spec.js
@@ -1,10 +1,16 @@
+/**
+ * External dependencies
+ */
 import {
 	activatePlugin,
 	loginUser,
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
+/**
+ * Internal dependencies
+ */
+import { waitForWpAdmin } from '../utils';
 
 describe( 'Activation flow', () => {
 	jest.setTimeout( 30000 );

--- a/tests/e2e/specs/plugin-action-link.spec.js
+++ b/tests/e2e/specs/plugin-action-link.spec.js
@@ -1,10 +1,16 @@
+/**
+ * External dependencies
+ */
 import {
 	activatePlugin,
 	loginUser,
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
+/**
+ * Internal dependencies
+ */
+import { waitForWpAdmin } from '../utils';
 
 describe( 'Plugin action link', () => {
 	jest.setTimeout( 30000 );
@@ -15,7 +21,7 @@ describe( 'Plugin action link', () => {
 
 		await waitForWpAdmin();
 
-		await expect(page).toClick( '[data-slug=wp-parsely] .settings>a', { text: 'Settings' } );
+		await expect( page ).toClick( '[data-slug=wp-parsely] .settings>a', { text: 'Settings' } );
 		await waitForWpAdmin();
 
 		const versionText = await page.$eval( '#wp-parsely_version', ( el ) => el.innerText );

--- a/tests/e2e/specs/recommended-widget.spec.js
+++ b/tests/e2e/specs/recommended-widget.spec.js
@@ -1,0 +1,34 @@
+import {
+	activatePlugin,
+	loginUser,
+	visitAdminPage,
+} from '@wordpress/e2e-test-utils';
+
+const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
+
+describe( 'Recommended widget', () => {
+	jest.setTimeout( 30000 );
+	it( 'Widget should be available', async () => {
+		await loginUser();
+		await activatePlugin( 'wp-parsely' );
+		await visitAdminPage( '/widgets.php', '' );
+
+		await waitForWpAdmin();
+
+		await page.keyboard.press( 'Escape' );
+
+		await page.click( '.block-list-appender' );
+		await page.focus( '#block-editor-inserter__search-0' );
+		await page.keyboard.type( 'parse.ly recommended widget' );
+
+		const [ button ] = await page.$x( "//button[contains(., 'Parse.ly Recommended Widget')]" );
+		await button.click();
+
+		await page.waitForSelector( '.wp-block-legacy-widget__edit-form-title', {
+			visible: true,
+		} );
+
+		const [ h3 ] = await page.$x( "//h3[contains(., 'Parse.ly Recommended Widget')]" );
+		expect( h3 ).toBeTruthy();
+	} );
+} );

--- a/tests/e2e/specs/recommended-widget.spec.js
+++ b/tests/e2e/specs/recommended-widget.spec.js
@@ -20,6 +20,11 @@ const searchForParselyWidget = async () => {
 	await page.keyboard.type( 'parse.ly recommended widget' );
 };
 
+const selectParselyWidgetFromWidgetSearch = async () => {
+	const [ button ] = await page.$x( "//button[contains(., 'Parse.ly Recommended Widget')]" );
+	await button.click();
+};
+
 describe( 'Recommended widget', () => {
 	jest.setTimeout( 30000 );
 	it( 'Widget should be available', async () => {
@@ -31,14 +36,12 @@ describe( 'Recommended widget', () => {
 
 		await closeWidgetScreenModal();
 		await searchForParselyWidget();
+		await selectParselyWidgetFromWidgetSearch();
 
-		const [ button ] = await page.$x( "//button[contains(., 'Parse.ly Recommended Widget')]" );
-		await button.click();
-
+		// Checking if Parse.ly widget is present in the widgets list
 		await page.waitForSelector( '.wp-block-legacy-widget__edit-form-title', {
 			visible: true,
 		} );
-
 		const [ h3 ] = await page.$x( "//h3[contains(., 'Parse.ly Recommended Widget')]" );
 		expect( h3 ).toBeTruthy();
 	} );

--- a/tests/e2e/specs/recommended-widget.spec.js
+++ b/tests/e2e/specs/recommended-widget.spec.js
@@ -17,7 +17,7 @@ const closeWidgetScreenModal = () => page.keyboard.press( 'Escape' );
 const searchForParselyWidget = async () => {
 	await page.click( '.block-list-appender' );
 	await page.focus( '#block-editor-inserter__search-0' );
-	page.keyboard.type( 'parse.ly recommended widget' );
+	await page.keyboard.type( 'parse.ly recommended widget' );
 };
 
 describe( 'Recommended widget', () => {

--- a/tests/e2e/specs/recommended-widget.spec.js
+++ b/tests/e2e/specs/recommended-widget.spec.js
@@ -1,10 +1,16 @@
+/**
+ * External dependencies
+ */
 import {
 	activatePlugin,
 	loginUser,
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
+/**
+ * Internal dependencies
+ */
+import { waitForWpAdmin } from '../utils';
 
 describe( 'Recommended widget', () => {
 	jest.setTimeout( 30000 );

--- a/tests/e2e/specs/recommended-widget.spec.js
+++ b/tests/e2e/specs/recommended-widget.spec.js
@@ -12,6 +12,14 @@ import {
  */
 import { waitForWpAdmin } from '../utils';
 
+const closeWidgetScreenModal = () => page.keyboard.press( 'Escape' );
+
+const searchForParselyWidget = async () => {
+	await page.click( '.block-list-appender' );
+	await page.focus( '#block-editor-inserter__search-0' );
+	page.keyboard.type( 'parse.ly recommended widget' );
+};
+
 describe( 'Recommended widget', () => {
 	jest.setTimeout( 30000 );
 	it( 'Widget should be available', async () => {
@@ -21,11 +29,8 @@ describe( 'Recommended widget', () => {
 
 		await waitForWpAdmin();
 
-		await page.keyboard.press( 'Escape' );
-
-		await page.click( '.block-list-appender' );
-		await page.focus( '#block-editor-inserter__search-0' );
-		await page.keyboard.type( 'parse.ly recommended widget' );
+		await closeWidgetScreenModal();
+		await searchForParselyWidget();
 
 		const [ button ] = await page.$x( "//button[contains(., 'Parse.ly Recommended Widget')]" );
 		await button.click();

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -1,0 +1,1 @@
+export const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );


### PR DESCRIPTION
## Description

This PR adds an end to end test that checks if the recommended widget exists an can be added in the site. We have also extracted some common functions into an utils file.

## Motivation and Context

Improve overall testing on the plugin.

## How Has This Been Tested?

Tests pass locally and in GitHub Actions

## Types of changes

New feature (non-breaking change which adds functionality)