### PR TITLE
Removing redundant code coverage annotations

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -22,8 +22,6 @@ use const Parsely\PARSELY_VERSION;
 class Parsely {
 	/**
 	 * Declare our constants
-	 *
-	 * @codeCoverageIgnoreStart
 	 */
 	public const VERSION     = PARSELY_VERSION;
 	public const MENU_SLUG   = 'parsely';             // Defines the page param passed to options-general.php.
@@ -760,12 +758,6 @@ class Parsely {
 			esc_url( 'mailto:support@parsely.com' )
 		);
 	}
-
-	/**
-	 * End the code coverage ignore.
-	 *
-	 * @codeCoverageIgnoreEnd
-	 */
 
 	/**
 	 * Actually inserts the code for the <meta name='parsely-page'> parameter within the <head></head> tag.


### PR DESCRIPTION
## Description

This PR gets rid of some code coverage annotations that disabled PHPCS. Since there was no issue in the code they comprised, we can safely remove them and enforce our rules in all the code base.

## Motivation and Context

Removing unnecessary code.

## How Has This Been Tested?

The CI pipeline that checks for style issues passes correctly without the annotations.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
