### PR TITLE
docs: Fix typo in example for PHP code standard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ composer lint
 To check your code with our code standards:
 
 ```
-compose cs
+composer cs
 ```
 
 ### Testing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`compose cs` should be `composer cs`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`compose` isn't a valid alias for the composer executable

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
running the real command works...the incorrect one dose not

## Screenshots (if appropriate)
