### PR TITLE
Checking for updates in GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
## Description

This PR adds a configuration change that enables Dependabot on GitHub Actions. Some of our GitHub Actions depend on third-party actions and it's good to keep them up to date.

## Motivation and Context

Keeping all repository's components up to date.

## How Has This Been Tested

This is a standard code snippet, it will tested in some days when new PRs regarding GitHub Actions start appearing in the repository.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)