### PR TITLE
Adding PHPStan to perform static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"squizlabs/php_codesniffer": "^3.5",
 		"wp-coding-standards/wpcs": "^2.3.0",
 		"yoast/wp-test-utils": "^1",
-		"phpstan/phpstan": "^1.3",
+		"phpstan/phpstan": "^1.4",
 		"phpstan/extension-installer": "^1.1",
 		"phpstan/phpstan-strict-rules": "^1.1",
 		"szepeviktor/phpstan-wordpress": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
 			"@php ./vendor/bin/phpunit --no-coverage --order-by=random"
 		],
 	   	"static-analysis": [
-		  "@php ./vendor/bin/phpstan analyze src views wp-parsely.php uninstall.php -l 9 --memory-limit 536870912"
+		  "@php ./vendor/bin/phpstan analyze --memory-limit 536870912"
 		],
 		"test-ms": [
 			"@putenv WP_MULTISITE=1",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
 		"yoast/wp-test-utils": "^1",
 		"phpstan/phpstan": "^1.3",
 		"phpstan/extension-installer": "^1.1",
+		"phpstan/phpstan-strict-rules": "^1.1",
 		"szepeviktor/phpstan-wordpress": "^1.0"
 	},
 	"config": {

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,16 @@
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"squizlabs/php_codesniffer": "^3.5",
 		"wp-coding-standards/wpcs": "^2.3.0",
-		"yoast/wp-test-utils": "^1"
+		"yoast/wp-test-utils": "^1",
+		"phpstan/phpstan": "^1.3",
+		"phpstan/extension-installer": "^1.1",
+		"szepeviktor/phpstan-wordpress": "^1.0"
 	},
 	"config": {
 		"allow-plugins": {
 			"composer/installers": true,
-			"dealerdirect/phpcodesniffer-composer-installer": true
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"phpstan/extension-installer": true
 		}
 	},
 	"autoload": {
@@ -74,6 +78,9 @@
 		],
 		"test": [
 			"@php ./vendor/bin/phpunit --no-coverage --order-by=random"
+		],
+	   	"static-analysis": [
+		  "@php ./vendor/bin/phpstan analyze src views wp-parsely.php uninstall.php -l 9 --memory-limit 536870912"
 		],
 		"test-ms": [
 			"@putenv WP_MULTISITE=1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,5 @@ parameters:
   paths:
     - src/
     - views/
-    - tests/
     - wp-parsely.php
     - uninstall.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,7 @@ parameters:
     - views/
     - wp-parsely.php
     - uninstall.php
+  inferPrivatePropertyTypeFromConstructor: true
+  ignoreErrors:
+    # Uses func_get_args()
+    - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+parameters:
+  level: 9
+  paths:
+    - src/
+    - views/
+    - tests/
+    - wp-parsely.php
+    - uninstall.php


### PR DESCRIPTION
## Description

We are enforcing strict type checks since version 3.0 of the plugin. That gives us an opportunity to run a static code analyzer to improve the quality and stability of our code.

This PR adds PHPStan (plus a WordPress compatibility PHPStan extension) for that purpose. We are adding the analyzer as a composer command, and running it to its highest level (9) so it can detect all issues. We have plenty of errors right now, so the command is purely informative so we can bring that number down gradually. 

## Motivation and Context

Improve stability of the plugin and prevent execution errors.

## How Has This Been Tested?

Run the following commands locally:

```
composer install
composer static-analysis
```