### PR TITLE
Adding translation support for Yes and No fields

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1431,11 +1431,11 @@ class Parsely {
 			<legend class="screen-reader-text"><span><?php echo esc_html( $args['title'] ); ?></span></legend>
 			<p>
 				<label for="<?php echo esc_attr( "{$id}_true" ); ?>">
-					<input type="radio" name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( "{$id}_true" ); ?>" value="true"<?php checked( $value ); ?> />Yes
+					<input type="radio" name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( "{$id}_true" ); ?>" value="true"<?php checked( $value ); ?> /><?php echo __('Yes', 'wp-parsely'); ?>
 				</label>
 				<br />
 				<label for="<?php echo esc_attr( "{$id}_false" ); ?>">
-					<input type="radio" name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( "{$id}_false" ); ?>" value="false"<?php checked( $value, false ); ?> />No
+					<input type="radio" name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( "{$id}_false" ); ?>" value="false"<?php checked( $value, false ); ?> /><?php echo __('No', 'wp-parsely'); ?>
 				</label>
 			</p>
 		<?php
@@ -1471,7 +1471,7 @@ class Parsely {
 
 		echo sprintf( "<input type='checkbox' name='%s' id='%s_true' value='true' ", esc_attr( $name ), esc_attr( $id ) );
 		echo checked( true === $value, true, false );
-		echo sprintf( " /> <label for='%s_true'>Yes</label>", esc_attr( $id ) );
+		echo sprintf( " /> <label for='%s_true'>%s</label>", esc_attr( $id ), __('Yes', 'wp-parsely') );
 
 		if ( isset( $args['help_text'] ) ) {
 			echo '<div class="help-text"><p class="description">' . esc_html( $args['help_text'] ) . '</p></div>';

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1471,7 +1471,7 @@ class Parsely {
 
 		echo sprintf( "<input type='checkbox' name='%s' id='%s_true' value='true' ", esc_attr( $name ), esc_attr( $id ) );
 		echo checked( true === $value, true, false );
-		echo sprintf( " /> <label for='%s_true'>%s</label>", esc_attr( $id ), esc_attr__( 'Yes', 'wp-parsely' ) );
+		echo sprintf( " /> <label for='%s_true'>%s</label>", esc_attr( $id ), esc_html__( 'Yes', 'wp-parsely' ) );
 
 		if ( isset( $args['help_text'] ) ) {
 			echo '<div class="help-text"><p class="description">' . esc_html( $args['help_text'] ) . '</p></div>';

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1431,11 +1431,11 @@ class Parsely {
 			<legend class="screen-reader-text"><span><?php echo esc_html( $args['title'] ); ?></span></legend>
 			<p>
 				<label for="<?php echo esc_attr( "{$id}_true" ); ?>">
-					<input type="radio" name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( "{$id}_true" ); ?>" value="true"<?php checked( $value ); ?> /><?php echo __('Yes', 'wp-parsely'); ?>
+					<input type="radio" name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( "{$id}_true" ); ?>" value="true"<?php checked( $value ); ?> /><?php echo esc_html__( 'Yes', 'wp-parsely' ); ?>
 				</label>
 				<br />
 				<label for="<?php echo esc_attr( "{$id}_false" ); ?>">
-					<input type="radio" name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( "{$id}_false" ); ?>" value="false"<?php checked( $value, false ); ?> /><?php echo __('No', 'wp-parsely'); ?>
+					<input type="radio" name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( "{$id}_false" ); ?>" value="false"<?php checked( $value, false ); ?> /><?php echo esc_html__( 'No', 'wp-parsely' ); ?>
 				</label>
 			</p>
 		<?php
@@ -1471,7 +1471,7 @@ class Parsely {
 
 		echo sprintf( "<input type='checkbox' name='%s' id='%s_true' value='true' ", esc_attr( $name ), esc_attr( $id ) );
 		echo checked( true === $value, true, false );
-		echo sprintf( " /> <label for='%s_true'>%s</label>", esc_attr( $id ), __('Yes', 'wp-parsely') );
+		echo sprintf( " /> <label for='%s_true'>%s</label>", esc_attr( $id ), esc_attr__( 'Yes', 'wp-parsely' ) );
 
 		if ( isset( $args['help_text'] ) ) {
 			echo '<div class="help-text"><p class="description">' . esc_html( $args['help_text'] ) . '</p></div>';


### PR DESCRIPTION
## Description

This PR marks the `Yes` and `No` fields in the settings page as translatable strings.

## Motivation and Context

https://github.com/Parsely/wp-parsely/issues/461

## How Has This Been Tested?

Tested using the [Piglatin plugin](https://github.com/nb/wordpress-piglatin).

## Screenshots (if appropriate):

**Before:**

<img width="1267" alt="Screen Shot 2021-10-21 at 5 12 03 PM" src="https://user-images.githubusercontent.com/7188409/138306644-f2994805-b21b-4522-abeb-f2b56bd63a18.png">

**After:**

<img width="1244" alt="Screen Shot 2021-10-21 at 5 11 42 PM" src="https://user-images.githubusercontent.com/7188409/138306575-0c1679c6-76ef-489c-aea4-53747fc7cde7.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
