### PR TITLE
Update defaults in `get_bottom_level_term` to empty array to prevent warnings downstream

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1643,8 +1643,8 @@ class Parsely {
 	 */
 	private function get_bottom_level_term( $post_id, $taxonomy_name ): string {
 		$terms    = get_the_terms( $post_id, $taxonomy_name );
-		$term_ids = is_array( $terms ) ? wp_list_pluck( $terms, 'term_id' ) : null;
-		$parents  = is_array( $terms ) ? array_filter( wp_list_pluck( $terms, 'parent' ) ) : null;
+		$term_ids = is_array( $terms ) ? wp_list_pluck( $terms, 'term_id' ) : [];
+		$parents  = is_array( $terms ) ? array_filter( wp_list_pluck( $terms, 'parent' ) ) : [];
 
 		// Get array of IDs of terms which are not parents.
 		$term_ids_not_parents = array_diff( $term_ids, $parents );

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1643,8 +1643,8 @@ class Parsely {
 	 */
 	private function get_bottom_level_term( $post_id, $taxonomy_name ): string {
 		$terms    = get_the_terms( $post_id, $taxonomy_name );
-		$term_ids = is_array( $terms ) ? wp_list_pluck( $terms, 'term_id' ) : [];
-		$parents  = is_array( $terms ) ? array_filter( wp_list_pluck( $terms, 'parent' ) ) : [];
+		$term_ids = is_array( $terms ) ? wp_list_pluck( $terms, 'term_id' ) : array();
+		$parents  = is_array( $terms ) ? array_filter( wp_list_pluck( $terms, 'parent' ) ) : array();
 
 		// Get array of IDs of terms which are not parents.
 		$term_ids_not_parents = array_diff( $term_ids, $parents );


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Change default from null to empty array to prevent warnings thrown by array_diff on line 1743 and any subsequent functions with array as a typehint

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Visit any site with Parsely enabled
2. Use Query Monitor or similar to view PHP Errors
3. Verify no `array_diff(): Argument #2 must be of type array, null` or `array_intersect_key(): Argument #2 must be of type array, null` errors occur
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
