### PR TITLE
Fixing return types of update_metadata_endpoint

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1080,18 +1080,17 @@ class Parsely {
 		return apply_filters( 'wp_parsely_metadata', $parsely_page, $post, $parsely_options );
 	}
 
-
 	/**
 	 * Updates the Parsely metadata endpoint with the new metadata of the post.
 	 *
 	 * @param int $post_id id of the post to update.
-	 * @return string
+	 * @return void
 	 */
-	public function update_metadata_endpoint( $post_id ): string {
+	public function update_metadata_endpoint( int $post_id ): void {
 		$parsely_options = $this->get_options();
 
 		if ( $this->api_key_is_missing() || empty( $parsely_options['metadata_secret'] ) ) {
-			return '';
+			return;
 		}
 
 		$post     = get_post( $post_id );
@@ -1130,8 +1129,11 @@ class Parsely {
 				'data_format' => 'body',
 			)
 		);
-		$current_timestamp       = time();
-		$meta_update             = update_post_meta( $post_id, 'parsely_metadata_last_updated', $current_timestamp );
+
+		if ( ! is_wp_error( $response ) ) {
+			$current_timestamp       = time();
+			update_post_meta( $post_id, 'parsely_metadata_last_updated', $current_timestamp );
+		}
 	}
 
 

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1131,7 +1131,7 @@ class Parsely {
 		);
 
 		if ( ! is_wp_error( $response ) ) {
-			$current_timestamp       = time();
+			$current_timestamp = time();
 			update_post_meta( $post_id, 'parsely_metadata_last_updated', $current_timestamp );
 		}
 	}


### PR DESCRIPTION
## Description

The `update_metadata_endpoint` function was not returning consistently. Since its a hook and its result is not used anywhere, we're making it return `void`.

The function basically performs a request to Parse.ly and then updates the metadata of the updated post with a timestamp. This PR also adds a check to see if the request succeeded and only updates the metadata if that's the case.

## Motivation and Context

https://github.com/Parsely/wp-parsely/issues/422

## How Has This Been Tested?

Running the code in a local environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
