### PR TITLE
Move Parse.ly settings to views folder

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -206,7 +206,7 @@ class Parsely {
 			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-parsely' ) );
 		}
 
-		include plugin_dir_path( PARSELY_FILE ) . 'src/parsely-settings.php';
+		require_once plugin_dir_path( PARSELY_FILE ) . 'views/parsely-settings.php';
 	}
 
 	/**

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -206,7 +206,7 @@ class Parsely {
 			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-parsely' ) );
 		}
 
-		require_once plugin_dir_path( PARSELY_FILE ) . 'views/parsely-settings.php';
+		include plugin_dir_path( PARSELY_FILE ) . 'views/parsely-settings.php';
 	}
 
 	/**

--- a/views/parsely-settings.php
+++ b/views/parsely-settings.php
@@ -4,9 +4,10 @@
  *
  * Create the settings page for parse.ly
  *
- * @category   Components
- * @package    WordPress
- * @subpackage Parse.ly
+ * @package      Parsely\wp-parsely
+ * @author       Parse.ly
+ * @copyright    2012 Parse.ly
+ * @license      GPL-2.0-or-later
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
## Description

This PR moves the plugin's settings page (view) from the `src/` folder to the `views/` one. Views like it are located in that folder.

## Motivation and Context

Improved code structure.

## How Has This Been Tested?

The settings page loads correctly.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
