### PR TITLE
Handle broken database option

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -648,7 +648,7 @@ class Parsely {
 	public function get_options(): array {
 		$options = get_option( self::OPTIONS_KEY, $this->option_defaults );
 
-		if ( "array" != gettype( $options ) ) {
+		if ( 'array' != gettype( $options ) ) {
 			return $this->option_defaults;
 		}
 

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -648,7 +648,7 @@ class Parsely {
 	public function get_options(): array {
 		$options = get_option( self::OPTIONS_KEY, $this->option_defaults );
 
-		if ( 'array' != gettype( $options ) ) {
+		if ( ! is_array( $options ) ) {
 			return $this->option_defaults;
 		}
 

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -647,6 +647,11 @@ class Parsely {
 	 */
 	public function get_options(): array {
 		$options = get_option( self::OPTIONS_KEY, $this->option_defaults );
+
+		if ( "array" != gettype( $options ) ) {
+			return $this->option_defaults;
+		}
+
 		return array_merge( $this->option_defaults, $options );
 	}
 

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -197,4 +197,18 @@ final class OtherTest extends TestCase {
 		self::set_options( array( 'apikey' => '' ) );
 		self::assertSame( '', self::$parsely->get_api_key() );
 	}
+
+	/**
+	 * Test if the `get_options` method can handle a corrupted (not an array) value in the database.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @covers \Parsely\Parsely::get_options
+	 */
+	public function test_corrupted_options(): void {
+		update_option( Parsely::OPTIONS_KEY, 'someinvalidvalue' );
+
+		$options = self::$parsely->get_options();
+		self::assertSame( self::EMPTY_DEFAULT_OPTIONS, $options );
+	}
 }

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -33,6 +33,26 @@ abstract class TestCase extends WPIntegrationTestCase {
 		'logo'                      => '',
 	);
 
+	public const EMPTY_DEFAULT_OPTIONS = array(
+		'apikey'                      => '',
+		'content_id_prefix'           => '',
+		'api_secret'                  => '',
+		'use_top_level_cats'          => false,
+		'custom_taxonomy_section'     => 'category',
+		'cats_as_tags'                => false,
+		'track_authenticated_users'   => true,
+		'lowercase_tags'              => true,
+		'force_https_canonicals'      => false,
+		'track_post_types'            => array( 'post' ),
+		'track_page_types'            => array( 'page' ),
+		'disable_javascript'          => false,
+		'disable_amp'                 => false,
+		'meta_type'                   => 'json_ld',
+		'logo'                        => '',
+		'metadata_secret'             => '',
+		'parsely_wipe_metadata_cache' => false,
+	);
+
 	/**
 	 * Utility function to update Parse.ly options with a merge of default values and custom values.
 	 *


### PR DESCRIPTION
## Description

It might be the case that the `parsely` option in the WordPress database is corrupted and is not an array. If that's the case, the site would fatal because the function `get_options` function is expected to always return an array. This PR checks that the value returned from the DB is indeed a an array and if it's not, it returns the default options.

## Motivation and Context

Preventing potential sites from fataling.

## How Has This Been Tested?

Go to the database and manually change the option value to something random, like `asdf`. With this PR the site should function normally.