### PR TITLE
Making sure the coauthors plugin returns a WP_User

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -788,7 +788,7 @@ class Parsely {
 						$post_author   = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_slug );
 						// In case the user has been deleted while plugin was deactivated.
 						if ( ! empty( $post_author ) ) {
-							$coauthors[] = $post_author;
+							$coauthors[] = new WP_User( $post_author );
 						}
 					}
 				} elseif ( ! $coauthors_plus->force_guest_authors ) {
@@ -861,10 +861,15 @@ class Parsely {
 		 */
 		$authors = apply_filters( 'wp_parsely_pre_authors', $authors, $post );
 
-		// Filtering falsy values from the array
-		$authors = array_filter($authors, function($x) { return !(is_null($x) || $x === false); });
+		// Filtering falsy values from the array.
+		$authors = array_filter(
+			$authors,
+			function( $x ) {
+				return ! ( is_null( $x ) || false === $x );
+			}
+		);
 
-		// Getting the author name for each author
+		// Getting the author name for each author.
 		$authors = array_map( array( $this, 'get_author_name' ), $authors );
 
 		/**

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -861,14 +861,6 @@ class Parsely {
 		 */
 		$authors = apply_filters( 'wp_parsely_pre_authors', $authors, $post );
 
-		// Filtering falsy values from the array.
-		$authors = array_filter(
-			$authors,
-			function( $x ) {
-				return ! ( is_null( $x ) || false === $x );
-			}
-		);
-
 		// Getting the author name for each author.
 		$authors = array_map( array( $this, 'get_author_name' ), $authors );
 

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -861,6 +861,10 @@ class Parsely {
 		 */
 		$authors = apply_filters( 'wp_parsely_pre_authors', $authors, $post );
 
+		// Filtering falsy values from the array
+		$authors = array_filter($authors, function($x) { return !(is_null($x) || $x === false); });
+
+		// Getting the author name for each author
 		$authors = array_map( array( $this, 'get_author_name' ), $authors );
 
 		/**

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -856,8 +856,8 @@ class Parsely {
 		 *
 		 * @since 1.14.0
 		 *
-		 * @param array   $authors One or more authors as WP_User objects (may also be `false`).
-		 * @param WP_Post $post    Post object.
+		 * @param WP_User[] $authors One or more authors as WP_User objects.
+		 * @param WP_Post   $post    Post object.
 		 */
 		$authors = apply_filters( 'wp_parsely_pre_authors', $authors, $post );
 


### PR DESCRIPTION
## Description

The `get_author_name` now expects an `$author` parameter that has type `?WP_User`. This wasn't the case when the Co-Authors Plus plugin was enabled and a Guest Author was being assigned to a post. It would throw a fatal error about that object not being a `WP_User`.

This PR casts the objects to WP_User to make sure they are compliant to the function signature.

## Motivation and Context

Fix an issue for some customers in 3.0.

## How Has This Been Tested?

With the Co-Authors Plus plugin installed, create a new Guest Author (Users->Guest Authors) in wp-admin. Then when editing a post, see the Authors section of the Post attributes, and start typing the slug / name, and add them.

![image](https://user-images.githubusercontent.com/7188409/143565556-ce3444ce-ef99-4c44-8510-7bb79e8a7ede.png)

![image](https://user-images.githubusercontent.com/7188409/143565574-ad9d1149-a1ea-4fdc-9e59-df660d3e1dbd.png)

The front-end should throw a fatal error without the patch, should work fine and render all co-authors as meta tags.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)