### PR TITLE
Restore trailing whitespace in readme for Stable tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.0.2
+Stable tag: 3.0.2  
 Requires at least: 5.0  
 Tested up to: 5.8  
 Requires PHP: 7.1  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

At some point, the trailing spaces on this line were dropped -- this reinstates them.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This denotes a new line so these annotations are parsed correctly by the plugin repo.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

n/a

## Screenshots (if appropriate)

n/a
