### PR TITLE
Adding dev-env logs command

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 	},
 	"scripts": {
 		"build": "wp-scripts build",
+	  	"dev:logs": "wp-env logs",
 		"dev:start": "wp-env start",
 		"dev:stop": "wp-env stop",
 		"lint:css": "wp-scripts lint-style",


### PR DESCRIPTION
## Description

This PR adds the `npm run dev:logs` command to the project as a shortcut to get the dev-env logs for users that don't have wp-env installed in their systems.

## Motivation and Context

Shortcut to get the logs while developing locally.

## How Has This Been Tested?

Run a local environment and get its logs:

```
npm run dev:start
npm run dev:logs
```