### PR TITLE
Adding help for local development issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,12 @@ First, you'll need to install the tests by running the install script:
 
 Then, you can use Composer to run the tests from your terminal.
 
+You might have some issues related to requiring files while running the tests locally. You shouldn't `require` any files on your tests. If you have those issues, you can fix them by running:
+
+```
+composer dump-autoload
+```
+
 To run the single-site tests:
 
 ```


### PR DESCRIPTION
## Description

Some developers were having issues while running the tests locally. Those were caused by issues with Composer autoload. We're updating our docs with a command that fixes that issue.

## Motivation and Context

Closes https://github.com/Parsely/wp-parsely/issues/586

## How Has This Been Tested?

Using the suggestion, tests work where previously there would be issues.