### PR TITLE
Removing version leak in front-end

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -193,7 +193,7 @@ class Parsely {
 			return;
 		}
 
-		echo "\n" . '<!-- BEGIN Parse.ly ' . esc_html( self::VERSION ) . ' -->' . "\n";
+		echo PHP_EOL;
 
 		// Insert JSON-LD or repeated metas.
 		if ( 'json_ld' === $parsely_options['meta_type'] ) {
@@ -230,7 +230,7 @@ class Parsely {
 			include plugin_dir_path( PARSELY_FILE ) . 'views/custom-metadata.php';
 		}
 
-		echo '<!-- END Parse.ly -->' . "\n\n";
+		echo PHP_EOL;
 	}
 
 	/**


### PR DESCRIPTION
## Description

When rendering the Parse.ly metadata in the site's front-end, the plugin displays something similar to:

```
<!-- BEGIN Parse.ly 2.6.1 -->
```

This might be a security issue, since it's revealing a WordPress plugin version in a quite obvious way to a non-authenticated user. It is also wasting some bandwidth. This PR gets rid of this HTML comment.

## Motivation and Context

Securing the plugin up.

## How Has This Been Tested?

The `BEGIN Parse.ly` comment is not rendered in the source code.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)