### PR TITLE
Settings page: Use submit_button() function

### DIFF
--- a/views/parsely-settings.php
+++ b/views/parsely-settings.php
@@ -20,10 +20,10 @@ $parsely_version_string = sprintf( __( 'Version %s', 'wp-parsely' ), Parsely::VE
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html( get_admin_page_title() ); ?></h1> <span id="wp-parsely_version"><?php echo esc_html( $parsely_version_string ); ?></span>
 	<form name="parsely" method="post" action="options.php">
-		<?php settings_fields( Parsely::OPTIONS_KEY ); ?>
-		<?php do_settings_sections( Parsely::OPTIONS_KEY ); ?>
-		<p class="submit">
-			<input name="submit" type="submit" class="button-primary" value="<?php esc_attr_e( 'Save Changes', 'wp-parsely' ); ?>"/>
-		</p>
+		<?php
+		settings_fields( Parsely::OPTIONS_KEY );
+		do_settings_sections( Parsely::OPTIONS_KEY );
+		submit_button();
+		?>
 	</form>
 </div>


### PR DESCRIPTION




<!--- Provide a general summary of your changes in the Title above -->

## Description
Use the `submit_button()` function on the settings page, instead of using HTML directly.

## Motivation and Context
Ensures consistency with the default submit button that WordPress uses on other settings pages.

See #8.

## How Has This Been Tested?
View and submit the form before and after the patch is applied.
