### PR TITLE
Adding types to function arguments in GetCurrentUrlTest

### DIFF
--- a/tests/Integration/GetCurrentUrlTest.php
+++ b/tests/Integration/GetCurrentUrlTest.php
@@ -110,7 +110,7 @@ final class GetCurrentUrlTest extends TestCase {
 	 * @param string $home        Home URL.
 	 * @param string $expected    Expected current URL.
 	 */
-	public function test_get_current_url( $force_https, $home, $expected ): void {
+	public function test_get_current_url( bool $force_https, string $home, string $expected ): void {
 		$this->set_options( array( 'force_https_canonicals' => $force_https ) );
 		update_option( 'home', $home );
 
@@ -124,7 +124,7 @@ final class GetCurrentUrlTest extends TestCase {
 	 *
 	 * @param string $expected Expected start of the URL.
 	 */
-	private function assertCurrentUrlForHomepage( $expected ): void {
+	private function assertCurrentUrlForHomepage( string $expected ): void {
 		$this->go_to( '/' );
 
 		$parsely = new Parsely();
@@ -138,7 +138,7 @@ final class GetCurrentUrlTest extends TestCase {
 	 *
 	 * @param string $expected Expected start of the URL.
 	 */
-	private function assertCurrentUrlForSpecificPostWithId( $expected ): void {
+	private function assertCurrentUrlForSpecificPostWithId( string $expected ): void {
 		$post_array = $this->create_test_post_array();
 		$post_id    = $this->factory->post->create( $post_array );
 		$this->go_to( '/?p=' . $post_id );
@@ -154,7 +154,7 @@ final class GetCurrentUrlTest extends TestCase {
 	 *
 	 * @param string $expected Expected start of the URL.
 	 */
-	private function assertCurrentUrlForRandomUrl( $expected ): void {
+	private function assertCurrentUrlForRandomUrl( string $expected ): void {
 		$parsely = new Parsely();
 		$this->go_to( '/random/url/' );
 		$res = $parsely->get_current_url();


### PR DESCRIPTION
## Description

This PR adds types to the functions that had arguments in the `GetCurrentUrlTest.php` file.

## Motivation and Context

Have strong typing across all the codebase.

## How Has This Been Tested?

Tests keep passing as expected.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)