### PR TITLE
Remove deprecated filter after_set_parsely_page

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1058,23 +1058,6 @@ class Parsely {
 		/**
 		 * Filters the structured metadata.
 		 *
-		 * @deprecated 2.5.0 Use `wp_parsely_metadata` filter instead.
-		 * @since 1.10.0
-		 *
-		 * @param array   $parsely_page    Existing structured metadata for a page.
-		 * @param WP_Post $post            Post object.
-		 * @param array   $parsely_options The Parsely options.
-		 */
-		$parsely_page = apply_filters_deprecated(
-			'after_set_parsely_page',
-			array( $parsely_page, $post, $parsely_options ),
-			'2.5.0',
-			'wp_parsely_metadata'
-		);
-
-		/**
-		 * Filters the structured metadata.
-		 *
 		 * @since 2.5.0
 		 *
 		 * @param array   $parsely_page    Existing structured metadata for a page.

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -253,7 +253,6 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	/**
 	 * Check out page filtering.
 	 *
-	 * @expectedDeprecated after_set_parsely_page
 	 * @covers \Parsely::construct_parsely_metadata
 	 * @uses \Parsely::get_author_name
 	 * @uses \Parsely::get_author_names
@@ -282,7 +281,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 		// Apply page filtering.
 		$headline = 'Completely New And Original Filtered Headline';
 		add_filter(
-			'after_set_parsely_page',
+			'wp_parsely_metadata',
 			function( $args ) use ( $headline ) {
 				$args['headline'] = $headline;
 


### PR DESCRIPTION
## Description

This PR removes the deprecated filter `after_set_parsely_page`. The filter got renamed in version 2.5 to `wp_parsely_metadata`, hence it's a drop-in replacement.

## Motivation and Context

General cleanup for major version.

## How Has This Been Tested?

Updated unit tests and checked for broken parts of the code and missing references.

## Screenshots (if appropriate):

## Types of changes

Breaking change (fix or feature that would cause existing functionality to change)
