### PR TITLE
Bug fix: multiple checkboxes labels

### DIFF
--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -760,9 +760,9 @@ final class Settings_Page {
 
 		foreach ( $select_options as $key => $val ) {
 			$selected = in_array( $val, $options[ $args['option_key'] ], true );
-			echo sprintf( "<p><input type='checkbox' name='%s[]' id='%s' value='%s' ", esc_attr( $name ), esc_attr( $name ), esc_attr( $key ) );
+			echo sprintf( '<p><input type="checkbox" name="%1$s[]" id="%1$s-%2$s" value="%2$s" ', esc_attr( $name ), esc_attr( $key ) );
 			echo checked( true === $selected, true, false );
-			echo sprintf( " /> <label for='%s'>%s</label></p>", esc_attr( $name ), esc_attr( $val ) );
+			echo sprintf( ' /> <label for="%1$s-%2$s">%2$s</label></p>', esc_attr( $name ), esc_attr( $val ) );
 		}
 
 		if ( isset( $args['help_text'] ) ) {


### PR DESCRIPTION
## Description
The ID attributes of the checkboxes, and the label `for` attributes for them, were all the same for each group of checkboxes, which means that click on a label toggled an incorrect checkbox, for most checkboxes.

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## Motivation and Context
Broken labels leads to incorrect behaviour for visual users and difficulties for screen reader users.

## How Has This Been Tested?
Manually checked.

## Screenshots (if appropriate)

Before:

https://user-images.githubusercontent.com/88371/143775902-627258be-3893-4797-850b-bcbd33cae322.mov

After:


https://user-images.githubusercontent.com/88371/143775995-f41ac9c0-8312-44e4-8b59-06bebfeeb420.mov

