### PR TITLE
Remove Plugin Actions global variable on load

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -83,8 +83,8 @@ function parsely_admin_init_register(): void {
 	$admin_warning = new Admin_Warning( $GLOBALS['parsely'] );
 	$admin_warning->run();
 
-	$GLOBALS['parsely_ui_plugins_actions'] = new Plugins_Actions();
-	$GLOBALS['parsely_ui_plugins_actions']->run();
+	$plugins_actions = new Plugins_Actions();
+	$plugins_actions->run();
 
 	$row_actions = new Row_Actions( $GLOBALS['parsely'] );
 	$row_actions->run();


### PR DESCRIPTION
## Description

This PR gets rid of a class that was being put available globally on plugin load. This is not being used elsewhere and it shouldn't be a way to access the class. 

Given that's a simple class and that it can be extended/changed anyway by using other filters, we are removing this global variable.

## Motivation and Context

Tighten up improper uses of the plugin.

See https://github.com/Parsely/wp-parsely/issues/586

## How Has This Been Tested?

Plugin runs and loads as normal.