### PR TITLE
Fix incorrect last modified date in json+ld

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -449,8 +449,8 @@ class Parsely {
 			);
 			$parsely_page['dateCreated']      = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );
 			$parsely_page['datePublished']    = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );
-			if ( get_the_modified_date( 'U', true ) >= get_post_time( 'U', true, $post ) ) {
-				$parsely_page['dateModified'] = gmdate( 'Y-m-d\TH:i:s\Z', get_the_modified_date( 'U', true ) );
+			if ( get_post_modified_time( 'U', true, $post ) >= get_post_time( 'U', true, $post ) ) {
+				$parsely_page['dateModified'] = gmdate( 'Y-m-d\TH:i:s\Z', get_post_modified_time( 'U', true, $post ) );
 			} else {
 				// Use the post time as the earliest possible modification date.
 				$parsely_page['dateModified'] = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -502,19 +502,15 @@ class Parsely {
 			return;
 		}
 
-		$post_time_gmt = gmdate( $date_format, $post_time );
+		$post_time_created_gmt = gmdate( $date_format, $post_time );
+		$post_time_modified    = get_post_modified_time( 'U', true, $post );
 
-		// Set post created and published time.
-		$metadata['dateCreated']   = $post_time_gmt;
-		$metadata['datePublished'] = $post_time_gmt;
+		$metadata['dateCreated']   = $post_time_created_gmt;
+		$metadata['datePublished'] = $post_time_created_gmt;
+		$metadata['dateModified']  = $post_time_created_gmt;
 
-		// Set post modified time.
-		$metadata['dateModified'] = $post_time_gmt;
-
-		$post_modified_time = get_post_modified_time( 'U', true, $post );
-
-		if ( false !== $post_modified_time && $post_modified_time > $post_time ) {
-			$metadata['dateModified'] = gmdate( $date_format, $post_modified_time );
+		if ( false !== $post_time_modified && $post_time_modified > $post_time ) {
+			$metadata['dateModified'] = gmdate( $date_format, $post_time_modified );
 		}
 	}
 

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -491,7 +491,7 @@ class Parsely {
 	 * Sets all metadata values related to post time.
 	 *
 	 * @param array   $metadata Array containing all metadata. It will be potentially mutated to add keys: dateCreated, dateModified, & datePublished.
-	 * @param WP_Post $post Post object from which to extract time data.
+	 * @param WP_Post $post     Post object from which to extract time data.
 	 * @return void
 	 */
 	private function set_metadata_post_times( array &$metadata, WP_Post $post ): void {

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -447,14 +447,9 @@ class Parsely {
 				'@type' => 'ImageObject',
 				'url'   => $image_url,
 			);
-			$parsely_page['dateCreated']      = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );
-			$parsely_page['datePublished']    = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );
-			if ( get_post_modified_time( 'U', true, $post ) >= get_post_time( 'U', true, $post ) ) {
-				$parsely_page['dateModified'] = gmdate( 'Y-m-d\TH:i:s\Z', get_post_modified_time( 'U', true, $post ) );
-			} else {
-				// Use the post time as the earliest possible modification date.
-				$parsely_page['dateModified'] = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );
-			}
+
+			$this->set_metadata_post_times( $parsely_page, $post );
+
 			$parsely_page['articleSection'] = $category;
 			$author_objects                 = array();
 			foreach ( $authors as $author ) {
@@ -490,6 +485,31 @@ class Parsely {
 		 * @param array   $parsely_options The Parsely options.
 		 */
 		return apply_filters( 'wp_parsely_metadata', $parsely_page, $post, $parsely_options );
+	}
+
+	/**
+	 * Sets all metadata values related to post time.
+	 *
+	 * @param array   $metadata Array containing all metadata.
+	 * @param WP_Post $post Post object from which to extract time data.
+	 * @return void
+	 */
+	private function set_metadata_post_times( array &$metadata, WP_Post $post ): void {
+		// Initializations.
+		$date_format   = 'Y-m-d\TH:i:s\Z';
+		$post_time     = get_post_time( 'U', true, $post );
+		$post_time_gmt = gmdate( $date_format, $post_time );
+
+		// Set post created and published time.
+		$metadata['dateCreated']   = $post_time_gmt;
+		$metadata['datePublished'] = $post_time_gmt;
+
+		// Set post modified time.
+		$metadata['dateModified'] = $post_time_gmt;
+		$post_modified_time       = get_post_modified_time( 'U', true, $post );
+		if ( false !== $post_modified_time && $post_modified_time > $post_time ) {
+			$metadata['dateModified'] = $post_modified_time;
+		}
 	}
 
 	/**

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -495,22 +495,21 @@ class Parsely {
 	 * @return void
 	 */
 	private function set_metadata_post_times( array &$metadata, WP_Post $post ): void {
-		$date_format = 'Y-m-d\TH:i:s\Z';
-		$post_time   = get_post_time( 'U', true, $post );
+		$date_format      = 'Y-m-d\TH:i:s\Z';
+		$post_created_gmt = get_post_time( $date_format, true, $post );
 
-		if ( false === $post_time ) {
+		if ( false === $post_created_gmt ) {
 			return;
 		}
 
-		$post_time_created_gmt = gmdate( $date_format, $post_time );
-		$post_time_modified    = get_post_modified_time( 'U', true, $post );
+		$metadata['dateCreated']   = $post_created_gmt;
+		$metadata['datePublished'] = $post_created_gmt;
+		$metadata['dateModified']  = $post_created_gmt;
 
-		$metadata['dateCreated']   = $post_time_created_gmt;
-		$metadata['datePublished'] = $post_time_created_gmt;
-		$metadata['dateModified']  = $post_time_created_gmt;
+		$post_modified_gmt = get_post_modified_time( $date_format, true, $post );
 
-		if ( false !== $post_time_modified && $post_time_modified > $post_time ) {
-			$metadata['dateModified'] = gmdate( $date_format, $post_time_modified );
+		if ( false !== $post_modified_gmt && $post_modified_gmt > $post_created_gmt ) {
+			$metadata['dateModified'] = $post_modified_gmt;
 		}
 	}
 

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -495,9 +495,13 @@ class Parsely {
 	 * @return void
 	 */
 	private function set_metadata_post_times( array &$metadata, WP_Post $post ): void {
-		// Initializations.
-		$date_format   = 'Y-m-d\TH:i:s\Z';
-		$post_time     = get_post_time( 'U', true, $post );
+		$date_format = 'Y-m-d\TH:i:s\Z';
+		$post_time   = get_post_time( 'U', true, $post );
+
+		if ( false === $post_time ) {
+			return;
+		}
+
 		$post_time_gmt = gmdate( $date_format, $post_time );
 
 		// Set post created and published time.
@@ -506,9 +510,11 @@ class Parsely {
 
 		// Set post modified time.
 		$metadata['dateModified'] = $post_time_gmt;
-		$post_modified_time       = get_post_modified_time( 'U', true, $post );
+
+		$post_modified_time = get_post_modified_time( 'U', true, $post );
+
 		if ( false !== $post_modified_time && $post_modified_time > $post_time ) {
-			$metadata['dateModified'] = $post_modified_time;
+			$metadata['dateModified'] = gmdate( $date_format, $post_modified_time );
 		}
 	}
 

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -490,7 +490,7 @@ class Parsely {
 	/**
 	 * Sets all metadata values related to post time.
 	 *
-	 * @param array   $metadata Array containing all metadata.
+	 * @param array   $metadata Array containing all metadata. It will be potentially mutated to add keys: dateCreated, dateModified, & datePublished.
 	 * @param WP_Post $post Post object from which to extract time data.
 	 * @return void
 	 */


### PR DESCRIPTION
## Description
This PR attempts to resolve an issue where the last modified date in the json+ld output could be wrong.  Additionally, this fixes potential fatal errors caused by passing `false` into the second param of the `gmdate` function now that we're enforcing strict types for function parameters.

Fixes #558
Fixes #562

## Motivation and Context
More details about the issue can be found in #558. This is something that should be fixed and we should aim to add a test for it.

## How Has This Been Tested?
So far only by examining browser output and by examining variables using step debugging, but will also look into writing a test for this.