### PR TITLE
Fix fatal TypeError in get_categories function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.3] - 2022-01-12
+
+- [Fixed a fatal error](https://github.com/Parsely/wp-parsely/issues/587) when requesting metadata for a post without categories and `categories as tags` enabled. [#588](https://github.com/Parsely/wp-parsely/pull/588)
+
 ## [3.0.2] - 2022-01-05
 
 ### Fixed
@@ -434,6 +438,7 @@ If you are using the plugin without any code-level customizations (for instance,
 - Initial version.
 - Add support for parsely-page and JavaScript on home page and published pages and posts as well as archive pages (date/author/category/tag).
 
+[3.0.3]: https://github.com/Parsely/wp-parsely/compare/3.0.2...3.0.3
 [3.0.2]: https://github.com/Parsely/wp-parsely/compare/3.0.1...3.0.2
 [3.0.1]: https://github.com/Parsely/wp-parsely/compare/3.0.0...3.0.1
 [3.0.0]: https://github.com/Parsely/wp-parsely/compare/2.6.1...3.0.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.0.2  
+Stable tag: 3.0.3  
 Requires at least: 5.0  
 Tested up to: 5.8  
 Requires PHP: 7.1  

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -670,8 +670,7 @@ class Parsely {
 		foreach ( get_the_category( $post_id ) as $category ) {
 			$hierarchy = get_category_parents( $category->term_id, false, $delimiter );
 			if ( ! is_wp_error( $hierarchy ) ) {
-				$hierarchy = rtrim( $hierarchy, '/' );
-				$tags[]    = $hierarchy;
+				$tags[] = rtrim( $hierarchy, '/' );
 			}
 		}
 		// take last element in the hierarchy, a string representing the full parent->child tree,

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -666,13 +666,16 @@ class Parsely {
 	private function get_categories( int $post_id, string $delimiter = '/' ): array {
 		$tags = array();
 		foreach ( get_the_category( $post_id ) as $category ) {
-			$hierarchy = get_category_parents( $category, false, $delimiter );
+			$hierarchy = get_category_parents( $category->term_id, false, $delimiter );
 			$hierarchy = rtrim( $hierarchy, '/' );
-			array_push( $tags, $hierarchy );
+			$tags[]    = $hierarchy;
 		}
 		// take last element in the hierarchy, a string representing the full parent->child tree,
 		// and split it into individual category names.
-		$tags = explode( '/', end( $tags ) );
+		$last_tag = end( $tags );
+		if ( $last_tag ) {
+			$tags = explode( '/', $last_tag );
+		}
 		// remove uncategorized value from tags.
 		return array_diff( $tags, array( 'Uncategorized' ) );
 	}

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -648,11 +648,13 @@ class Parsely {
 	 * @return array The tags of the post represented by the post id.
 	 */
 	private function get_tags( int $post_id ): array {
-		$tags = array();
-		foreach ( wp_get_post_tags( $post_id ) as $wp_tag ) {
-			array_push( $tags, $wp_tag->name );
+		$tags      = array();
+		$post_tags = wp_get_post_tags( $post_id );
+		if ( ! is_wp_error( $post_tags ) ) {
+			foreach ( $post_tags as $wp_tag ) {
+				$tags[] = $wp_tag->name;
+			}
 		}
-
 		return $tags;
 	}
 
@@ -713,7 +715,7 @@ class Parsely {
 		// as the category value if 'use_top_level_cats' option is checked.
 		// Assign as "Uncategorized" if no value is checked for the chosen taxonomy.
 		$category = 'Uncategorized';
-		if ( ! empty( $taxonomy_dropdown_choice ) ) {
+		if ( ! empty( $taxonomy_dropdown_choice ) && ! is_wp_error( $taxonomy_dropdown_choice ) ) {
 			if ( $parsely_options['use_top_level_cats'] ) {
 				$first_term = array_shift( $taxonomy_dropdown_choice );
 				$term_name  = $this->get_top_level_term( $first_term->term_id, $first_term->taxonomy );

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -667,8 +667,10 @@ class Parsely {
 		$tags = array();
 		foreach ( get_the_category( $post_id ) as $category ) {
 			$hierarchy = get_category_parents( $category->term_id, false, $delimiter );
-			$hierarchy = rtrim( $hierarchy, '/' );
-			$tags[]    = $hierarchy;
+			if ( ! is_wp_error( $hierarchy ) ) {
+				$hierarchy = rtrim( $hierarchy, '/' );
+				$tags[]    = $hierarchy;
+			}
 		}
 		// take last element in the hierarchy, a string representing the full parent->child tree,
 		// and split it into individual category names.

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -248,7 +248,6 @@ final class OtherTest extends TestCase {
 		self::assertTrue( $result );
 	}
 
-
 	/**
 	 * Tests if keywords in Parse.ly metadata are generated correctly when categories are tags.
 	 *
@@ -258,14 +257,14 @@ final class OtherTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_categories
 	 */
 	public function test_post_with_categories_as_tags(): void {
-		self::set_options( array('cats_as_tags' => true) );
+		self::set_options( array( 'cats_as_tags' => true ) );
 		$options = self::$parsely->get_options();
 
 		// Create a single post.
 		$post_id = $this->factory->post->create();
 		$post    = get_post( $post_id );
 
-		$expected = array( "uncategorized", );
+		$expected = array( 'uncategorized' );
 		$metadata = self::$parsely->construct_parsely_metadata( $options, $post );
 
 		self::assertSame( $expected, $metadata['keywords'] );
@@ -280,7 +279,7 @@ final class OtherTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_categories
 	 */
 	public function test_post_with_categories_as_tags_without_categories(): void {
-		self::set_options( array('cats_as_tags' => true) );
+		self::set_options( array( 'cats_as_tags' => true ) );
 		$options = self::$parsely->get_options();
 
 		// Create a single post.

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -247,4 +247,51 @@ final class OtherTest extends TestCase {
 		$result = Parsely::post_has_trackable_status( $post );
 		self::assertTrue( $result );
 	}
+
+
+	/**
+	 * Tests if keywords in Parse.ly metadata are generated correctly when categories are tags.
+	 *
+	 * @since 3.0.3
+	 *
+	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @uses \Parsely\Parsely::get_categories
+	 */
+	public function test_post_with_categories_as_tags(): void {
+		self::set_options( array('cats_as_tags' => true) );
+		$options = self::$parsely->get_options();
+
+		// Create a single post.
+		$post_id = $this->factory->post->create();
+		$post    = get_post( $post_id );
+
+		$expected = array( "uncategorized", );
+		$metadata = self::$parsely->construct_parsely_metadata( $options, $post );
+
+		self::assertSame( $expected, $metadata['keywords'] );
+	}
+
+	/**
+	 * Tests if keywords in Parse.ly metadata are generated correctly when categories are tags and the post has no categories.
+	 *
+	 * @since 3.0.3
+	 *
+	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @uses \Parsely\Parsely::get_categories
+	 */
+	public function test_post_with_categories_as_tags_without_categories(): void {
+		self::set_options( array('cats_as_tags' => true) );
+		$options = self::$parsely->get_options();
+
+		// Create a single post.
+		$post_id = $this->factory->post->create();
+		$post    = get_post( $post_id );
+
+		wp_remove_object_terms( $post_id, 'uncategorized', 'category' );
+
+		$expected = array();
+		$metadata = self::$parsely->construct_parsely_metadata( $options, $post );
+
+		self::assertSame( $expected, $metadata['keywords'] );
+	}
 }

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://www.parse.ly/help/integration/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code to your WordPress blog.
- * Version:           3.0.2
+ * Version:           3.0.3
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -39,7 +39,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.0.2';
+const PARSELY_VERSION = '3.0.3';
 const PARSELY_FILE    = __FILE__;
 
 require __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
## Description

When a site had the plugin configured with the categories as tags option, the plugin would fail if that post wouldn't have categories. This was because we were calling `end()` of an empty array.

This PR adds a check to prevent that from failing plus two integration tests to prevent this regression from happening again. It is also addressing some other type issues in which a `WP_Error` might be returned and passed into a function that would not accept it.

## Motivation and Context

Closes #587

## How Has This Been Tested?

Integration tests.