### PR TITLE
Running Node JS checks with latest version only

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,21 +1,15 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# This workflow will do a clean install of node dependencies, build the source code and run tests.
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI
 
 on:
   pull_request:
-    paths:
-      - .github/workflows/*.js.yml
-      - '**/*[tj]sx?'
-      - package*.json
   push:
     paths:
       - .github/workflows/*.js.yml
       - '**/*[tj]sx?'
       - package*.json
-  # Allow manually triggering the workflow.
-  workflow_dispatch:
 
 jobs:
   build:
@@ -23,8 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description

As per 3.0, the supported Node JS version for development is 16, which is now an LTS. We previously run the checks for multiple node versions, 14 and 16. The step checks if the static files can be correctly build and if the match with whatever built files are in the repository.

Given that building with different versions of node could lead to different outputs, we are removing the old version and just keeping 16, which is the one that we're currently using for development. We expect to upgrade this version whenever we upgrade the development version in `.nvmrc`. 

This PR also changes when the step is run. We want to make sure **every** pull request has the correct node code, so we are removing the conditions on the changed files and running this step always.

## Motivation and Context

Simplify the CI pipeline.

## How Has This Been Tested?

Node JS step in GitHub Actions pipeline runs correctly.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)