### PR TITLE
Adding E2E test to verify if scripts are rendered in FE

### DIFF
--- a/tests/e2e/specs/front-end-code.spec.js
+++ b/tests/e2e/specs/front-end-code.spec.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import {
+	activatePlugin,
+	createURL,
+	loginUser,
+} from '@wordpress/e2e-test-utils';
+import { activatePluginApiKey, PLUGIN_VERSION } from '../utils';
+
+/**
+ * Internal dependencies
+ */
+
+
+describe( 'Front end code insertion', () => {
+	it('Should inject loading script homepage', async () => {
+		await loginUser();
+		await activatePlugin('wp-parsely');
+		await activatePluginApiKey();
+
+		await page.goto(createURL('/'));
+
+		const content = await page.content();
+
+		expect(content).toContain(`<script data-parsely-site="e2etest.example.com" src="https://cdn.parsely.com/keys/e2etest.example.com/p.js?ver=${PLUGIN_VERSION}" id="parsely-cfg"></script>`);
+	})
+} )

--- a/tests/e2e/specs/front-end-code.spec.js
+++ b/tests/e2e/specs/front-end-code.spec.js
@@ -6,11 +6,11 @@ import {
 	createURL,
 	loginUser,
 } from '@wordpress/e2e-test-utils';
-import { changeKeysState, PLUGIN_VERSION } from '../utils';
 
 /**
  * Internal dependencies
  */
+import { changeKeysState, PLUGIN_VERSION } from '../utils';
 
 
 describe( 'Front end code insertion', () => {

--- a/tests/e2e/specs/front-end-code.spec.js
+++ b/tests/e2e/specs/front-end-code.spec.js
@@ -6,7 +6,7 @@ import {
 	createURL,
 	loginUser,
 } from '@wordpress/e2e-test-utils';
-import { activatePluginApiKey, PLUGIN_VERSION } from '../utils';
+import { changeKeysState, PLUGIN_VERSION } from '../utils';
 
 /**
  * Internal dependencies
@@ -17,12 +17,30 @@ describe( 'Front end code insertion', () => {
 	it('Should inject loading script homepage', async () => {
 		await loginUser();
 		await activatePlugin('wp-parsely');
-		await activatePluginApiKey();
+		await changeKeysState( true, false );
 
 		await page.goto(createURL('/'));
 
 		const content = await page.content();
 
+		expect(content).toContain('<link rel="dns-prefetch" href="//cdn.parsely.com">');
 		expect(content).toContain(`<script data-parsely-site="e2etest.example.com" src="https://cdn.parsely.com/keys/e2etest.example.com/p.js?ver=${PLUGIN_VERSION}" id="parsely-cfg"></script>`);
-	})
+		expect(content).not.toContain('<script id="wp-parsely-api-js-extra">');
+		expect(content).not.toContain('var wpParsely');
+	});
+
+	it('Should inject loading script homepage and extra variable', async () => {
+		await loginUser();
+		await activatePlugin('wp-parsely');
+		await changeKeysState( true, true );
+
+		await page.goto(createURL('/'));
+
+		const content = await page.content();
+
+		expect(content).toContain('<link rel="dns-prefetch" href="//cdn.parsely.com">');
+		expect(content).toContain(`<script data-parsely-site="e2etest.example.com" src="https://cdn.parsely.com/keys/e2etest.example.com/p.js?ver=${PLUGIN_VERSION}" id="parsely-cfg"></script>`);
+		expect(content).toContain('<script id="wp-parsely-api-js-extra">');
+		expect(content).toContain('var wpParsely = {"apikey":"e2etest.example.com"};');
+	});
 } )

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -16,7 +16,7 @@ export const changeKeysState = async (activateApiKey, activateApiSecret ) => {
 	await page.evaluate( () => document.getElementById( 'api_secret' ).value = '' );
 	if ( activateApiSecret ) {
 		await page.focus( '#api_secret' );
-		await page.keyboad.type( 'somesecret' );
+		await page.keyboard.type( 'somesecret' );
 	}
 
 	const [ input ] = await page.$x( '//p[contains(@class, \'submit\')]//input' );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -1,5 +1,7 @@
 import { visitAdminPage } from '@wordpress/e2e-test-utils';
 
+export const PLUGIN_VERSION = '3.1.0-alpha';
+
 export const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
 
 export const changeKeysState = async (activateApiKey, activateApiSecret ) => {


### PR DESCRIPTION
## Description

This PR adds an end-to-end test spec that contains two tests. The tests check script tags that contain the Parse.ly tracker are inserted in the WordPress-controlled front-end.

## Motivation and Context

Critical functionality of the plugin that we must ensure is always working.

## How Has This Been Tested?

Tests run locally and in GitHub Actions.