### PR TITLE
Adding explicit dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,15 @@ updates:
       interval: 'daily'
 
   - package-ecosystem: 'composer'
+    reviewers:
+      - 'Parsely/wp-parsely'
     directory: '/'
     schedule:
       interval: 'daily'
 
   - package-ecosystem: 'github-actions'
+    reviewers:
+      - 'Parsely/wp-parsely'
     directory: '/'
     schedule:
       interval: 'daily'


### PR DESCRIPTION
## Description

This PR explicitly adds users in the `Parsely/wp-parsely` group (the maintainers of this repository) to be tagged in the Dependabot PRs.

## Motivation and Context

Ensure Parse.ly developers get notified when a new dependabot PR happens.

## How Has This Been Tested?

PRs should start appearing with correct reviewers in the following days.