### PR TITLE
README.md: Change "meta data" to "metadata"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The `parsely` field contains the following fields:
  - `meta`, which is an array of metadata for the specific post, page or other object type.
  - `rendered`, which is the rendered HTML of the metadata for the post, page or other object type. This will be a JSON-LD `<script>` tag, or a set of `<meta>` tags, depending on the format selected in the plugin settings. The decoupled code can consume and use this directly, instead of building the values from the `meta` field values.
 
-The `rendered` field is a convenience field containing the HTML-formatted meta data which can be printed to a decoupled page as is.
+The `rendered` field is a convenience field containing the HTML-formatted metadata which can be printed to a decoupled page as is.
 
 This can be disabled by returning `false` from the `wp_parsely_enable_rest_rendered_support` filter.
 


### PR DESCRIPTION
## Description
The README.md was referring to "meta data" on line 87, but everywhere else in the plugin only the term "metadata" is used. So the specific occurrence was changed to "metadata".

## Motivation and Context
Keeping language consistency.