### PR TITLE
Correct Parsely spelling in comments within tests

### DIFF
--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -86,7 +86,7 @@ final class OtherTest extends TestCase {
 	 * @group filters
 	 */
 	public function test_parsely_page_filter(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 

--- a/tests/Integration/StructuredData/AuthorArchiveTest.php
+++ b/tests/Integration/StructuredData/AuthorArchiveTest.php
@@ -41,7 +41,7 @@ final class AuthorArchiveTest extends NonPostTestCase {
 		// See https://github.com/Parsely/wp-parsely/issues/151.
 		$this->set_permalink_structure( '/%postname%/' );
 
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 

--- a/tests/Integration/StructuredData/BlogArchiveTest.php
+++ b/tests/Integration/StructuredData/BlogArchiveTest.php
@@ -37,7 +37,7 @@ final class BlogArchiveTest extends NonPostTestCase {
 	 * @group metadata
 	 */
 	public function test_blog_page_for_posts_paged(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 

--- a/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
@@ -42,7 +42,7 @@ final class CustomPostTypeArchiveTest extends NonPostTestCase {
 		// See https://github.com/Parsely/wp-parsely/issues/151.
 		$this->set_permalink_structure( '/%postname%/' );
 
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 

--- a/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
@@ -42,7 +42,7 @@ class CustomTaxonomyTermArchiveTest extends NonPostTestCase {
 		// See https://github.com/Parsely/wp-parsely/issues/151.
 		$this->set_permalink_structure( '/%postname%/' );
 
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 

--- a/tests/Integration/StructuredData/HomePageTest.php
+++ b/tests/Integration/StructuredData/HomePageTest.php
@@ -48,7 +48,7 @@ final class HomePageTest extends NonPostTestCase {
 	 * @group metadata
 	 */
 	public function test_home_page_for_posts(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 
@@ -94,7 +94,7 @@ final class HomePageTest extends NonPostTestCase {
 	 * @group metadata
 	 */
 	public function test_home_page_for_posts_paged(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 
@@ -145,7 +145,7 @@ final class HomePageTest extends NonPostTestCase {
 	 * @group metadata
 	 */
 	public function test_home_page_on_front(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 
@@ -197,7 +197,7 @@ final class HomePageTest extends NonPostTestCase {
 	 * @group metadata
 	 */
 	public function test_home_for_misconfigured_settings(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 

--- a/tests/Integration/StructuredData/SinglePageTest.php
+++ b/tests/Integration/StructuredData/SinglePageTest.php
@@ -38,7 +38,7 @@ final class SinglePageTest extends NonPostTestCase {
 	 * @group metadata
 	 */
 	public function test_single_page(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 

--- a/tests/Integration/StructuredData/SinglePostTest.php
+++ b/tests/Integration/StructuredData/SinglePostTest.php
@@ -48,7 +48,7 @@ final class SinglePostTest extends TestCase {
 	 * @group metadata
 	 */
 	public function test_single_post(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 
@@ -87,7 +87,7 @@ final class SinglePostTest extends TestCase {
 	 * @group metadata
 	 */
 	public function test_category_data_for_single_post(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 
@@ -123,7 +123,7 @@ final class SinglePostTest extends TestCase {
 	 * @group settings
 	 */
 	public function test_tag_data_assigned_to_a_post_are_lowercase(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 
@@ -170,7 +170,7 @@ final class SinglePostTest extends TestCase {
 	 * @group settings
 	 */
 	public function test_parsely_categories_as_tags_in_single_post(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 
@@ -217,7 +217,7 @@ final class SinglePostTest extends TestCase {
 	 * @group settings
 	 */
 	public function test_custom_taxonomy_as_tags_in_single_post(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 
@@ -275,7 +275,7 @@ final class SinglePostTest extends TestCase {
 	 * @group settings
 	 */
 	public function test_use_top_level_cats_in_single_post(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 
@@ -332,7 +332,7 @@ final class SinglePostTest extends TestCase {
 	 * @group settings
 	 */
 	public function test_custom_taxonomy_as_section_in_single_post(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 
@@ -399,7 +399,7 @@ final class SinglePostTest extends TestCase {
 	 * @group settings
 	 */
 	public function test_http_canonicals_for_single_post(): void {
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 

--- a/tests/Integration/StructuredData/TermArchiveTest.php
+++ b/tests/Integration/StructuredData/TermArchiveTest.php
@@ -41,7 +41,7 @@ final class TermArchiveTest extends NonPostTestCase {
 		// See https://github.com/Parsely/wp-parsely/issues/151.
 		$this->set_permalink_structure( '/%postname%/' );
 
-		// Setup Parsley object.
+		// Setup Parsely object.
 		$parsely         = new Parsely();
 		$parsely_options = get_option( Parsely::OPTIONS_KEY );
 


### PR DESCRIPTION
## Description
The Parsely object was referred to as "Parsley" in a few comments within tests. This PR fixes that.

## Motivation and Context
Spelling correctly is always better than spelling wrong!