### PR TITLE
Fix recommended widget e2e tests for WordPress 5.9

### DIFF
--- a/tests/e2e/specs/recommended-widget.spec.js
+++ b/tests/e2e/specs/recommended-widget.spec.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import {
+	activateTheme,
 	activatePlugin,
 	loginUser,
 	visitAdminPage,
@@ -24,7 +25,7 @@ const searchForParselyWidget = async () => {
 		visible: true,
 	} );
 	await page.click( '.block-list-appender' );
-	await page.focus( '#block-editor-inserter__search-0' );
+	await page.focus( '#components-search-control-0' );
 	await page.keyboard.type( 'parse.ly recommended widget' );
 };
 
@@ -49,14 +50,22 @@ const getNonActiveWidgetText = async () => {
 
 describe( 'Recommended widget', () => {
 	beforeAll( () => {
-		page.once( 'dialog', async function( dialog ) {
+		page.on( 'dialog', async function( dialog ) {
 			await dialog.accept();
 		} );
 	} );
 
-	it( 'Widget should be available but inactive without api key and secret', async () => {
+	beforeEach( async () => {
 		await loginUser();
+		await activateTheme( 'twentytwentyone' );
 		await activatePlugin( 'wp-parsely' );
+	} );
+
+	afterEach( async () => {
+		await activateTheme( 'twentytwentytwo' );
+	} );
+
+	it( 'Widget should be available but inactive without api key and secret', async () => {
 		await changeKeysState( false, false );
 
 		await visitAdminPage( '/widgets.php', '' );
@@ -70,8 +79,6 @@ describe( 'Recommended widget', () => {
 	} );
 
 	it( 'Widget should be available but inactive without api secret', async () => {
-		await loginUser();
-		await activatePlugin( 'wp-parsely' );
 		await changeKeysState( true, false );
 
 		await visitAdminPage( '/widgets.php', '' );


### PR DESCRIPTION
## Description

After the release of WordPress 5.9 and its adoption on `wp-env`,  our e2e tests would fail due to the new default theme, 2022, would not support widgets. This PR sets the 2021 theme for the recommended widget tests.

## Motivation and Context

All pipelines would fail, even if changes weren't related.

## How Has This Been Tested?

Tests pass locally and in GitHub Actions using WordPress 5.9.