### PR TITLE
Remove deprecated filter parsely_filter_insert_javascript

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1275,25 +1275,6 @@ class Parsely {
 		}
 
 		/**
-		 * Filters whether to include the Parsely JavaScript file.
-		 *
-		 * If true, the JavaScript files are sourced.
-		 *
-		 * @since 2.2.0
-		 * @deprecated 2.5.0 Use `wp_parsely_load_js_tracker` filter instead.
-		 *
-		 * @param bool $display True if the JavaScript file should be included. False if not.
-		 */
-		if ( ! apply_filters_deprecated(
-			'parsely_filter_insert_javascript',
-			array( $display ),
-			'2.5.0',
-			'wp_parsely_load_js_tracker'
-		) ) {
-			return;
-		}
-
-		/**
 		 * Filters whether to enqueue the Parsely JavaScript tracking script from the CDN.
 		 *
 		 * If true, the script is enqueued.

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -494,47 +494,6 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 	}
 
 	/**
-	 * Test the parsely_filter_insert_javascript filter
-	 * When it returns false, the tracking script should not be enqueued.
-	 *
-	 * @deprecated deprecated since 2.5.0. This test can be removed when the filter is removed.
-	 *
-	 * @expectedDeprecated parsely_filter_insert_javascript
-	 *
-	 * @covers \Parsely::load_js_tracker
-	 * @uses \Parsely::api_key_is_missing
-	 * @uses \Parsely::api_key_is_set
-	 * @uses \Parsely::get_options
-	 * @uses \Parsely::post_has_trackable_status
-	 * @uses \Parsely::update_metadata_endpoint
-	 */
-	public function test_deprecated_insert_javascript_filter(): void {
-		add_filter( 'parsely_filter_insert_javascript', '__return_false' );
-
-		ob_start();
-		$post_array = $this->create_test_post_array();
-		$post       = $this->factory->post->create( $post_array );
-		$this->go_to( '/?p=' . $post );
-		self::$parsely->load_js_tracker();
-		$intermediate_output = ob_get_contents();
-
-		self::assertSame(
-			'',
-			$intermediate_output,
-			'Failed to confirm scripts were not printed by load_js_tracker()'
-		);
-
-		wp_print_scripts();
-
-		$output = ob_get_clean();
-		self::assertSame(
-			'',
-			$output,
-			'Failed to confirm filter prevented enqueued scripts'
-		);
-	}
-
-	/**
 	 * Test the wp_parsely_post_type filter
 	 *
 	 * @covers \Parsely::construct_parsely_metadata


### PR DESCRIPTION
## Description

This PR removes the deprecated filter `parsely_filter_insert_javascript`. The filter got renamed in version 2.5 to `wp_parsely_load_js_tracker`, hence it's a drop-in replacement.

## Motivation and Context

General cleanup for major version.

## How Has This Been Tested?

Updated unit tests and checked for broken parts of the code and missing references.

## Screenshots (if appropriate):

## Types of changes

Breaking change (fix or feature that would cause existing functionality to change)
