### PR TITLE
Source the correct asset meta data file for the Recommendations Widget

### DIFF
--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -112,7 +112,7 @@ final class Recommended_Widget extends WP_Widget {
 			(int) $instance['return_limit']
 		);
 
-		$recommended_widget_script_asset = require plugin_dir_path( PARSELY_FILE ) . 'build/admin-page.asset.php';
+		$recommended_widget_script_asset = require plugin_dir_path( PARSELY_FILE ) . 'build/recommended-widget.asset.php';
 
 		?>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When the `build/admin-page.asset.php` file was removed in #518, it revealed that we've been sourcing the incorrect backing asset file. This corrects the file name to: `build/recommended-widget.asset.php`.

The previous arrangement worked because the widget only relies on the `wp-dom-ready` package which was included in the `admin-page.asset.php` file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since the admin asset file is gone, active widgets will not work & produce a PHP fatal error:

<img width="536" alt="Screen Shot 2021-12-15 at 12 58 57 PM" src="https://user-images.githubusercontent.com/1587282/146240224-6327090a-c31d-4a95-a116-19faf7492594.png">

Fortuitously, this uncovered the erroneous path and we can correct it before releasing something that does just happen to work :) 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Confirm the issue

* run the `develop` branch
* add a widget as usual
* view the route where the widget should be displayed
* notice the non-functioning widget

### Confirm the fix

* switch to this branch
* view the route where the widget should be displayed
* notice the now functioning widget

