### PR TITLE
Change get_current_url default type to non-post

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1848,7 +1848,6 @@ class Parsely {
 	 * Get the URL of the current PHP script.
 	 * A fall-back implementation to determine permalink
 	 *
-	 *
 	 * @param string $parsely_type Optional. Parse.ly post type you're interested in, either 'post' or 'non-post'. Default is 'non-post'.
 	 * @param int    $post_id      Optional. ID of the post you want to get the URL for. Default is 0, which means the global `$post` is used.
 	 * @return string

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1848,11 +1848,12 @@ class Parsely {
 	 * Get the URL of the current PHP script.
 	 * A fall-back implementation to determine permalink
 	 *
-	 * @param string $parsely_type Optional. Parse.ly post type you're interested in, either 'post' or 'nonpost'. Default is 'nonpost'.
+	 *
+	 * @param string $parsely_type Optional. Parse.ly post type you're interested in, either 'post' or 'non-post'. Default is 'non-post'.
 	 * @param int    $post_id      Optional. ID of the post you want to get the URL for. Default is 0, which means the global `$post` is used.
 	 * @return string
 	 */
-	public function get_current_url( $parsely_type = 'nonpost', $post_id = 0 ): string {
+	public function get_current_url( string $parsely_type = 'non-post', int $post_id = 0 ): string {
 		if ( 'post' === $parsely_type ) {
 			$permalink = (string) get_permalink( $post_id );
 
@@ -1863,7 +1864,7 @@ class Parsely {
 			 * @since 2.5.0  Added $post_id.
 			 *
 			 * @param string $permalink         The permalink URL or false if post does not exist.
-			 * @param string $parsely_type      Parse.ly type ("post" or "nonpost").
+			 * @param string $parsely_type      Parse.ly type ("post" or "non-post").
 			 * @param int    $post_id           ID of the post you want to get the URL for. May be 0, so $permalink will be
 			 *                                  for the global $post.
 			 */

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1848,6 +1848,8 @@ class Parsely {
 	 * Get the URL of the current PHP script.
 	 * A fall-back implementation to determine permalink
 	 *
+	 * @since 3.0.0 $parsely_type Default parameter changed to `non-post`.
+	 *
 	 * @param string $parsely_type Optional. Parse.ly post type you're interested in, either 'post' or 'non-post'. Default is 'non-post'.
 	 * @param int    $post_id      Optional. ID of the post you want to get the URL for. Default is 0, which means the global `$post` is used.
 	 * @return string


### PR DESCRIPTION
## Description

This PR changes the default argument of the `get_current_url` function from `nonpost` to `non-post`. This change is to keep in line with the naming of the rest of Parse.ly

## Motivation and Context

https://github.com/Parsely/wp-parsely/issues/246

## How Has This Been Tested?

Test that URL metadata in a post works fine and the URL is generated correctly.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
