### PR TITLE
Adding uninstall script

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,20 +1,21 @@
 <?php
 /**
- * Uninstall script for wp-parsely. It deletes the `parsely` option on the database
+ * Uninstall script for wp-parsely. It deletes the `parsely` option on the database.
  *
+ * @package      Parsely\wp-parsely
  * @since 3.0.0
  */
 
 declare(strict_types=1);
 
-// if uninstall.php is not called by WordPress, die
-if (!defined('WP_UNINSTALL_PLUGIN')) {
+// If uninstall.php is not called by WordPress, die.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	die;
 }
 
-$option_name = 'parsely';
+$parsely_option_name = 'parsely';
 
-delete_option($option_name);
+delete_option( $parsely_option_name );
 
-// for site options in Multisite
-delete_site_option($option_name);
+// For site options in Multisite.
+delete_site_option( $parsely_option_name );

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Uninstall script for wp-parsely. It deletes the `parsely` option on the database
+ *
+ * @since 3.0.0
+ */
+
+declare(strict_types=1);
+
+// if uninstall.php is not called by WordPress, die
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+	die;
+}
+
+$option_name = 'parsely';
+
+delete_option($option_name);
+
+// for site options in Multisite
+delete_site_option($option_name);


### PR DESCRIPTION
## Description

This PR adds an `uninstall.php` script that gets executed when the plugin is uninstalled (**not** deactivated). It simply cleans the `parsely` option up from the database.

## Motivation and Context

https://github.com/Parsely/wp-parsely/issues/394

## How Has This Been Tested?

Uninstalling the plugin in different environments deletes the `parsely` option.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
