### PR TITLE
Cleaning up Scripts class

### DIFF
--- a/src/class-scripts.php
+++ b/src/class-scripts.php
@@ -41,9 +41,12 @@ class Scripts {
 	 * @return void
 	 */
 	public function run(): void {
-		add_action( 'init', array( $this, 'register_scripts' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_js_api' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_js_tracker' ) );
+		$parsely_options = $this->parsely->get_options();
+		if ( ! $this->parsely->api_key_is_missing() && ! $parsely_options['disable_javascript'] ) {
+			add_action( 'init', array( $this, 'register_scripts' ) );
+			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_js_api' ) );
+			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_js_tracker' ) );
+		}
 	}
 
 	/**
@@ -55,13 +58,7 @@ class Scripts {
 	 * @return void
 	 */
 	public function register_scripts(): void {
-		$parsely_options = $this->parsely->get_options();
-
-		if ( $this->parsely->api_key_is_missing() ) {
-			return;
-		}
-
-		$tracker_url = 'https://cdn.parsely.com/keys/' . $parsely_options['apikey'] . '/p.js';
+		$tracker_url = 'https://cdn.parsely.com/keys/' . $this->parsely->get_api_key() . '/p.js';
 		$tracker_url = esc_url( $tracker_url );
 
 		wp_register_script(
@@ -85,7 +82,7 @@ class Scripts {
 			'wp-parsely-api',
 			'wpParsely', // This globally-scoped object holds variables used to interact with the API.
 			array(
-				'apikey' => $parsely_options['apikey'],
+				'apikey' => $this->parsely->get_api_key(),
 			)
 		);
 	}
@@ -100,9 +97,6 @@ class Scripts {
 	 */
 	public function enqueue_js_tracker(): void {
 		$parsely_options = $this->parsely->get_options();
-		if ( $this->parsely->api_key_is_missing() || $parsely_options['disable_javascript'] ) {
-			return;
-		}
 
 		global $post;
 		$display = true;
@@ -129,7 +123,7 @@ class Scripts {
 			return;
 		}
 
-		if ( ! has_filter( 'script_loader_tag', array( $this, 'script_loader_tag' ) ) ) {
+		if ( false === has_filter( 'script_loader_tag', array( $this, 'script_loader_tag' ) ) ) {
 			add_filter( 'script_loader_tag', array( $this, 'script_loader_tag' ), 10, 3 );
 		}
 
@@ -152,7 +146,7 @@ class Scripts {
 			return;
 		}
 
-		if ( ! has_filter( 'script_loader_tag', array( $this, 'script_loader_tag' ) ) ) {
+		if ( false === has_filter( 'script_loader_tag', array( $this, 'script_loader_tag' ) ) ) {
 			add_filter( 'script_loader_tag', array( $this, 'script_loader_tag' ), 10, 3 );
 		}
 

--- a/src/class-scripts.php
+++ b/src/class-scripts.php
@@ -42,7 +42,7 @@ class Scripts {
 	 */
 	public function run(): void {
 		$parsely_options = $this->parsely->get_options();
-		if ( ! $this->parsely->api_key_is_missing() && ! $parsely_options['disable_javascript'] ) {
+		if ( $this->parsely->api_key_is_set() && false !== $parsely_options['disable_javascript'] ) {
 			add_action( 'init', array( $this, 'register_scripts' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_js_api' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_js_tracker' ) );

--- a/src/class-scripts.php
+++ b/src/class-scripts.php
@@ -42,7 +42,7 @@ class Scripts {
 	 */
 	public function run(): void {
 		$parsely_options = $this->parsely->get_options();
-		if ( $this->parsely->api_key_is_set() && false !== $parsely_options['disable_javascript'] ) {
+		if ( $this->parsely->api_key_is_set() && true !== $parsely_options['disable_javascript'] ) {
 			add_action( 'init', array( $this, 'register_scripts' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_js_api' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_js_tracker' ) );

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -42,6 +42,59 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
+	 * Test whether the run method adds the register and enqueue actions.
+	 *
+	 * @covers \Parsely\Scripts::run
+	 *
+	 * @group scripts
+	 */
+	public function test_run_adds_actions(): void {
+		self::assertFalse( has_action( 'init', array( self::$scripts, 'register_scripts' ) ) );
+		self::assertFalse( has_action( 'wp_enqueue_scripts', array( self::$scripts, 'enqueue_js_api' ) ) );
+		self::assertFalse( has_action( 'wp_enqueue_scripts', array( self::$scripts, 'enqueue_js_tracker' ) ) );
+
+		self::$scripts->run();
+
+		self::assertSame( 10, has_action( 'init', array( self::$scripts, 'register_scripts' ) ) );
+		self::assertSame( 10, has_action( 'wp_enqueue_scripts', array( self::$scripts, 'enqueue_js_api' ) ) );
+		self::assertSame( 10, has_action( 'wp_enqueue_scripts', array( self::$scripts, 'enqueue_js_tracker' ) ) );
+	}
+
+	/**
+	 * Test whether the run method adds the register and enqueue actions when no API key is set.
+	 *
+	 * @covers \Parsely\Scripts::run
+	 *
+	 * @group scripts
+	 */
+	public function test_run_not_adds_actions_no_api_key(): void {
+		TestCase::set_options( array( 'apikey' => null ) );
+
+		self::$scripts->run();
+
+		self::assertFalse( has_action( 'init', array( self::$scripts, 'register_scripts' ) ) );
+		self::assertFalse( has_action( 'wp_enqueue_scripts', array( self::$scripts, 'enqueue_js_api' ) ) );
+		self::assertFalse( has_action( 'wp_enqueue_scripts', array( self::$scripts, 'enqueue_js_tracker' ) ) );
+	}
+
+	/**
+	 * Test whether the run method adds the register and enqueue actions when the disable javascript option is set.
+	 *
+	 * @covers \Parsely\Scripts::run
+	 *
+	 * @group scripts
+	 */
+	public function test_run_not_adds_actions_disable_javascript(): void {
+		TestCase::set_options( array( 'disable_javascript' => true ) );
+
+		self::$scripts->run();
+
+		self::assertFalse( has_action( 'init', array( self::$scripts, 'register_scripts' ) ) );
+		self::assertFalse( has_action( 'wp_enqueue_scripts', array( self::$scripts, 'enqueue_js_api' ) ) );
+		self::assertFalse( has_action( 'wp_enqueue_scripts', array( self::$scripts, 'enqueue_js_tracker' ) ) );
+	}
+
+	/**
 	 * Test script registration functionality.
 	 *
 	 * @covers \Parsely\Scripts::register_scripts
@@ -104,35 +157,6 @@ final class ScriptsTest extends TestCase {
 		$this->assert_script_statuses(
 			'wp-parsely-tracker',
 			array( 'registered', 'enqueued' )
-		);
-	}
-
-	/**
-	 * Test the tracker script enqueue with the disable_javascript option set
-	 * to true.
-	 *
-	 * @covers \Parsely\Scripts::enqueue_js_tracker
-	 * @uses \Parsely\Parsely::api_key_is_missing
-	 * @uses \Parsely\Parsely::api_key_is_set
-	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::post_has_trackable_status
-	 * @uses \Parsely\Parsely::update_metadata_endpoint
-	 * @uses \Parsely\Scripts::register_scripts
-	 * @uses \Parsely\Scripts::script_loader_tag
-	 * @group scripts
-	 */
-	public function test_enqueue_js_tracker_with_javascript_option_disabled(): void {
-		TestCase::set_options( array( 'disable_javascript' => true ) );
-
-		$this->go_to_new_post();
-		self::$scripts->register_scripts();
-		self::$scripts->enqueue_js_tracker();
-
-		// Confirm that tracker script is registered but not enqueued.
-		$this->assert_script_statuses(
-			'wp-parsely-tracker',
-			array( 'registered' ),
-			array( 'enqueued' )
 		);
 	}
 


### PR DESCRIPTION
## Description

This PR contains preparatory work for opening the scripts to third parties. We clean up some PHPStan warnings and we avoid doing the checks for an API key more than once. Tests are updated accordingly.

## Motivation and Context

See #640 

## How Has This Been Tested?

Scripts get inserted normally and tests pass.