### PR TITLE
Try to improve script integration tests

### DIFF
--- a/tests/Integration/GetCurrentUrlTest.php
+++ b/tests/Integration/GetCurrentUrlTest.php
@@ -139,9 +139,7 @@ final class GetCurrentUrlTest extends TestCase {
 	 * @param string $expected Expected start of the URL.
 	 */
 	private function assertCurrentUrlForSpecificPostWithId( string $expected ): void {
-		$post_array = $this->create_test_post_array();
-		$post_id    = $this->factory->post->create( $post_array );
-		$this->go_to( '/?p=' . $post_id );
+		$post_id = $this->go_to_new_post();
 
 		$parsely = new Parsely();
 		$res     = $parsely->get_current_url( 'post', $post_id );

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -134,10 +134,8 @@ final class OtherTest extends TestCase {
 	public function test_filter_wp_parsely_post_type(): void {
 		$options = get_option( Parsely::OPTIONS_KEY );
 
-		$post_array = $this->create_test_post_array();
-		$post_id    = $this->factory->post->create( $post_array );
-		$post_obj   = get_post( $post_id );
-		$this->go_to( '/?p=' . $post_id );
+		$post_id  = $this->go_to_new_post();
+		$post_obj = get_post( $post_id );
 
 		// Try to change the post type to a supported value - BlogPosting.
 		add_filter(

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -139,6 +139,37 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
+	 * Test the wp_parsely_enqueue_js_tracker filter
+	 * When it returns false, the tracking script should not be enqueued.
+	 *
+	 * @covers \Parsely\Scripts::enqueue_js_tracker
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::update_metadata_endpoint
+	 */
+	public function test_enqueue_js_tracker_filter(): void {
+		add_filter( 'wp_parsely_load_js_tracker', '__return_false' );
+
+		$post_array = $this->create_test_post_array();
+		$post       = $this->factory->post->create( $post_array );
+		$this->go_to( '/?p=' . $post );
+		self::$scripts->register_scripts();
+		self::$scripts->enqueue_js_tracker();
+
+		// Confirm that tracker script is registered but not enqueued.
+		self::assertTrue(
+			wp_script_is( 'wp-parsely-tracker', 'registered' ),
+			'Script wp-parsely-tracker was not registered'
+		);
+		self::assertFalse(
+			wp_script_is( 'wp-parsely-tracker', 'enqueued' ),
+			'Script wp-parsely-tracker should not be enqueued'
+		);
+	}
+
+	/**
 	 * Test the API init script enqueue.
 	 *
 	 * @covers \Parsely\Scripts::enqueue_js_api
@@ -290,37 +321,6 @@ final class ScriptsTest extends TestCase {
 		self::assertTrue(
 			wp_script_is( 'wp-parsely-tracker', 'enqueued' ),
 			'Failed to confirm tracker script was enqueued'
-		);
-	}
-
-	/**
-	 * Test the wp_parsely_enqueue_js_tracker filter
-	 * When it returns false, the tracking script should not be enqueued.
-	 *
-	 * @covers \Parsely\Scripts::enqueue_js_tracker
-	 * @uses \Parsely\Parsely::api_key_is_missing
-	 * @uses \Parsely\Parsely::api_key_is_set
-	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::post_has_trackable_status
-	 * @uses \Parsely\Parsely::update_metadata_endpoint
-	 */
-	public function test_enqueue_js_tracker_filter(): void {
-		add_filter( 'wp_parsely_load_js_tracker', '__return_false' );
-
-		$post_array = $this->create_test_post_array();
-		$post       = $this->factory->post->create( $post_array );
-		$this->go_to( '/?p=' . $post );
-		self::$scripts->register_scripts();
-		self::$scripts->enqueue_js_tracker();
-
-		// Confirm that tracker script is registered but not enqueued.
-		self::assertTrue(
-			wp_script_is( 'wp-parsely-tracker', 'registered' ),
-			'Script wp-parsely-tracker was not registered'
-		);
-		self::assertFalse(
-			wp_script_is( 'wp-parsely-tracker', 'enqueued' ),
-			'Script wp-parsely-tracker should not be enqueued'
 		);
 	}
 }

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -248,12 +248,18 @@ final class ScriptsTest extends TestCase {
 	 * @group settings
 	 */
 	public function test_do_not_track_logged_in_users(): void {
-		TestCase::set_options( array( 'track_authenticated_users' => false ) );
+		TestCase::set_options(
+			array(
+				'api_secret'                => 'hunter2',
+				'track_authenticated_users' => false,
+			)
+		);
 		$new_user = $this->create_test_user( 'bill_brasky' );
 		wp_set_current_user( $new_user );
 
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
+		self::$scripts->enqueue_js_api();
 
 		// As track_authenticated_users options is false, enqueue should fail.
 		// Confirm that tracker script is registered but not enqueued.
@@ -261,6 +267,13 @@ final class ScriptsTest extends TestCase {
 			'wp-parsely-tracker',
 			array( 'registered' ),
 			array( 'enqueued' )
+		);
+
+		// API should be unaffected by track_authenticated_users setting.
+		// Confirm that API script is registered and enqueued.
+		$this->assert_script_statuses(
+			'wp-parsely-api',
+			array( 'registered', 'enqueued' )
 		);
 	}
 

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -88,10 +88,40 @@ final class ScriptsTest extends TestCase {
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 
-		// Confirm that JS tracker script is registered and enqueued.
+		// Confirm that tracker script is registered and enqueued.
 		$this->assert_script_statuses(
 			'wp-parsely-tracker',
 			array( 'registered', 'enqueued' )
+		);
+	}
+
+	/**
+	 * Test the tracker script enqueue with the disable_javascript option set
+	 * to true.
+	 *
+	 * @covers \Parsely\Scripts::enqueue_js_tracker
+	 * @uses \Parsely\Parsely::get_asset_cache_buster
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::update_metadata_endpoint
+	 * @uses \Parsely\Scripts::register_scripts
+	 * @uses \Parsely\Scripts::script_loader_tag
+	 * @group enqueue-js
+	 */
+	public function test_enqueue_js_tracker_with_javascript_option_disabled(): void {
+		TestCase::set_options( array( 'disable_javascript' => true ) );
+
+		$this->go_to_new_post();
+		self::$scripts->register_scripts();
+		self::$scripts->enqueue_js_tracker();
+
+		// Confirm that tracker script is registered but not enqueued.
+		$this->assert_script_statuses(
+			'wp-parsely-tracker',
+			array( 'registered' ),
+			array( 'enqueued' )
 		);
 	}
 
@@ -282,7 +312,7 @@ final class ScriptsTest extends TestCase {
 		self::assertEquals( get_current_blog_id(), $first_blog );
 		self::assertTrue( is_user_member_of_blog( $first_blog_admin, $first_blog ) );
 
-		// Enqueue JS tracker.
+		// Enqueue tracker script.
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 
@@ -304,7 +334,7 @@ final class ScriptsTest extends TestCase {
 		self::assertEquals( get_current_blog_id(), $second_blog );
 		self::assertFalse( is_user_member_of_blog( $first_blog_admin, get_current_blog_id() ) );
 
-		// Enqueue JS tracker.
+		// Enqueue tracker script.
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -11,6 +11,7 @@ namespace Parsely\Tests\Integration;
 
 use Parsely\Parsely;
 use Parsely\Scripts;
+use PHPUnit\Framework\RiskyTestError;
 use WP_Scripts;
 
 /**
@@ -379,9 +380,14 @@ final class ScriptsTest extends TestCase {
 	 * @param string $handle       Script handle to test.
 	 * @param array  $assert_true  Optional. Statuses that should assert to true. Accepts 'enqueued', 'registered', 'queue', 'to_do', and 'done'. Default is an empty array.
 	 * @param array  $assert_false Optional. Statuses that should assert to false. Accepts 'enqueued', 'registered', 'queue', 'to_do', and 'done'. Default is an empty array.
-	 * @return void
+	 *
+	 * @throws RiskyTestError If no assertions ($assert_true, $assert_false) get passed to the function.
 	 */
 	public function assert_script_statuses( string $handle, array $assert_true = array(), array $assert_false = array() ): void {
+		if ( 0 === count( $assert_true ) + count( $assert_false ) ) {
+			throw new RiskyTestError( 'Function assert_script_statuses() has been used without any arguments' );
+		}
+
 		foreach ( $assert_true as $status ) {
 			self::assertTrue(
 				wp_script_is( $handle, $status ),

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -111,25 +111,29 @@ final class ScriptsTest extends TestCase {
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 		$intermediate_output = ob_get_contents();
+
+		// Enqueueing JS tracker script should not produce any output.
 		self::assertSame(
 			'',
 			$intermediate_output,
-			'Failed to confirm scripts were not printed by enqueue_js_tracker()'
+			'Function enqueue_js_tracker() should not return any output'
 		);
 
+		// Confirm that JS tracker script gets enqueued.
 		self::assertTrue(
 			wp_script_is( 'wp-parsely-tracker', 'enqueued' ),
-			'Failed to confirm tracker script was enqueued'
+			'Script wp-parsely-tracker was not enqueued'
 		);
 
+		// Confirm that JS tracker script gets printed correctly.
 		wp_print_scripts();
+		wp_print_footer_scripts();
 		$output = ob_get_clean();
-
 		self::assertSame(
 			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 			"<script type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=" . Parsely::VERSION . "' id=\"parsely-cfg\"></script>\n",
 			$output,
-			'Failed to confirm script tag was printed correctly'
+			'JS tracker script tag was not printed correctly'
 		);
 	}
 

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -317,7 +317,7 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
-	 * Test multiple script statuses in one go.
+	 * Assert multiple enqueueing statuses for a script.
 	 *
 	 * @param string $handle Script handle to test.
 	 * @param array  $assert_true Statuses that should assert to true.

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -90,9 +90,7 @@ final class ScriptsTest extends TestCase {
 	 * @group enqueue-js
 	 */
 	public function test_enqueue_js_tracker(): void {
-		$post_data = $this->create_test_post_array();
-		$post      = $this->factory->post->create( $post_data );
-		$this->go_to( '/?p=' . $post );
+		$this->go_to_new_post();
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 
@@ -122,9 +120,7 @@ final class ScriptsTest extends TestCase {
 		add_filter( 'wp_parsely_enable_cfasync_attribute', '__return_true' );
 
 		ob_start();
-		$post_array = $this->create_test_post_array();
-		$post       = $this->factory->post->create( $post_array );
-		$this->go_to( '/?p=' . $post );
+		$this->go_to_new_post();
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 
@@ -153,9 +149,7 @@ final class ScriptsTest extends TestCase {
 	public function test_enqueue_js_tracker_filter(): void {
 		add_filter( 'wp_parsely_load_js_tracker', '__return_false' );
 
-		$post_array = $this->create_test_post_array();
-		$post       = $this->factory->post->create( $post_array );
-		$this->go_to( '/?p=' . $post );
+		$this->go_to_new_post();
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 
@@ -293,9 +287,7 @@ final class ScriptsTest extends TestCase {
 		);
 		TestCase::set_options( $custom_options );
 
-		$post_array = $this->create_test_post_array();
-		$post       = $this->factory->post->create( $post_array );
-		$this->go_to( '/?p=' . $post );
+		$this->go_to_new_post();
 
 		self::assertEquals( get_current_blog_id(), $first_blog );
 		self::assertTrue( is_user_member_of_blog( $new_user, $first_blog ) );

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -354,7 +354,7 @@ final class ScriptsTest extends TestCase {
 	 * @group scripts
 	 * @group scripts-output
 	 */
-	public function test_tracker_html_markup_when_cfasync_filter_is_called(): void {
+	public function test_tracker_markup_has_attribute_when_cfasync_filter_is_used(): void {
 		add_filter( 'wp_parsely_enable_cfasync_attribute', '__return_true' );
 
 		ob_start();

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -49,7 +49,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
-	 * @group enqueue-js
+	 * @group scripts
 	 */
 	public function test_parsely_register_scripts(): void {
 
@@ -94,7 +94,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @uses \Parsely\Scripts::register_scripts
 	 * @uses \Parsely\Scripts::script_loader_tag
-	 * @group enqueue-js
+	 * @group scripts
 	 */
 	public function test_enqueue_js_tracker(): void {
 		$this->go_to_new_post();
@@ -121,7 +121,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @uses \Parsely\Scripts::register_scripts
 	 * @uses \Parsely\Scripts::script_loader_tag
-	 * @group enqueue-js
+	 * @group scripts
 	 */
 	public function test_enqueue_js_tracker_with_javascript_option_disabled(): void {
 		TestCase::set_options( array( 'disable_javascript' => true ) );
@@ -175,7 +175,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @uses \Parsely\Scripts::register_scripts
-	 * @group enqueue-js
+	 * @group scripts
 	 */
 	public function test_enqueue_js_api_no_secret(): void {
 		self::$scripts->register_scripts();
@@ -201,7 +201,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @uses \Parsely\Scripts::register_scripts
 	 * @uses \Parsely\Scripts::script_loader_tag
-	 * @group enqueue-js
+	 * @group scripts
 	 */
 	public function test_enqueue_js_api_with_secret(): void {
 		self::$scripts->register_scripts();
@@ -223,7 +223,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::parsely_is_user_logged_in
-	 * @group enqueue-js
+	 * @group scripts
 	 * @group settings
 	 */
 	public function test_do_not_track_logged_in_users(): void {
@@ -271,7 +271,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @uses \Parsely\Scripts::register_scripts
 	 * @uses \Parsely\Scripts::script_loader_tag
-	 * @group enqueue-js
+	 * @group scripts
 	 * @group settings
 	 */
 	public function test_do_not_track_logged_in_users_multisite(): void {
@@ -339,6 +339,41 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
+	 * Test that the tracker script is correctly output in HTML markup
+	 * when the wp_parsely_enable_cfasync_attribute filter is used.
+	 *
+	 * @covers \Parsely\Scripts::enqueue_js_tracker
+	 * @uses \Parsely\Parsely::get_asset_cache_buster
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::update_metadata_endpoint
+	 * @uses \Parsely\Scripts::register_scripts
+	 * @uses \Parsely\Scripts::script_loader_tag
+	 * @group scripts
+	 * @group scripts-output
+	 */
+	public function test_tracker_html_markup_when_cfasync_filter_is_called(): void {
+		add_filter( 'wp_parsely_enable_cfasync_attribute', '__return_true' );
+
+		ob_start();
+		$this->go_to_new_post();
+		self::$scripts->register_scripts();
+		self::$scripts->enqueue_js_tracker();
+
+		wp_print_scripts();
+		$output = ob_get_clean();
+
+		self::assertSame(
+			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+			"<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=" . Parsely::VERSION . "' id=\"parsely-cfg\"></script>\n",
+			$output,
+			'Tracker script tag was not printed correctly'
+		);
+	}
+
+	/**
 	 * Assert multiple enqueueing statuses for a script.
 	 *
 	 * @param string $handle       Script handle to test.
@@ -360,40 +395,5 @@ final class ScriptsTest extends TestCase {
 				"Unexpected script status: $handle status should NOT be '$status'"
 			);
 		}
-	}
-
-	/**
-	 * Test that the tracker script is correctly output in HTML markup
-	 * when the wp_parsely_enable_cfasync_attribute filter is used.
-	 *
-	 * @covers \Parsely\Scripts::enqueue_js_tracker
-	 * @uses \Parsely\Parsely::get_asset_cache_buster
-	 * @uses \Parsely\Parsely::api_key_is_missing
-	 * @uses \Parsely\Parsely::api_key_is_set
-	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::post_has_trackable_status
-	 * @uses \Parsely\Parsely::update_metadata_endpoint
-	 * @uses \Parsely\Scripts::register_scripts
-	 * @uses \Parsely\Scripts::script_loader_tag
-	 * @group enqueue-js
-	 * @group insert-js
-	 */
-	public function test_tracker_html_markup_when_cfasync_filter_is_called(): void {
-		add_filter( 'wp_parsely_enable_cfasync_attribute', '__return_true' );
-
-		ob_start();
-		$this->go_to_new_post();
-		self::$scripts->register_scripts();
-		self::$scripts->enqueue_js_tracker();
-
-		wp_print_scripts();
-		$output = ob_get_clean();
-
-		self::assertSame(
-			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-			"<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=" . Parsely::VERSION . "' id=\"parsely-cfg\"></script>\n",
-			$output,
-			'Tracker script tag was not printed correctly'
-		);
 	}
 }

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -91,7 +91,7 @@ final class ScriptsTest extends TestCase {
 		// Confirm that JS tracker script is registered and enqueued.
 		$this->assert_script_statuses(
 			'wp-parsely-tracker',
-			array( 'registered', 'enqueued' ),
+			array( 'registered', 'enqueued' )
 		);
 	}
 
@@ -282,7 +282,7 @@ final class ScriptsTest extends TestCase {
 		self::assertEquals( get_current_blog_id(), $first_blog );
 		self::assertTrue( is_user_member_of_blog( $first_blog_admin, $first_blog ) );
 
-		// Enqueue JS tracker
+		// Enqueue JS tracker.
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 
@@ -304,7 +304,7 @@ final class ScriptsTest extends TestCase {
 		self::assertEquals( get_current_blog_id(), $second_blog );
 		self::assertFalse( is_user_member_of_blog( $first_blog_admin, get_current_blog_id() ) );
 
-		// Enqueue JS tracker
+		// Enqueue JS tracker.
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 
@@ -320,8 +320,8 @@ final class ScriptsTest extends TestCase {
 	 * Test multiple script statuses in one go.
 	 *
 	 * @param string $handle Script handle to test.
-	 * @param array $assert_true Statuses that should assert to true.
-	 * @param array $assert_false Statuses that should assert to false.
+	 * @param array  $assert_true Statuses that should assert to true.
+	 * @param array  $assert_false Statuses that should assert to false.
 	 * @return void
 	 */
 	public function assert_script_statuses( string $handle, array $assert_true = array(), array $assert_false = array() ): void {

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -61,30 +61,31 @@ final class ScriptsTest extends TestCase {
 		self::$scripts->register_scripts();
 		$output = ob_get_clean();
 
+		// Registering scripts should not produce any output.
 		self::assertSame(
 			'',
 			$output,
-			'Failed to confirm nothing was printed by register_scripts()'
+			'Unexpected output while registering scripts'
 		);
 
+		// Confirm that API script is registered but not enqueued.
 		self::assertTrue(
 			wp_script_is( 'wp-parsely-api', 'registered' ),
-			'Failed to confirm API script was registered'
+			'Script wp-parsely-api was not registered'
 		);
-
 		self::assertFalse(
 			wp_script_is( 'wp-parsely-api', 'enqueued' ),
-			'Failed to confirm API script was not enqueued'
+			'Script wp-parsely-api should not be enqueued'
 		);
 
+		// Confirm that tracker script is registered but not enqueued.
 		self::assertTrue(
 			wp_script_is( 'wp-parsely-tracker', 'registered' ),
-			'Failed to confirm API script was registered'
+			'Script wp-parsely-tracker was not registered'
 		);
-
 		self::assertFalse(
 			wp_script_is( 'wp-parsely-tracker', 'enqueued' ),
-			'Failed to confirm API script was not enqueued'
+			'Script wp-parsely-tracker should not be enqueued'
 		);
 	}
 

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -136,7 +136,7 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
-	 * Test the wp_parsely_enqueue_js_tracker filter
+	 * Test the wp_parsely_load_js_tracker filter
 	 * When it returns false, the tracking script should not be enqueued.
 	 *
 	 * @covers \Parsely\Scripts::enqueue_js_tracker
@@ -146,7 +146,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 */
-	public function test_enqueue_js_tracker_filter(): void {
+	public function test_wp_parsely_load_js_tracker_filter(): void {
 		add_filter( 'wp_parsely_load_js_tracker', '__return_false' );
 
 		$this->go_to_new_post();

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -125,7 +125,7 @@ final class ScriptsTest extends TestCase {
 			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 			"<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=" . Parsely::VERSION . "' id=\"parsely-cfg\"></script>\n",
 			$output,
-			'Failed to confirm script tag was printed correctly'
+			'Tracker script tag was not printed correctly'
 		);
 	}
 

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -126,40 +126,6 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
-	 * Test the tracker script enqueue.
-	 *
-	 * @covers \Parsely\Scripts::enqueue_js_tracker
-	 * @uses \Parsely\Parsely::get_asset_cache_buster
-	 * @uses \Parsely\Parsely::api_key_is_missing
-	 * @uses \Parsely\Parsely::api_key_is_set
-	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::post_has_trackable_status
-	 * @uses \Parsely\Parsely::update_metadata_endpoint
-	 * @uses \Parsely\Scripts::register_scripts
-	 * @uses \Parsely\Scripts::script_loader_tag
-	 * @group enqueue-js
-	 * @group insert-js
-	 */
-	public function test_enqueue_js_tracker_with_cloudflare(): void {
-		add_filter( 'wp_parsely_enable_cfasync_attribute', '__return_true' );
-
-		ob_start();
-		$this->go_to_new_post();
-		self::$scripts->register_scripts();
-		self::$scripts->enqueue_js_tracker();
-
-		wp_print_scripts();
-		$output = ob_get_clean();
-
-		self::assertSame(
-			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-			"<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=" . Parsely::VERSION . "' id=\"parsely-cfg\"></script>\n",
-			$output,
-			'Tracker script tag was not printed correctly'
-		);
-	}
-
-	/**
 	 * Test the wp_parsely_load_js_tracker filter
 	 * When it returns false, the tracking script should not be enqueued.
 	 *
@@ -381,5 +347,40 @@ final class ScriptsTest extends TestCase {
 				"Unexpected script status: $handle status should NOT be '$status'"
 			);
 		}
+	}
+
+	/**
+	 * Test that the tracker script is correctly output in HTML markup
+	 * when the wp_parsely_enable_cfasync_attribute filter is used.
+	 *
+	 * @covers \Parsely\Scripts::enqueue_js_tracker
+	 * @uses \Parsely\Parsely::get_asset_cache_buster
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::update_metadata_endpoint
+	 * @uses \Parsely\Scripts::register_scripts
+	 * @uses \Parsely\Scripts::script_loader_tag
+	 * @group enqueue-js
+	 * @group insert-js
+	 */
+	public function test_tracker_html_markup_when_cfasync_filter_is_called(): void {
+		add_filter( 'wp_parsely_enable_cfasync_attribute', '__return_true' );
+
+		ob_start();
+		$this->go_to_new_post();
+		self::$scripts->register_scripts();
+		self::$scripts->enqueue_js_tracker();
+
+		wp_print_scripts();
+		$output = ob_get_clean();
+
+		self::assertSame(
+			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+			"<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=" . Parsely::VERSION . "' id=\"parsely-cfg\"></script>\n",
+			$output,
+			'Tracker script tag was not printed correctly'
+		);
 	}
 }

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -362,9 +362,9 @@ final class ScriptsTest extends TestCase {
 	/**
 	 * Assert multiple enqueueing statuses for a script.
 	 *
-	 * @param string $handle Script handle to test.
-	 * @param array  $assert_true Statuses that should assert to true.
-	 * @param array  $assert_false Statuses that should assert to false.
+	 * @param string $handle       Script handle to test.
+	 * @param array  $assert_true  Optional. Statuses that should assert to true. Accepts 'enqueued', 'registered', 'queue', 'to_do', and 'done'. Default is an empty array.
+	 * @param array  $assert_false Optional. Statuses that should assert to false. Accepts 'enqueued', 'registered', 'queue', 'to_do', and 'done'. Default is an empty array.
 	 * @return void
 	 */
 	public function assert_script_statuses( string $handle, array $assert_true = array(), array $assert_false = array() ): void {

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -49,7 +49,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
-	 * @group insert-js
+	 * @group enqueue-js
 	 */
 	public function test_parsely_register_scripts(): void {
 		self::$scripts->register_scripts();
@@ -87,7 +87,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @uses \Parsely\Scripts::register_scripts
 	 * @uses \Parsely\Scripts::script_loader_tag
-	 * @group insert-js
+	 * @group enqueue-js
 	 */
 	public function test_enqueue_js_tracker(): void {
 		$post_data = $this->create_test_post_array();
@@ -115,6 +115,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @uses \Parsely\Scripts::register_scripts
 	 * @uses \Parsely\Scripts::script_loader_tag
+	 * @group enqueue-js
 	 * @group insert-js
 	 */
 	public function test_enqueue_js_tracker_with_cloudflare(): void {
@@ -179,7 +180,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @uses \Parsely\Scripts::register_scripts
-	 * @group insert-js
+	 * @group enqueue-js
 	 */
 	public function test_enqueue_js_api_no_secret(): void {
 		self::$scripts->register_scripts();
@@ -203,7 +204,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @uses \Parsely\Scripts::register_scripts
 	 * @uses \Parsely\Scripts::script_loader_tag
-	 * @group insert-js
+	 * @group enqueue-js
 	 */
 	public function test_enqueue_js_api_with_secret(): void {
 		self::$scripts->register_scripts();
@@ -224,7 +225,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::parsely_is_user_logged_in
-	 * @group insert-js
+	 * @group enqueue-js
 	 * @group settings
 	 */
 	public function test_user_logged_in(): void {
@@ -268,7 +269,7 @@ final class ScriptsTest extends TestCase {
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @uses \Parsely\Scripts::register_scripts
 	 * @uses \Parsely\Scripts::script_loader_tag
-	 * @group insert-js
+	 * @group enqueue-js
 	 * @group settings
 	 */
 	public function test_user_logged_in_multisite(): void {

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -41,7 +41,7 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
-	 * Test JavaScript registrations.
+	 * Test script registration functionality.
 	 *
 	 * @covers \Parsely\Scripts::register_scripts
 	 * @uses \Parsely\Parsely::get_asset_cache_buster
@@ -52,16 +52,29 @@ final class ScriptsTest extends TestCase {
 	 * @group enqueue-js
 	 */
 	public function test_parsely_register_scripts(): void {
+
+		// Confirm that API and tracker scripts are not registered.
+		$this->assert_script_statuses(
+			'wp-parsely-api',
+			array(),
+			array( 'registered' )
+		);
+		$this->assert_script_statuses(
+			'wp-parsely-tracker',
+			array(),
+			array( 'registered' )
+		);
+
+		// Attempt to register API and tracker scripts.
 		self::$scripts->register_scripts();
 
-		// Confirm that API script is registered but not enqueued.
+		// Confirm that API and tracker scripts are now registered
+		// (but not yet enqueued).
 		$this->assert_script_statuses(
 			'wp-parsely-api',
 			array( 'registered' ),
 			array( 'enqueued' )
 		);
-
-		// Confirm that tracker script is registered but not enqueued.
 		$this->assert_script_statuses(
 			'wp-parsely-tracker',
 			array( 'registered' ),

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -163,4 +163,17 @@ abstract class TestCase extends WPIntegrationTestCase {
 		$method->setAccessible( true );
 		return $method;
 	}
+
+	/**
+	 * Create a new post and go to it.
+	 *
+	 * @return int The new post's ID.
+	 */
+	public function go_to_new_post(): int {
+		$post_data = $this->create_test_post_array();
+		$post_id   = $this->factory->post->create( $post_data );
+		$this->go_to( '/?p=' . $post_id );
+
+		return $post_id;
+	}
 }


### PR DESCRIPTION
# Goal

This PR tries to address the issues reported in #338 and opens a discussion so we can focus on finding the most correct approach to this.

**I will need your feedback!**

# Points made and code examination results

If I correctly understand the points made by @GaryJones, it is said that:  
1. `wp_script_is()` could be enough for our testing, as well as that testing the output is "out of our scope".
2. If we stick to testing output, we should also make sure that any footer-injected scripts are taken into account.

## Point 1
Looking at the code, I see that tests use a combination of output checking **and** `wp_script_is()`. `wp_script_is()` should definitely be checked, but the only way to really know if something actually made it to output is output examination. So I think that using both together can be considered as a valid approach.

Having said that, I also do agree that this is in WP scope and that we're testing something that's "out of our control and business". It would be easy to just remove output checking and it would mitigate point 2 altogether, but I'd rather have feedback from contributors first as I wouldn't like to decide by myself on this.

## Point 2

I made some tryouts using `wp_print_scripts()`, `wp_print_footer_scripts()` and `wp_footer()` functions. `wp_footer` gave me errors and I gave up on it quite quickly on the basis that `wp_print_footer_scripts()` is much more fitting for our use case and that `wp_footer` could result in unpredictable output.

I used `wp_print_scripts()` and `wp_print_footer_scripts()` in combination (in both orders) as well as isolated, with scripts being included in the footer and header. My findings were that they behaved exactly the same, and that when calling both, the second call wouldn't give any output. I was a bit surprised by that.

So from my findings, using `wp_print_scripts()` should be enough for our needs, but we could add both functions for good measure as it's easy and doesn't introduce any side effects (at least from my own testing).

# Final notes

- I find that test messages like "Failed to confirm nothing was printed by register_scripts()" can be confusing for me. I think that going for something like "register_scripts() unexpected output" or "register_scripts() should not produce any output" is more easily understandable and I've started modifying test messages towards that direction. Let me know if I shouldn't.
- So far I've made changes only to the `test_parsely_register_scripts()` and `test_enqueue_js_tracker()` functions just to give you an idea where I'm going with this.
- Let me know of any comments or feedback so we can decide on the final direction this will take.

Thanks!
