### PR TITLE
Fixing end to end tests in CI (#521)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build # Remove or modify this step as needed
         run: |
-          npm install
+          npm ci
           npm run build
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,6 +3,16 @@ name: End-to-end (e2e) Tests
 on:
   # Run on all pull requests.
   pull_request:
+  push:
+    branches:
+      - trunk
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -13,25 +23,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Spin up WordPress
-        run: docker-compose -f tests/e2e/docker-compose.yml up &
-
-      - name: Use node lts/*
+      - name: Use desired version of NodeJS
         uses: actions/setup-node@v2
         with:
-          node-version: lts/*
-          cache: 'npm'
+          node-version: 16
+          cache: npm
 
-      - name: Installing dependencies
-        run: npm ci
+      - name: Npm install
+        run: |
+          npm ci
+          npm install -g @wordpress/env
 
-      - name: Wait for WP
-        run: until docker-compose -f tests/e2e/docker-compose.yml run cli wp db check &> /dev/null; do >&2 echo "Waiting for the back end to provision..."; sleep 2; done; >&2 echo "WordPress is ready!"
-        shell: bash
+      - name: Install WordPress
+        run: |
+          wp-env start
 
-      - name: Run e2e tests
-        run: npm run test:e2e
-
-      - name: Clean up
-        if: ${{ always() }}
-        run: docker-compose -f tests/e2e/docker-compose.yml down -v
+      - name: Running the tests
+        run: |
+          $( npm bin )/wp-scripts test-e2e --listTests > ~/.jest-e2e-tests
+          $( npm bin )/wp-scripts test-e2e --cacheDirectory="$HOME/.jest-cache"


### PR DESCRIPTION
This PR brings https://github.com/Parsely/wp-parsely/pull/521 to `trunk` ahead of 3.0.0 release.
