### PR TITLE
Adding additional check for e2e tests

### DIFF
--- a/tests/e2e/specs/front-end-code.spec.js
+++ b/tests/e2e/specs/front-end-code.spec.js
@@ -6,11 +6,19 @@ import {
 	createURL,
 	loginUser,
 } from '@wordpress/e2e-test-utils';
+import * as fs from 'fs';
 
 /**
  * Internal dependencies
  */
 import { changeKeysState, PLUGIN_VERSION } from '../utils';
+
+const getAssetVersion = () => {
+	const data = fs.readFileSync( 'build/init-api.asset.php', { encoding: 'utf8', flag: 'r' } );
+	const re = new RegExp( "\'version\' => \'(.*)\'" );
+	const r = data.match( re );
+	return r[ 1 ];
+};
 
 describe( 'Front end code insertion', () => {
 	it( 'Should inject loading script homepage', async () => {
@@ -42,6 +50,6 @@ describe( 'Front end code insertion', () => {
 		expect( content ).toContain( `<script data-parsely-site="e2etest.example.com" src="https://cdn.parsely.com/keys/e2etest.example.com/p.js?ver=${ PLUGIN_VERSION }" id="parsely-cfg"></script>` );
 		expect( content ).toContain( '<script id="wp-parsely-api-js-extra">' );
 		expect( content ).toContain( 'var wpParsely = {"apikey":"e2etest.example.com"};' );
-		expect( content ).toContain( '<script src="http://localhost:8889/wp-content/plugins/wp-parsely/build/init-api.js?ver=f68f5afd116c18f188eb32c9cd990d80" id="wp-parsely-api-js"></script>' );
+		expect( content ).toContain( `<script src="http://localhost:8889/wp-content/plugins/wp-parsely/build/init-api.js?ver=${ getAssetVersion() }" id="wp-parsely-api-js"></script>` );
 	} );
 } );

--- a/tests/e2e/specs/front-end-code.spec.js
+++ b/tests/e2e/specs/front-end-code.spec.js
@@ -26,6 +26,7 @@ describe( 'Front end code insertion', () => {
 		expect( content ).toContain( `<script data-parsely-site="e2etest.example.com" src="https://cdn.parsely.com/keys/e2etest.example.com/p.js?ver=${ PLUGIN_VERSION }" id="parsely-cfg"></script>` );
 		expect( content ).not.toContain( '<script id="wp-parsely-api-js-extra">' );
 		expect( content ).not.toContain( 'var wpParsely' );
+		expect( content ).not.toContain( 'init-api.js' );
 	} );
 
 	it( 'Should inject loading script homepage and extra variable', async () => {
@@ -41,5 +42,6 @@ describe( 'Front end code insertion', () => {
 		expect( content ).toContain( `<script data-parsely-site="e2etest.example.com" src="https://cdn.parsely.com/keys/e2etest.example.com/p.js?ver=${ PLUGIN_VERSION }" id="parsely-cfg"></script>` );
 		expect( content ).toContain( '<script id="wp-parsely-api-js-extra">' );
 		expect( content ).toContain( 'var wpParsely = {"apikey":"e2etest.example.com"};' );
+		expect( content ).toContain( '<script src="http://localhost:8889/wp-content/plugins/wp-parsely/build/init-api.js?ver=f68f5afd116c18f188eb32c9cd990d80" id="wp-parsely-api-js"></script>' );
 	} );
 } );


### PR DESCRIPTION
## Description

This PR adds some checks on the end to end tests that verify the existence of the `init-api.js` file on the front end.

## Motivation and Context

Cover more functionality with end to end tests.

## How Has This Been Tested?

Tests pass against `develop` locally and on GitHub.