### PR TITLE
Enabling linting for JS and CSS files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,9 +14,6 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 
-[*.json]
-indent_size = 4
-
 [*.yml]
 indent_style = space
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 
+[*.json]
+indent_size = 4
+
 [*.yml]
 indent_style = space
 indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,5 +6,9 @@
 	},
 	"rules": {
 		"@wordpress/i18n-text-domain": [ "error", { "allowedTextDomain": [ "wp-parsely" ] } ]
+	},
+    "globals": {
+	  	// Page variable for Puppeteer tests
+	  	"page": true
 	}
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,8 +7,8 @@
 	"rules": {
 		"@wordpress/i18n-text-domain": [ "error", { "allowedTextDomain": [ "wp-parsely" ] } ]
 	},
-    "globals": {
-	  	// Page variable for Puppeteer tests
-	  	"page": true
+	"globals": {
+		// Page variable for Puppeteer tests
+		"page": true
 	}
 }

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Install JavaScript dependencies
         run: npm ci
 
+      - name: Lint CSS code
+        run: npm run lint:css
+
+      - name: Lint package.json file
+        run: npm run lint:pkg-json
+
+      - name: Lint JS code
+        run: npm run lint:js
+
       - name: Build application
         run: npm run build
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,30 @@ For JavaScript we recommend installing ESLint. This plugin includes a [.eslintrc
 
 If you haven't installed Composer, you will need to do that first.
 
+To lint your JS code:
+
+```
+npm run lint:js
+
+# Fix automatically fixable issues
+npm run lint:js -- --fix
+```
+
+To lint your CSS code:
+
+```
+npm run lint:css
+
+# Fix automatically fixable issues
+npm run lint:css -- --fix
+```
+
+To lint package.json:
+
+```
+npm run lint:pkg-json
+```
+
 To lint your PHP code:
 
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The plugin requires an active Parse.ly account. Parse.ly gives creators, markete
 
 ## Local development
 
-To run the plugin locally or to contribute to it, please check the instructions in the [CONTRIBUTING.md] file.
+To run the plugin locally or to contribute to it, please check the instructions in the [CONTRIBUTING](CONTRIBUTING.md) file.
 
 ## Frequently Asked Questions
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = ( api ) => {
+	api.cache( true );
+
+	return {
+		presets: [ '@wordpress/babel-preset-default' ],
+	};
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,12 @@
 {
   "name": "wp-parsely",
+  "version": "3.1.0-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "wp-parsely",
+      "version": "3.1.0-alpha",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/dom-ready": "^2.13.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "js-cookie": "^3.0.0"
       },
       "devDependencies": {
+        "@wordpress/babel-preset-default": "^6.4.1",
         "@wordpress/e2e-test-utils": "^5.4.8",
         "@wordpress/env": "^4.1.3",
         "@wordpress/eslint-plugin": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -1,54 +1,59 @@
 {
-  "private": true,
-  "directories": {
-    "test": "tests"
+  "name": "wp-parsely",
+  "version": "3.1.0-alpha",
+  "private": false,
+  "description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
+  "author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, pauarge",
+  "license": "GPL-2.0-or-later",
+  "keywords": ["analytics", "parse.ly", "parsely", "parsley"],
+  "homepage": "https://github.com/Parsely/wp-parsely",
+  "repository": {
+	"type": "git",
+	"url": "git+https://github.com/Parsely/wp-parsely.git"
+  },
+  "bugs": {
+	"url": "https://github.com/Parsely/wp-parsely/issues"
   },
   "engines": {
-    "node": ">=16",
-    "npm": ">=7"
+	"node": ">=16",
+	"npm": ">=7"
   },
-  "scripts": {
-    "build": "wp-scripts build",
-    "start": "wp-scripts start",
-    "dev:start": "wp-env start",
-    "dev:stop": "wp-env stop",
-    "test": "npm run test:unit",
-    "test:e2e": "wp-scripts test-e2e",
-    "test:e2e:debug": "wp-scripts --inspect-brk test-e2e --puppeteer-devtools",
-    "test:e2e:help": "wp-scripts test-e2e --help",
-    "test:e2e:watch": "npm run test:e2e -- --watch",
-    "test:e2e:interactive": "npm run test:e2e -- --puppeteer-interactive",
-    "test:unit": "wp-scripts test-unit-js",
-    "test:unit:help": "wp-scripts test-unit-js --help",
-    "test:unit:watch": "wp-scripts test-unit-js --watch",
-    "test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache",
-    "lint:css": "wp-scripts lint-style",
-    "lint:js": "wp-scripts lint-js",
-    "lint:pkg-json": "wp-scripts lint-pkg-json"
+  "directories": {
+	"test": "tests"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Parsely/wp-parsely.git"
-  },
-  "license": "GPL-2.0-or-later",
-  "bugs": {
-    "url": "https://github.com/Parsely/wp-parsely/issues"
-  },
-  "homepage": "https://github.com/Parsely/wp-parsely#readme",
   "browserslist": [
     "defaults"
   ],
-  "devDependencies": {
-    "@wordpress/babel-preset-default": "^6.4.1",
-    "@wordpress/e2e-test-utils": "^5.4.8",
-    "@wordpress/env": "^4.1.3",
-    "@wordpress/eslint-plugin": "^9.3.0",
-    "@wordpress/scripts": "^19.2.2",
-    "prettier": "^2.5.0"
-  },
   "dependencies": {
     "@wordpress/dom-ready": "^2.13.2",
     "@wordpress/i18n": "^3.20.0",
     "js-cookie": "^3.0.0"
+  },
+  "devDependencies": {
+	"@wordpress/babel-preset-default": "^6.4.1",
+	"@wordpress/e2e-test-utils": "^5.4.8",
+	"@wordpress/env": "^4.1.3",
+	"@wordpress/eslint-plugin": "^9.3.0",
+	"@wordpress/scripts": "^19.2.2",
+	"prettier": "^2.5.0"
+  },
+  "scripts": {
+	"build": "wp-scripts build",
+	"start": "wp-scripts start",
+	"dev:start": "wp-env start",
+	"dev:stop": "wp-env stop",
+	"test": "npm run test:unit",
+	"test:e2e": "wp-scripts test-e2e",
+	"test:e2e:debug": "wp-scripts --inspect-brk test-e2e --puppeteer-devtools",
+	"test:e2e:help": "wp-scripts test-e2e --help",
+	"test:e2e:watch": "npm run test:e2e -- --watch",
+	"test:e2e:interactive": "npm run test:e2e -- --puppeteer-interactive",
+	"test:unit": "wp-scripts test-unit-js",
+	"test:unit:help": "wp-scripts test-unit-js --help",
+	"test:unit:watch": "wp-scripts test-unit-js --watch",
+	"test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache",
+	"lint:css": "wp-scripts lint-style",
+	"lint:js": "wp-scripts lint-js",
+	"lint:pkg-json": "wp-scripts lint-pkg-json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "test:unit:help": "wp-scripts test-unit-js --help",
     "test:unit:watch": "wp-scripts test-unit-js --watch",
     "test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache",
-    "format": "wp-scripts format",
     "lint:css": "wp-scripts lint-style",
     "lint:js": "wp-scripts lint-js",
     "lint:pkg-json": "wp-scripts lint-pkg-json"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,11 @@
     "test:unit": "wp-scripts test-unit-js",
     "test:unit:help": "wp-scripts test-unit-js --help",
     "test:unit:watch": "wp-scripts test-unit-js --watch",
-    "test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache"
+    "test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache",
+	"format": "wp-scripts format",
+	"lint:css": "wp-scripts lint-style",
+	"lint:js": "wp-scripts lint-js",
+	"lint:pkg-json": "wp-scripts lint-pkg-json"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "test:unit:help": "wp-scripts test-unit-js --help",
     "test:unit:watch": "wp-scripts test-unit-js --watch",
     "test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache",
-	"format": "wp-scripts format",
-	"lint:css": "wp-scripts lint-style",
-	"lint:js": "wp-scripts lint-js",
-	"lint:pkg-json": "wp-scripts lint-pkg-json"
+    "format": "wp-scripts format",
+    "lint:css": "wp-scripts lint-style",
+    "lint:js": "wp-scripts lint-js",
+    "lint:pkg-json": "wp-scripts lint-pkg-json"
   },
   "repository": {
     "type": "git",
@@ -40,6 +40,7 @@
     "defaults"
   ],
   "devDependencies": {
+    "@wordpress/babel-preset-default": "^6.4.1",
     "@wordpress/e2e-test-utils": "^5.4.8",
     "@wordpress/env": "^4.1.3",
     "@wordpress/eslint-plugin": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -1,59 +1,64 @@
 {
-  "name": "wp-parsely",
-  "version": "3.1.0-alpha",
-  "private": false,
-  "description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
-  "author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, pauarge",
-  "license": "GPL-2.0-or-later",
-  "keywords": ["analytics", "parse.ly", "parsely", "parsley"],
-  "homepage": "https://github.com/Parsely/wp-parsely",
-  "repository": {
-	"type": "git",
-	"url": "git+https://github.com/Parsely/wp-parsely.git"
-  },
-  "bugs": {
-	"url": "https://github.com/Parsely/wp-parsely/issues"
-  },
-  "engines": {
-	"node": ">=16",
-	"npm": ">=7"
-  },
-  "directories": {
-	"test": "tests"
-  },
-  "browserslist": [
-    "defaults"
-  ],
-  "dependencies": {
-    "@wordpress/dom-ready": "^2.13.2",
-    "@wordpress/i18n": "^3.20.0",
-    "js-cookie": "^3.0.0"
-  },
-  "devDependencies": {
-	"@wordpress/babel-preset-default": "^6.4.1",
-	"@wordpress/e2e-test-utils": "^5.4.8",
-	"@wordpress/env": "^4.1.3",
-	"@wordpress/eslint-plugin": "^9.3.0",
-	"@wordpress/scripts": "^19.2.2",
-	"prettier": "^2.5.0"
-  },
-  "scripts": {
-	"build": "wp-scripts build",
-	"start": "wp-scripts start",
-	"dev:start": "wp-env start",
-	"dev:stop": "wp-env stop",
-	"test": "npm run test:unit",
-	"test:e2e": "wp-scripts test-e2e",
-	"test:e2e:debug": "wp-scripts --inspect-brk test-e2e --puppeteer-devtools",
-	"test:e2e:help": "wp-scripts test-e2e --help",
-	"test:e2e:watch": "npm run test:e2e -- --watch",
-	"test:e2e:interactive": "npm run test:e2e -- --puppeteer-interactive",
-	"test:unit": "wp-scripts test-unit-js",
-	"test:unit:help": "wp-scripts test-unit-js --help",
-	"test:unit:watch": "wp-scripts test-unit-js --watch",
-	"test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache",
-	"lint:css": "wp-scripts lint-style",
-	"lint:js": "wp-scripts lint-js",
-	"lint:pkg-json": "wp-scripts lint-pkg-json"
-  }
+	"name": "wp-parsely",
+	"version": "3.1.0-alpha",
+	"private": true,
+	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
+	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, pauarge",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"analytics",
+		"parse.ly",
+		"parsely",
+		"parsley"
+	],
+	"homepage": "https://github.com/Parsely/wp-parsely",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Parsely/wp-parsely.git"
+	},
+	"bugs": {
+		"url": "https://github.com/Parsely/wp-parsely/issues"
+	},
+	"engines": {
+		"node": ">=16",
+		"npm": ">=7"
+	},
+	"directories": {
+		"test": "tests"
+	},
+	"browserslist": [
+		"defaults"
+	],
+	"dependencies": {
+		"@wordpress/dom-ready": "^2.13.2",
+		"@wordpress/i18n": "^3.20.0",
+		"js-cookie": "^3.0.0"
+	},
+	"devDependencies": {
+		"@wordpress/babel-preset-default": "^6.4.1",
+		"@wordpress/e2e-test-utils": "^5.4.8",
+		"@wordpress/env": "^4.1.3",
+		"@wordpress/eslint-plugin": "^9.3.0",
+		"@wordpress/scripts": "^19.2.2",
+		"prettier": "^2.5.0"
+	},
+	"scripts": {
+		"build": "wp-scripts build",
+		"dev:start": "wp-env start",
+		"dev:stop": "wp-env stop",
+		"lint:css": "wp-scripts lint-style",
+		"lint:js": "wp-scripts lint-js",
+		"lint:pkg-json": "wp-scripts lint-pkg-json",
+		"start": "wp-scripts start",
+		"test": "npm run test:unit",
+		"test:e2e": "wp-scripts test-e2e",
+		"test:e2e:debug": "wp-scripts --inspect-brk test-e2e --puppeteer-devtools",
+		"test:e2e:help": "wp-scripts test-e2e --help",
+		"test:e2e:interactive": "npm run test:e2e -- --puppeteer-interactive",
+		"test:e2e:watch": "npm run test:e2e -- --watch",
+		"test:unit": "wp-scripts test-unit-js",
+		"test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache",
+		"test:unit:help": "wp-scripts test-unit-js --help",
+		"test:unit:watch": "wp-scripts test-unit-js --watch"
+	}
 }

--- a/tests/e2e/specs/front-end-code.spec.js
+++ b/tests/e2e/specs/front-end-code.spec.js
@@ -12,35 +12,34 @@ import {
  */
 import { changeKeysState, PLUGIN_VERSION } from '../utils';
 
-
 describe( 'Front end code insertion', () => {
-	it('Should inject loading script homepage', async () => {
+	it( 'Should inject loading script homepage', async () => {
 		await loginUser();
-		await activatePlugin('wp-parsely');
+		await activatePlugin( 'wp-parsely' );
 		await changeKeysState( true, false );
 
-		await page.goto(createURL('/'));
+		await page.goto( createURL( '/' ) );
 
 		const content = await page.content();
 
-		expect(content).toContain('<link rel="dns-prefetch" href="//cdn.parsely.com">');
-		expect(content).toContain(`<script data-parsely-site="e2etest.example.com" src="https://cdn.parsely.com/keys/e2etest.example.com/p.js?ver=${PLUGIN_VERSION}" id="parsely-cfg"></script>`);
-		expect(content).not.toContain('<script id="wp-parsely-api-js-extra">');
-		expect(content).not.toContain('var wpParsely');
-	});
+		expect( content ).toContain( '<link rel="dns-prefetch" href="//cdn.parsely.com">' );
+		expect( content ).toContain( `<script data-parsely-site="e2etest.example.com" src="https://cdn.parsely.com/keys/e2etest.example.com/p.js?ver=${ PLUGIN_VERSION }" id="parsely-cfg"></script>` );
+		expect( content ).not.toContain( '<script id="wp-parsely-api-js-extra">' );
+		expect( content ).not.toContain( 'var wpParsely' );
+	} );
 
-	it('Should inject loading script homepage and extra variable', async () => {
+	it( 'Should inject loading script homepage and extra variable', async () => {
 		await loginUser();
-		await activatePlugin('wp-parsely');
+		await activatePlugin( 'wp-parsely' );
 		await changeKeysState( true, true );
 
-		await page.goto(createURL('/'));
+		await page.goto( createURL( '/' ) );
 
 		const content = await page.content();
 
-		expect(content).toContain('<link rel="dns-prefetch" href="//cdn.parsely.com">');
-		expect(content).toContain(`<script data-parsely-site="e2etest.example.com" src="https://cdn.parsely.com/keys/e2etest.example.com/p.js?ver=${PLUGIN_VERSION}" id="parsely-cfg"></script>`);
-		expect(content).toContain('<script id="wp-parsely-api-js-extra">');
-		expect(content).toContain('var wpParsely = {"apikey":"e2etest.example.com"};');
-	});
-} )
+		expect( content ).toContain( '<link rel="dns-prefetch" href="//cdn.parsely.com">' );
+		expect( content ).toContain( `<script data-parsely-site="e2etest.example.com" src="https://cdn.parsely.com/keys/e2etest.example.com/p.js?ver=${ PLUGIN_VERSION }" id="parsely-cfg"></script>` );
+		expect( content ).toContain( '<script id="wp-parsely-api-js-extra">' );
+		expect( content ).toContain( 'var wpParsely = {"apikey":"e2etest.example.com"};' );
+	} );
+} );

--- a/tests/e2e/specs/recommended-widget.spec.js
+++ b/tests/e2e/specs/recommended-widget.spec.js
@@ -33,7 +33,7 @@ const selectParselyWidgetFromWidgetSearch = async () => {
 	await button.click();
 };
 
-const checkForNonActiveWidgetText = async () => {
+const getNonActiveWidgetText = async () => {
 	// Checking if Parse.ly widget is present in the widgets list
 	await page.waitForSelector( '.wp-block-legacy-widget__edit-form', {
 		visible: true,
@@ -44,9 +44,7 @@ const checkForNonActiveWidgetText = async () => {
 	await h3.click();
 
 	const widgetContent = await page.evaluateHandle( ( el ) => el.nextElementSibling, h3 );
-	const textContent = await page.evaluate( ( el ) => el.textContent, widgetContent );
-
-	expect( textContent ).toContain( deactivatedPluginWidgetText );
+	return page.evaluate( ( el ) => el.textContent, widgetContent );
 };
 
 describe( 'Recommended widget', () => {
@@ -68,7 +66,7 @@ describe( 'Recommended widget', () => {
 		await searchForParselyWidget();
 		await selectParselyWidgetFromWidgetSearch();
 
-		await checkForNonActiveWidgetText();
+		expect( getNonActiveWidgetText() ).toContain( deactivatedPluginWidgetText );
 	} );
 
 	it( 'Widget should be available but inactive without api secret', async () => {
@@ -83,6 +81,6 @@ describe( 'Recommended widget', () => {
 		await searchForParselyWidget();
 		await selectParselyWidgetFromWidgetSearch();
 
-		await checkForNonActiveWidgetText();
+		expect( getNonActiveWidgetText() ).toContain( deactivatedPluginWidgetText );
 	} );
 } );

--- a/tests/e2e/specs/recommended-widget.spec.js
+++ b/tests/e2e/specs/recommended-widget.spec.js
@@ -66,7 +66,7 @@ describe( 'Recommended widget', () => {
 		await searchForParselyWidget();
 		await selectParselyWidgetFromWidgetSearch();
 
-		expect( getNonActiveWidgetText() ).toContain( deactivatedPluginWidgetText );
+		expect( await getNonActiveWidgetText() ).toContain( deactivatedPluginWidgetText );
 	} );
 
 	it( 'Widget should be available but inactive without api secret', async () => {
@@ -81,6 +81,6 @@ describe( 'Recommended widget', () => {
 		await searchForParselyWidget();
 		await selectParselyWidgetFromWidgetSearch();
 
-		expect( getNonActiveWidgetText() ).toContain( deactivatedPluginWidgetText );
+		expect( await getNonActiveWidgetText() ).toContain( deactivatedPluginWidgetText );
 	} );
 } );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -2,7 +2,7 @@ import { visitAdminPage } from '@wordpress/e2e-test-utils';
 
 export const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
 
-export const changeKeysState = async (activateApiKey, activateApiSecret ) => {
+export const changeKeysState = async ( activateApiKey, activateApiSecret ) => {
 	await visitAdminPage( '/options-general.php', '?page=parsely' );
 
 	await page.evaluate( () => document.getElementById( 'apikey' ).value = '' );

--- a/wp-parsely.css
+++ b/wp-parsely.css
@@ -34,7 +34,7 @@
 
 .parsely-recommended-widget-title {
 	font-size: 1.1em;
-	font-weight: bold;
+	font-weight: 700; /* Bold */
 }
 
 .list-horizontal .parsely-recommended-widget-entry {
@@ -69,6 +69,17 @@
 		grid-template-columns: minmax(85px, auto) minmax(50%, auto);
 	}
 
+	.list-horizontal .parsely-recommended-widget-entry {
+		border: none;
+		display: block;
+		min-width: initial;
+		max-width: initial;
+		margin: 0;
+		padding: 0;
+		vertical-align: initial;
+		width: initial;
+	}
+
 	.display-thumbnail:not(.list-horizontal) .parsely-recommended-widget-entry {
 		display: contents;
 	}
@@ -84,16 +95,5 @@
 		grid-template-rows: auto;
 		grid-gap: 15px;
 		grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-	}
-
-	.list-horizontal .parsely-recommended-widget-entry {
-		border: none;
-		display: block;
-		min-width: initial;
-		max-width: initial;
-		margin: 0;
-		padding: 0;
-		vertical-align: initial;
-		width: initial;
 	}
 }

--- a/wp-parsely.css
+++ b/wp-parsely.css
@@ -34,7 +34,7 @@
 
 .parsely-recommended-widget-title {
 	font-size: 1.1em;
-	font-weight: 700; /* Bold */
+	font-weight: 700;
 }
 
 .list-horizontal .parsely-recommended-widget-entry {

--- a/wp-parsely.css
+++ b/wp-parsely.css
@@ -21,7 +21,7 @@
 	margin-right: 15px;
 }
 
-.parsely-recommended-widget-entry:after {
+.parsely-recommended-widget-entry::after {
 	content: "";
 	display: table;
 	clear: both;
@@ -55,8 +55,9 @@
 	max-width: 100%;
 }
 
-@supports(display: grid){
-	.parsely-recommended-widget-entry:after {
+@supports (display: grid) {
+
+	.parsely-recommended-widget-entry::after {
 		display: none;
 		clear: initial;
 	}


### PR DESCRIPTION
## Description

This PR adds three new commands that check if Javascript, CSS and the `package.json` file are correctly formatted:

- `npm run lint:css`
- `npm run lint:js`
- `npm run lint:pkg-json`

The three commands rely on `wp-scripts` and have been added to the GitHub Actions pipeline, so if they fail the build will not succeed. The `@wordpress/babel-preset-default` package has been added as a development dependency and it's the styling that is being followed.

Some files were not compliant to the standards. They have been updated in this PR so linting issues are fixed.

## Motivation and Context

More maintainable codebase.

## How Has This Been Tested?

The linting commands above exist and execute without any issues:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated plugin metadata with enhanced versioning, descriptions, and contributor information.
  - Introduced improved JavaScript transpiling support for a smoother WordPress experience.

- **Chores**
  - Streamlined code quality processes with enhanced linting routines and continuous integration improvements.

- **Documentation**
  - Refined contribution guidelines and clarified documentation links for easier onboarding.

- **Style**
  - Adjusted widget styling for a more consistent and refined visual display.

- **Tests**
  - Improved test readability and structure to bolster overall quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->