### PR TITLE
Metadata: Format dates & directly compare instead of making extra gmdate calls

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -495,14 +495,12 @@ class Parsely {
 	 * @return void
 	 */
 	private function set_metadata_post_times( array &$metadata, WP_Post $post ): void {
-		$date_format = 'Y-m-d\TH:i:s\Z';
-		$post_time   = get_post_time( 'U', true, $post );
+		$date_format   = 'Y-m-d\TH:i:s\Z';
+		$post_time_gmt = get_post_time( $date_format, true, $post );
 
-		if ( false === $post_time ) {
+		if ( false === $post_time_gmt ) {
 			return;
 		}
-
-		$post_time_gmt = gmdate( $date_format, $post_time );
 
 		// Set post created and published time.
 		$metadata['dateCreated']   = $post_time_gmt;
@@ -511,10 +509,10 @@ class Parsely {
 		// Set post modified time.
 		$metadata['dateModified'] = $post_time_gmt;
 
-		$post_modified_time = get_post_modified_time( 'U', true, $post );
+		$post_modified_gmt = get_post_modified_time( $date_format, true, $post );
 
-		if ( false !== $post_modified_time && $post_modified_time > $post_time ) {
-			$metadata['dateModified'] = gmdate( $date_format, $post_modified_time );
+		if ( false !== $post_modified_gmt && $post_modified_gmt > $post_time_gmt ) {
+			$metadata['dateModified'] = $post_modified_gmt;
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since our date format is comparable (ISO 8601), we can avoid the intermediate step of pulling and comparing timestamps and just pass the format string to `get_post_time` & `get_post_modified_time` directly. 

NOTE: This is targeting the branch in #560. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fewer LOC, fewer variables to grok, etc.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Automated tests still pass. Fatal errors still not present when we coerce the post creation and modification date values to `false` via filter
