### PR TITLE
Constant return type on insert_parsely_page

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -856,7 +856,10 @@ class Parsely {
 	}
 
 	/**
-	 * Actually inserts the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
+	 * Deprecated. Echoes the metadata into the page, and returns the inserted values.
+	 *
+	 * To just echo the metadata, use the `insert_page_header_metadata()` method.
+	 * To get the metadata to be inserted, use the `construct_parsely_metadata()` method.
 	 *
 	 * @deprecated 3.0.0
 	 * @see construct_parsely_metadata()

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -121,7 +121,7 @@ class Parsely {
 		add_action( 'parsely_bulk_metas_update', array( $this, 'bulk_update_posts' ) );
 
 		// inserting parsely code.
-		add_action( 'wp_head', array( $this, 'insert_parsely_page' ) );
+		add_action( 'wp_head', array( $this, 'insert_page_header_metadata' ) );
 		add_action( 'init', array( $this, 'register_js' ) );
 
 		// load_js_api should be called prior to load_js_tracker so the relevant scripts are enqueued in order.
@@ -770,9 +770,11 @@ class Parsely {
 	/**
 	 * Actually inserts the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
 	 *
+	 * @since 3.0.0
+	 *
 	 * @return void
 	 */
-	public function insert_parsely_page(): void {
+	public function insert_page_header_metadata(): void {
 		/**
 		 * Filters whether the Parse.ly meta tags should be inserted in the page.
 		 *
@@ -789,16 +791,16 @@ class Parsely {
 		$parsely_options = $this->get_options();
 
 		if (
-			$this->api_key_is_missing() ||
+				$this->api_key_is_missing() ||
 
-			// Chosen not to track logged-in users.
-			( ! $parsely_options['track_authenticated_users'] && $this->parsely_is_user_logged_in() ) ||
+				// Chosen not to track logged-in users.
+				( ! $parsely_options['track_authenticated_users'] && $this->parsely_is_user_logged_in() ) ||
 
-			// 404 pages are not tracked.
-			is_404() ||
+				// 404 pages are not tracked.
+				is_404() ||
 
-			// Search pages are not tracked.
-			is_search()
+				// Search pages are not tracked.
+				is_search()
 		) {
 			return;
 		}
@@ -826,14 +828,14 @@ class Parsely {
 			}
 
 			$parsely_metas = array(
-				'title'     => $parsely_page['headline'] ?? null,
-				'link'      => $parsely_page['url'] ?? null,
-				'type'      => $parsely_post_type,
-				'image-url' => $parsely_page['thumbnailUrl'] ?? null,
-				'pub-date'  => $parsely_page['datePublished'] ?? null,
-				'section'   => $parsely_page['articleSection'] ?? null,
-				'tags'      => $parsely_page['keywords'] ?? null,
-				'author'    => isset( $parsely_page['author'] ),
+					'title'     => $parsely_page['headline'] ?? null,
+					'link'      => $parsely_page['url'] ?? null,
+					'type'      => $parsely_post_type,
+					'image-url' => $parsely_page['thumbnailUrl'] ?? null,
+					'pub-date'  => $parsely_page['datePublished'] ?? null,
+					'section'   => $parsely_page['articleSection'] ?? null,
+					'tags'      => $parsely_page['keywords'] ?? null,
+					'author'    => isset( $parsely_page['author'] ),
 			);
 			$parsely_metas = array_filter( $parsely_metas, array( $this, 'filter_empty_and_not_string_from_array' ) );
 
@@ -851,6 +853,20 @@ class Parsely {
 		}
 
 		echo '<!-- END Parse.ly -->' . "\n\n";
+	}
+
+	/**
+	 * Actually inserts the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
+	 *
+	 * @deprecated 3.0.0
+	 * @see construct_parsely_metadata()
+	 *
+	 * @return array
+	 */
+	public function insert_parsely_page(): array {
+		_deprecated_function( __FUNCTION__, '3.0', 'construct_parsely_metadata()');
+		$this->insert_page_header_metadata();
+		return $this->get_options();
 	}
 
 	/**

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -866,7 +866,9 @@ class Parsely {
 	public function insert_parsely_page(): array {
 		_deprecated_function( __FUNCTION__, '3.0', 'construct_parsely_metadata()' );
 		$this->insert_page_header_metadata();
-		return $this->get_options();
+
+		global $post;
+		return $this->construct_parsely_metadata( $this->get_options(), $post );
 	}
 
 	/**

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -770,9 +770,9 @@ class Parsely {
 	/**
 	 * Actually inserts the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
 	 *
-	 * @return string|null|array
+	 * @return void
 	 */
-	public function insert_parsely_page() {
+	public function insert_parsely_page(): void {
 		/**
 		 * Filters whether the Parse.ly meta tags should be inserted in the page.
 		 *
@@ -800,7 +800,7 @@ class Parsely {
 			// Search pages are not tracked.
 			is_search()
 		) {
-			return '';
+			return;
 		}
 
 		global $post;
@@ -851,8 +851,6 @@ class Parsely {
 		}
 
 		echo '<!-- END Parse.ly -->' . "\n\n";
-
-		return $parsely_page;
 	}
 
 	/**

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -828,14 +828,14 @@ class Parsely {
 			}
 
 			$parsely_metas = array(
-					'title'     => $parsely_page['headline'] ?? null,
-					'link'      => $parsely_page['url'] ?? null,
-					'type'      => $parsely_post_type,
-					'image-url' => $parsely_page['thumbnailUrl'] ?? null,
-					'pub-date'  => $parsely_page['datePublished'] ?? null,
-					'section'   => $parsely_page['articleSection'] ?? null,
-					'tags'      => $parsely_page['keywords'] ?? null,
-					'author'    => isset( $parsely_page['author'] ),
+				'title'     => $parsely_page['headline'] ?? null,
+				'link'      => $parsely_page['url'] ?? null,
+				'type'      => $parsely_post_type,
+				'image-url' => $parsely_page['thumbnailUrl'] ?? null,
+				'pub-date'  => $parsely_page['datePublished'] ?? null,
+				'section'   => $parsely_page['articleSection'] ?? null,
+				'tags'      => $parsely_page['keywords'] ?? null,
+				'author'    => isset( $parsely_page['author'] ),
 			);
 			$parsely_metas = array_filter( $parsely_metas, array( $this, 'filter_empty_and_not_string_from_array' ) );
 
@@ -864,7 +864,7 @@ class Parsely {
 	 * @return array
 	 */
 	public function insert_parsely_page(): array {
-		_deprecated_function( __FUNCTION__, '3.0', 'construct_parsely_metadata()');
+		_deprecated_function( __FUNCTION__, '3.0', 'construct_parsely_metadata()' );
 		$this->insert_page_header_metadata();
 		return $this->get_options();
 	}


### PR DESCRIPTION
## Description

This PR refactors the `insert_parsely_page` method to have a constant return type, `void` (it used to return `null`, an empty string, or an unused array depending on the case). The main purpose of this method is to `echo` the Parse.ly tags into the page.

## Motivation and Context

https://github.com/Parsely/wp-parsely/issues/423

https://github.com/Parsely/wp-parsely/issues/389

## How Has This Been Tested?

All tests suites passing and Parse.ly tags rendering in the header.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)