### PR TITLE
Enqueue scripts with theme independent hook

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -127,11 +127,11 @@ class Parsely {
 		add_action( 'wp_head', array( $this, 'insert_page_header_metadata' ) );
 		add_action( 'init', array( $this, 'register_js' ) );
 
-		// load_js_api should be called prior to load_js_tracker so the relevant scripts are enqueued in order.
-		add_action( 'wp_footer', array( $this, 'load_js_api' ) );
-		add_action( 'wp_footer', array( $this, 'load_js_tracker' ) );
-
 		add_action( 'save_post', array( $this, 'update_metadata_endpoint' ) );
+
+		// load_js_api should be called prior to load_js_tracker so the relevant scripts are enqueued in order.
+		add_action( 'wp_enqueue_scripts', array( $this, 'load_js_api' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'load_js_tracker' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'wp_parsely_style_init' ) );
 	}
 
@@ -1284,7 +1284,7 @@ class Parsely {
 		 * @param bool $display True if the JavaScript file should be included. False if not.
 		 */
 		if ( ! apply_filters( 'wp_parsely_load_js_tracker', $display ) ) {
-				return;
+			return;
 		}
 
 		if ( ! has_filter( 'script_loader_tag', array( $this, 'script_loader_tag' ) ) ) {


### PR DESCRIPTION
## Description

This PR changes the hook in which JS scripts are enqueued, from `wp_footer` to `wp_enqueue_scripts`. They are registered as `in_footer`, no it doesn't have any other practical effect than using a non-theme dependent hook.

## Motivation and Context

https://github.com/Parsely/wp-parsely/issues/176

## How Has This Been Tested?

Tracking scripts get loaded correctly.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
