### PR TITLE
Fix fatal TypeError in get_categories function

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -646,11 +646,13 @@ class Parsely {
 	 * @return array The tags of the post represented by the post id.
 	 */
 	private function get_tags( int $post_id ): array {
-		$tags = array();
-		foreach ( wp_get_post_tags( $post_id ) as $wp_tag ) {
-			array_push( $tags, $wp_tag->name );
+		$tags      = array();
+		$post_tags = wp_get_post_tags( $post_id );
+		if ( ! is_wp_error( $post_tags ) ) {
+			foreach ( $post_tags as $wp_tag ) {
+				$tags[] = $wp_tag->name;
+			}
 		}
-
 		return $tags;
 	}
 
@@ -664,13 +666,17 @@ class Parsely {
 	private function get_categories( int $post_id, string $delimiter = '/' ): array {
 		$tags = array();
 		foreach ( get_the_category( $post_id ) as $category ) {
-			$hierarchy = get_category_parents( $category, false, $delimiter );
-			$hierarchy = rtrim( $hierarchy, '/' );
-			array_push( $tags, $hierarchy );
+			$hierarchy = get_category_parents( $category->term_id, false, $delimiter );
+			if ( ! is_wp_error( $hierarchy ) ) {
+				$tags[] = rtrim( $hierarchy, '/' );
+			}
 		}
 		// take last element in the hierarchy, a string representing the full parent->child tree,
 		// and split it into individual category names.
-		$tags = explode( '/', end( $tags ) );
+		$last_tag = end( $tags );
+		if ( $last_tag ) {
+			$tags = explode( '/', $last_tag );
+		}
 		// remove uncategorized value from tags.
 		return array_diff( $tags, array( 'Uncategorized' ) );
 	}
@@ -706,7 +712,7 @@ class Parsely {
 		// as the category value if 'use_top_level_cats' option is checked.
 		// Assign as "Uncategorized" if no value is checked for the chosen taxonomy.
 		$category = 'Uncategorized';
-		if ( ! empty( $taxonomy_dropdown_choice ) ) {
+		if ( ! empty( $taxonomy_dropdown_choice ) && ! is_wp_error( $taxonomy_dropdown_choice ) ) {
 			if ( $parsely_options['use_top_level_cats'] ) {
 				$first_term = array_shift( $taxonomy_dropdown_choice );
 				$term_name  = $this->get_top_level_term( $first_term->term_id, $first_term->taxonomy );

--- a/tests/Integration/StructuredData/SinglePostTest.php
+++ b/tests/Integration/StructuredData/SinglePostTest.php
@@ -632,6 +632,35 @@ final class SinglePostTest extends TestCase {
 	}
 
 	/**
+	 * Tests if keywords in Parse.ly metadata are generated correctly when categories are tags and the post has no categories.
+	 *
+	 * @since 3.0.3
+	 *
+	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @uses \Parsely\Parsely::get_categories
+	 */
+	public function test_post_with_categories_as_tags_without_categories(): void {
+		// Setup Parsely object.
+		$parsely         = new Parsely();
+		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+
+		// Create a single post.
+		$post_id = self::factory()->post->create();
+		$post    = get_post( $post_id );
+
+		// Set Parsely to not force https canonicals.
+		$parsely_options['cats_as_tags'] = true;
+		update_option( 'parsely', $parsely_options );
+
+		wp_remove_object_terms( $post_id, 'uncategorized', 'category' );
+
+		$expected = array();
+		$metadata = $parsely->construct_parsely_metadata( $parsely_options, $post );
+
+		self::assertSame( $expected, $metadata['keywords'] );
+	}
+
+	/**
 	 * These are the required properties for posts.
 	 *
 	 * @return string[]


### PR DESCRIPTION
## Description

When a site had the plugin configured with the categories as tags option, the plugin would fail if that post wouldn't have categories. This was because we were calling `end()` of an empty array.

This PR adds a check to prevent that from failing plus two integration tests to prevent this regression from happening again. It is also addressing some other type issues in which a `WP_Error` might be returned and passed into a function that would not accept it.

## Motivation and Context

Closes #587

## How Has This Been Tested?

Integration tests.