### PR TITLE
Tests: Run in random order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,14 +67,14 @@
 			"bash bin/install-wp-tests.sh wordpress_test root root localhost trunk"
 		],
 		"test": [
-			"@php ./vendor/bin/phpunit --no-coverage"
+			"@php ./vendor/bin/phpunit --no-coverage --order-by=random"
 		],
 		"test-ms": [
 			"@putenv WP_MULTISITE=1",
 			"@composer test"
 		],
 		"testwp": [
-			"@php ./vendor/bin/phpunit --no-coverage -c phpunit-integration.xml.dist"
+			"@php ./vendor/bin/phpunit --no-coverage --order-by=random -c phpunit-integration.xml.dist"
 		],
 		"testwp-ms": [
 			"@putenv WP_MULTISITE=1",


### PR DESCRIPTION
## Description
Run Unit and Integration (WP) tests in a random order.

## Motivation and Context
This ensures that we don't have tests written in a way that are dependent on other tests having been run first, which may have left the environment in a presumptive state.

## How Has This Been Tested?
Run locally several times, including with a `--debug` flag that shows the actual order of tests (the results are always shown in the regular order). No test fails or errors.
