### PR TITLE
Hide Disable AMP setting when AMP plugin is not enabled

### DIFF
--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -230,20 +230,22 @@ Once you have changed a value and and saved, please contact support@parsely.com 
 			)
 		);
 
-		// Disable AMP tracking.
-		$h = __( 'If you use a separate system for JavaScript tracking on AMP pages (Tealium / Segment / Google Tag Manager / other tag manager solution) you may want to use that instead of having the plugin load the tracker.', 'wp-parsely' );
-		add_settings_field(
-			'disable_amp',
-			__( 'Disable AMP Tracking', 'wp-parsely' ),
-			array( $this, 'print_binary_radio_tag' ),
-			Parsely::MENU_SLUG,
-			'basic_settings',
-			array(
-				'title'      => __( 'Disable AMP Tracking', 'wp-parsely' ), // Passed for legend element.
-				'option_key' => 'disable_amp',
-				'help_text'  => $h,
-			)
-		);
+		if ( defined( 'AMP__VERSION' ) ) {
+			// Disable AMP tracking.
+			$h = __( 'If you use a separate system for JavaScript tracking on AMP pages (Tealium / Segment / Google Tag Manager / other tag manager solution) you may want to use that instead of having the plugin load the tracker.', 'wp-parsely' );
+			add_settings_field(
+				'disable_amp',
+				__( 'Disable AMP Tracking', 'wp-parsely' ),
+				array( $this, 'print_binary_radio_tag' ),
+				Parsely::MENU_SLUG,
+				'basic_settings',
+				array(
+					'title'      => __( 'Disable AMP Tracking', 'wp-parsely' ), // Passed for legend element.
+					'option_key' => 'disable_amp',
+					'help_text'  => $h,
+				)
+			);
+		}
 
 		// These are the Requires Recrawl Settings.
 		add_settings_section(
@@ -703,6 +705,16 @@ Once you have changed a value and and saved, please contact support@parsely.com 
 			);
 		} else {
 			$input['disable_javascript'] = 'true' === $input['disable_javascript'];
+		}
+
+		// Allow for Disable AMP setting to be conditionally included on the page.
+		// If it's not shown, then set the value as what was previously saved.
+		if ( null === $input['disable_amp'] ) {
+			$options              = $this->parsely->get_options();
+			$input['disable_amp'] = 'true';
+			if ( false === $options['disable_amp'] ) {
+				$input['disable_amp'] = 'false';
+			}
 		}
 
 		if ( 'true' !== $input['disable_amp'] && 'false' !== $input['disable_amp'] ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hide the Disable AMP setting if the AMP plugin is not enabled.

Handle the validation of the submitted values, but using the previously saved value as the incoming value if none was submitted for `disable_amp`.

## Motivation and Context
Fixes #516.

## How Has This Been Tested?
Requires #518. Once #518 has been merged into `develop`, then this PR should be rebased.

1. Activate the AMP plugin
2. Change Disable AMP to a different value, then save.
2. Deactivate the plugin, make a different change on the settings page, and save. Note no validation errors despite no disable_amp value being sent.
3. Reactivate the AMP plugin, and reload the Parse.ly settings page, and see how the value for disable_amp has been retained.
4. Repeat 2-3 with the other value for disable_amp, to show that it doesn't just stick to a default value.


