### PR TITLE
Recommended Widget: Remove migrate_old_fields fn

### DIFF
--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -142,31 +142,11 @@ final class Recommended_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Migrates previous display_options settings
-	 *
-	 * @param array $instance Values saved to the db.
-	 * @return void
-	 */
-	private function migrate_old_fields( array $instance ): void {
-		if ( ! empty( $instance['display_options'] ) && is_array( $instance['display_options'] ) ) {
-			if ( empty( $instance['img_src'] ) ) {
-				$instance['img_src'] = in_array( 'display_thumbnail', $instance['display_options'], true ) ? 'parsely_thumb' : 'none';
-			}
-
-			if ( empty( $instance['display_author'] ) ) {
-				$instance['display_author'] = in_array( 'display_author', $instance['display_options'], true );
-			}
-		}
-	}
-
-	/**
 	 * This is the form function
 	 *
 	 * @param array $instance Values saved to the db.
 	 */
 	public function form( $instance ): void {
-		$this->migrate_old_fields( $instance );
-
 		if ( ! $this->api_key_and_secret_are_populated() ) {
 			$settings_page_url = add_query_arg( 'page', 'parsely', get_admin_url() . 'options-general.php' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As is, the function is called without effect. The `$instance` data that's passed in is an array (confirmed manually and in the [core source](https://github.com/WordPress/wordpress-develop/blob/bdfa786d88984f96b262bbe66f166b10808de2e3/src/wp-includes/class-wp-widget.php#L139)), thus it is passed by value by default in PHP.

Since it is neither passed by reference nor returned and reassigned, operations that occur inside this function are only on a local copy of the `$instance` data and do not propagate to the remaining critical path or database.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This function was added way back in https://github.com/Parsely/wp-parsely/pull/120, but it doesn't look like it has ever worked properly. Any sites that have updated since version 1.14 have likely lost whatever functionality these parameters provided and have either set the new settings manually or accepted the new behavior.

This proposal is to remove the private function and its sole caller, but if folks feel strongly that we should see the original intention through, we could change:

https://github.com/Parsely/wp-parsely/blob/develop/src/UI/class-recommended-widget.php#L150

to:

`private function migrate_old_fields( array &$instance ): void {`

instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually mutated the local copy of `$instance` inside that function and verified the change had no effect on the remainder of the widget code's state.

## Screenshots (if appropriate)
