### PR TITLE
Enforce phpcs severity=1 in CI

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -69,7 +69,7 @@ jobs:
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
-        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
+        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml --severity=1
 
       - name: Show PHPCS results in PR
         run: cs2pr ./phpcs-report.xml

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -75,7 +75,7 @@ jobs:
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
-        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml --severity=1
+        run: composer cs -- --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
         run: cs2pr ./phpcs-report.xml

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npm run lint
-composer cs
+composer cs -- --severity=1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npm run lint
-composer cs -- --severity=1
+composer cs

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
 			"@php ./vendor/bin/phpunit -c phpunit-integration.xml.dist -v"
 		],
 		"cs": [
-			"@php ./vendor/bin/phpcs"
+			"@php ./vendor/bin/phpcs --severity=1"
 		],
 		"lint": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -391,7 +391,6 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 			'Failed to confirm script tags were not printed'
 		);
 
-		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
 		switch_to_blog( $second_blog );
 		TestCase::set_options( $custom_options );
 

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -391,6 +391,7 @@ var wpParsely = {\"apikey\":\"blog.parsely.com\"};
 			'Failed to confirm script tags were not printed'
 		);
 
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
 		switch_to_blog( $second_blog );
 		TestCase::set_options( $custom_options );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* Add the `--severity=1` flag to the calls to `phpcs` in:
  * the `cs-lint.yml` github action workflow
  * the `composer cs` script
* Remove the `--severity=1` flag from the `composer cs` call in the pre-commit hook now that it's included in the underlying composer script. 

Fixes #544

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Now that we are enforcing coding standards at commit time with "severity=1" and the codebase is compliant (per #538), this change also extends the granularity to the check performed in CI and via manual runs on the CLI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Bypassed the pre-commit hook to commit a warning violation
  * https://github.com/Parsely/wp-parsely/pull/549/commits/32b16f847b2a8a1ac07b9aedb0ec697726c384b4
  * Confirmed the change to the CI script [caught the error](https://github.com/Parsely/wp-parsely/runs/4551289531?check_suite_focus=true)
* Reverted the demo
  * (re) confirmed that tests now pass
* Confirm that pre-commit hooks still apply the coding standards w/ the `severity=1` flag included
