### PR TITLE
Remove custom admin CSS

### DIFF
--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -55,14 +55,6 @@ final class Settings_Page {
 	 * @return void
 	 */
 	public function add_admin_header(): void {
-		// TODO: Extract style to CSS file.
-		echo '
-<style>
-#wp-parsely_version { color: #777; font-size: 12px; margin-left: 1em; }
-.help-text { width: 75%; }
-</style>
-';
-
 		$admin_script_asset = require plugin_dir_path( PARSELY_FILE ) . 'build/admin-page.asset.php';
 		wp_enqueue_script(
 			'wp-parsely-admin',

--- a/views/parsely-settings.php
+++ b/views/parsely-settings.php
@@ -18,7 +18,8 @@ namespace Parsely;
 $parsely_version_string = sprintf( __( 'Version %s', 'wp-parsely' ), Parsely::VERSION );
 ?>
 <div class="wrap">
-	<h1 class="wp-heading-inline"><?php echo esc_html( get_admin_page_title() ); ?></h1> <span id="wp-parsely_version"><?php echo esc_html( $parsely_version_string ); ?></span>
+	<h1 class="wp-heading-inline"><?php echo esc_html( get_admin_page_title() ); ?></h1>
+	<span id="wp-parsely_version"><?php echo esc_html( $parsely_version_string ); ?></span>
 	<form name="parsely" method="post" action="options.php">
 		<?php
 		settings_fields( Parsely::OPTIONS_KEY );


### PR DESCRIPTION
## Description

This PR removes the custom CSS code that was being `echo`-ed in the admin page. It is not ideal to echo code directly and we considered moving it to a separate CSS file. However, given the low value added by that CSS, we have decided to remove it completely and rely on WordPress's default styling.

## Motivation and Context

Code cleanup.

## How Has This Been Tested?

The UI in the admin settings page is correctly rendered.

## Screenshots (if appropriate):

**Before**

<img width="368" alt="Screen Shot 2021-11-18 at 5 00 44 PM" src="https://user-images.githubusercontent.com/7188409/142450983-7573925d-0517-4ff5-a6c9-fa53ab16518f.png">

<img width="1059" alt="Screen Shot 2021-11-18 at 5 00 53 PM" src="https://user-images.githubusercontent.com/7188409/142451013-2316dbff-c6a4-4bbf-8f04-f0e7c1513fd6.png">

**After**

<img width="560" alt="Screen Shot 2021-11-18 at 4 59 53 PM" src="https://user-images.githubusercontent.com/7188409/142450838-2c6e4a18-f4b3-4a92-aaaa-3a7fbfda9ce7.png">

<img width="1013" alt="Screen Shot 2021-11-18 at 5 00 16 PM" src="https://user-images.githubusercontent.com/7188409/142450907-31dcd2ea-e891-4cfb-b653-b1e5c306d525.png">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)