### PR TITLE
CI: Add concurrency to CI configs, and Composer tweaks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,12 @@ on:
   schedule:
     - cron: '27 20 * * 2'
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -10,6 +10,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checkcs:
     name: 'Basic CS and QA checks'

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -48,16 +48,16 @@ jobs:
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate
       - name: Validate Composer installation
-        run: composer validate --no-check-all --strict
+        run: composer validate --no-check-all --strict --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       # Lint PHP.
       - name: Lint PHP against parse errors
-        run: composer lint-ci | cs2pr
+        run: composer lint-ci --no-interaction | cs2pr
 
       # Needed as runs-on: system doesn't have xml-lint by default.
       # @link https://github.com/marketplace/actions/xml-lint

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,11 +70,11 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       # - name: Install Composer dependencies for PHP >= 8.2
       #  if: ${{ matrix.php >= 8.2 }}
-      #  uses: ramsey/composer-install@v1
+      #  uses: ramsey/composer-install@v2
       #  with:
       #    composer-options: --ignore-platform-reqs
 
@@ -86,12 +86,12 @@ jobs:
         run: mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
 
       - name: Prepare environment for integration tests
-        run: composer prepare-ci
+        run: composer prepare-ci --no-interaction
 
       - name: Run integration tests (single site)
         if: ${{ matrix.php != 8.0 }}
-        run: composer testwp
+        run: composer testwp --no-interaction
 
       - name: Run integration tests (multisite site with code coverage)
         if: ${{ matrix.php == 8.0 }}
-        run: composer coveragewp-ci
+        run: composer coveragewp-ci --no-interaction

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,6 +8,12 @@ on:
       - '**.md'
   pull_request:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: PHP ${{ matrix.php }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,6 +11,12 @@ on:
       - '**/*[tj]sx?'
       - package*.json
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,6 +10,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: PHP ${{ matrix.php }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -73,13 +73,13 @@ jobs:
 
       - name: Install Composer dependencies for PHP < 8.2
         if: ${{ matrix.php < 8.2 }}
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Install Composer dependencies for PHP >= 8.2
         if: ${{ matrix.php >= 8.2 }}
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
         with:
           composer-options: --ignore-platform-reqs
 
       - name: Run unit tests
-        run: composer test
+        run: composer test --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,12 @@
 		"wp-coding-standards/wpcs": "^2.3.0",
 		"yoast/wp-test-utils": "^1"
 	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
 	"autoload": {
 		"classmap": [
 			"src/"
@@ -42,13 +48,13 @@
 			"@putenv WP_MULTISITE=1",
 			"@php ./vendor/bin/phpunit --coverage-html ./build/coverage-html/unit -v"
 		],
-		"coveragewp": [
-			"@putenv WP_MULTISITE=1",
-			"@php ./vendor/bin/phpunit --coverage-html ./build/coverage-html/integration -c phpunit-integration.xml.dist -v"
-		],
 		"coverage-ci": [
 			"@putenv WP_MULTISITE=1",
 			"@php ./vendor/bin/phpunit -v"
+		],
+		"coveragewp": [
+			"@putenv WP_MULTISITE=1",
+			"@php ./vendor/bin/phpunit --coverage-html ./build/coverage-html/integration -c phpunit-integration.xml.dist -v"
 		],
 		"coveragewp-ci": [
 			"@putenv WP_MULTISITE=1",
@@ -82,13 +88,17 @@
 		]
 	},
 	"scripts-descriptions": {
-		"coverage": "Run tests with code coverage for the Parse.ly plugin and generate local HTML output.",
-		"coverage-ci": "Run tests with code coverage for the Parse.ly plugin and generate a Clover XML file for CI.",
+		"coverage": "Run unit tests with code coverage for the Parse.ly plugin, send results to stdout, and generate plus local HTML output.",
+		"coverage-ci": "Run unit tests with code coverage for the Parse.ly plugin and send results to stdout.",
+		"coveragewp": "Run integration tests with code coverage for the Parse.ly plugin, send results to stdout, and generate local HTML output.",
+		"coveragewp-ci": "Run integration tests with code coverage for the Parse.ly plugin and send results to stdout.",
 		"cs": "Run PHPCS to checking coding standards for the Parse.ly plugin.",
 		"lint": "Run PHP linting on the Parse.ly plugin.",
 		"lint-ci": "Run PHP linting on the Parse.ly plugin with checkstyle output for CI.",
 		"prepare-ci": "Install the files and setup a database needed to run tests for the Parse.ly plugin for CI.",
-		"test": "Run the tests for the Parse.ly plugin.",
-		"test-ms": "Run the tests for the Parse.ly plugin on a multisite install."
+		"test": "Run the unit tests for the Parse.ly plugin.",
+		"test-ms": "Run the unit tests for the Parse.ly plugin on a multisite install.",
+		"testwp": "Run the integration tests for the Parse.ly plugin.",
+		"testwp-ms": "Run the integration tests for the Parse.ly plugin on a multisite install."
 	}
 }


### PR DESCRIPTION
## Description

### Add concurrency to CI configs 

Previously, in Travis, when the same branch was pushed again and the "Auto cancellation" option on the "Settings" page had been turned on (as it was for most repos), any still running builds for the same branch would be stopped in favour of starting the build for the newly pushed version of the branch.

To enable this behaviour in GH Actions, a concurrency configuration needs to be added to each workflow for which this should applied to.

More than anything, this is a way to be kind to GitHub by not wasting resources which they so kindly provide to us for free.
### Composer tweaks 

- `ramsay/composer-install`, the action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means the action reference needs to be updated to benefit from it.
- Add `--no-interaction` to "plain" Composer commands to potentially prevent CI hanging if, for whatever reason, interaction would be needed in the future.

### Composer: permit composer plugins 

The `dealerdirect/phpcodesniffer-composer-installer` and `composer/installers` Composer plugins are used to register an external PHPCS standards with PHPCS, and allow the plugin to be installed in a `wp-content/plugins` directory.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run. This adds the necessary configuration for that.

Any globally-installed Composer plugin should be configured in the global `composer.json`.

`composer normalize` also run on the file, which fixes a non-alphabetical script.

Also, refreshes the list of script descriptions.

Refs:
 - https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution

## Motivation and Context
All kudos to @jrfnl - 95% of this PR is her original work and words from https://github.com/Automattic/VIP-Coding-Standards/pull/705 🙏🏻

> If I have seen further it is by standing on the shoulders of giants.
> — [Sir Isaac Newton](https://en.wikipedia.org/wiki/Standing_on_the_shoulders_of_giants#cite_note-3)

## How Has This Been Tested?
The CI jobs for this PR all pass.
