### PR TITLE
PR Template: Remove checkboxes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,10 +12,5 @@
 <!--- Include details of your testing environment, and the tests you ran to -->
 <!--- see how your change affects other areas of the code, etc. -->
 
-## Screenshots (if appropriate):
+## Screenshots (if appropriate)
 
-## Types of changes
-<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### PR DESCRIPTION
## Description
Checkboxes on PRs are often made more visible as a list of tasks to complete (one or more that can and should be marked off before a PR is deemed acceptable). They shouldn't be treated as a radio button (only one item selected from a list).

In this case, the type of fix being asked for, was in relation to Semantic Versioning, but it wasn't comprehensive enough (many PRs are Type: Maintenance), and so labels would be a better choice for this by the repo owners, rather than just contributors. Most PRs are opened by repo owners anyway.

## Screenshots

Here's how the checkboxes are made more visible on the PR lists (not the multiple "1 of 3 tasks")
<img width="413" alt="Screenshot of GitHub interface showing checkbox counts" src="https://user-images.githubusercontent.com/88371/143576791-b2cc3163-87c9-4824-a15f-6fd7a6090691.png">
