### PR TITLE
Release 3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -446,6 +446,7 @@ If you are using the plugin without any code-level customizations (for instance,
 - Initial version.
 - Add support for parsely-page and JavaScript on home page and published pages and posts as well as archive pages (date/author/category/tag).
 
+[3.0.4]: https://github.com/Parsely/wp-parsely/compare/3.0.3...3.0.4
 [3.0.3]: https://github.com/Parsely/wp-parsely/compare/3.0.2...3.0.3
 [3.0.2]: https://github.com/Parsely/wp-parsely/compare/3.0.1...3.0.2
 [3.0.1]: https://github.com/Parsely/wp-parsely/compare/3.0.0...3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.4] - 2022-01-17
+
+### Changed
+
+- Changed plugin loading functions from anonymous to named functions. [#595](https://github.com/Parsely/wp-parsely/pull/595)
+
 ## [3.0.3] - 2022-01-12
+
+### Fixed
 
 - [Fixed a fatal error](https://github.com/Parsely/wp-parsely/issues/587) when requesting metadata for a post without categories and `categories as tags` enabled. [#588](https://github.com/Parsely/wp-parsely/pull/588)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.0.3  
+Stable tag: 3.0.4  
 Requires at least: 5.0  
 Tested up to: 5.8  
 Requires PHP: 7.1  

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -55,9 +55,6 @@ function parsely_initialize_plugin(): void {
 	$GLOBALS['parsely'] = new Parsely();
 	$GLOBALS['parsely']->run();
 
-	$rest = new Rest( $GLOBALS['parsely'] );
-	$rest->run();
-
 	$scripts = new Scripts( $GLOBALS['parsely'] );
 	$scripts->run();
 }

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -44,43 +44,57 @@ const PARSELY_FILE    = __FILE__;
 
 require __DIR__ . '/src/class-parsely.php';
 require __DIR__ . '/src/class-scripts.php';
-add_action(
-	'plugins_loaded',
-	function(): void {
-		$GLOBALS['parsely'] = new Parsely();
-		$GLOBALS['parsely']->run();
 
-		$scripts = new Scripts( $GLOBALS['parsely'] );
-		$scripts->run();
-	}
-);
+add_action( 'plugins_loaded', __NAMESPACE__ . '\\parsely_initialize_plugin' );
+/**
+ * Register the basic classes to initialize the plugin.
+ *
+ * @return void
+ */
+function parsely_initialize_plugin(): void {
+	$GLOBALS['parsely'] = new Parsely();
+	$GLOBALS['parsely']->run();
 
-// Until auto-loading happens, we need to include this file for tests as well.
+	$rest = new Rest( $GLOBALS['parsely'] );
+	$rest->run();
+
+	$scripts = new Scripts( $GLOBALS['parsely'] );
+	$scripts->run();
+}
+
 require __DIR__ . '/src/UI/class-admin-warning.php';
 require __DIR__ . '/src/UI/class-plugins-actions.php';
 require __DIR__ . '/src/UI/class-row-actions.php';
-add_action(
-	'admin_init',
-	function(): void {
-		$admin_warning = new Admin_Warning( $GLOBALS['parsely'] );
-		$admin_warning->run();
 
-		$GLOBALS['parsely_ui_plugins_actions'] = new Plugins_Actions();
-		$GLOBALS['parsely_ui_plugins_actions']->run();
+add_action( 'admin_init', __NAMESPACE__ . '\\parsely_admin_init_register' );
+/**
+ * Register the Parse.ly wp-admin warnings, plugin actions and row actions.
+ *
+ * @return void
+ */
+function parsely_admin_init_register(): void {
+	$admin_warning = new Admin_Warning( $GLOBALS['parsely'] );
+	$admin_warning->run();
 
-		$row_actions = new Row_Actions( $GLOBALS['parsely'] );
-		$row_actions->run();
-	}
-);
+	$GLOBALS['parsely_ui_plugins_actions'] = new Plugins_Actions();
+	$GLOBALS['parsely_ui_plugins_actions']->run();
+
+	$row_actions = new Row_Actions( $GLOBALS['parsely'] );
+	$row_actions->run();
+}
 
 require __DIR__ . '/src/UI/class-settings-page.php';
-add_action(
-	'_admin_menu',
-	function(): void {
-		$settings_page = new Settings_Page( $GLOBALS['parsely'] );
-		$settings_page->run();
-	}
-);
+
+add_action( '_admin_menu', __NAMESPACE__ . '\\parsely_admin_menu_register' );
+/**
+ * Register the Parse.ly wp-admin settings page.
+ *
+ * @return void
+ */
+function parsely_admin_menu_register(): void {
+	$settings_page = new Settings_Page( $GLOBALS['parsely'] );
+	$settings_page->run();
+}
 
 require __DIR__ . '/src/UI/class-recommended-widget.php';
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://www.parse.ly/help/integration/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code to your WordPress blog.
- * Version:           3.0.3
+ * Version:           3.0.4
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -39,7 +39,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.0.3';
+const PARSELY_VERSION = '3.0.4';
 const PARSELY_FILE    = __FILE__;
 
 require __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
Releases version 3.0.4. It contains the cherry-picked changes from https://github.com/Parsely/wp-parsely/pull/595 and the updated changelog.