### PR TITLE
Correct "since" annotations to 3.1.0

### DIFF
--- a/src/UI/class-admin-bar.php
+++ b/src/UI/class-admin-bar.php
@@ -3,7 +3,7 @@
  * Parsely tweaks to WordPress admin bar
  *
  * @package Parsely
- * @since 3.2.0
+ * @since 3.1.0
  */
 
 declare(strict_types=1);
@@ -17,7 +17,7 @@ use Parsely\Dashboard_Link;
 /**
  * Render Parse.ly related buttons in the WordPress administrator top bar.
  *
- * @since 3.2.0
+ * @since 3.1.0
  */
 final class Admin_Bar {
 	/**
@@ -39,7 +39,7 @@ final class Admin_Bar {
 	/**
 	 * Register admin bar buttons.
 	 *
-	 * @since 3.2.0
+	 * @since 3.1.0
 	 *
 	 * @return void
 	 */

--- a/src/class-dashboard-link.php
+++ b/src/class-dashboard-link.php
@@ -3,7 +3,7 @@
  * Parse.ly Dashboard Link utility class.
  *
  * @package Parsely
- * @since 3.2.0
+ * @since 3.1.0
  */
 
 declare(strict_types=1);
@@ -15,14 +15,14 @@ use WP_Post;
 /**
  * Utility methods to build and generate dashboard links.
  *
- * @since 3.2.0
+ * @since 3.1.0
  */
 class Dashboard_Link {
 	/**
 	 * Generate the Parse.ly dashboard URL for the post.
 	 *
 	 * @since 2.6.0
-	 * @since 3.2.0 Moved to class-dashboard-link.php. Added source parameter.
+	 * @since 3.1.0 Moved to class-dashboard-link.php. Added source parameter.
 	 *
 	 * @param WP_Post $post   Which post object or ID to check.
 	 * @param string  $apikey API key or empty string.
@@ -47,7 +47,7 @@ class Dashboard_Link {
 	 * Determine whether Parse.ly dashboard link should be shown or not.
 	 *
 	 * @since 2.6.0
-	 * @since 3.2.0 Moved to class-utils.php. Renamed from `cannot_show_parsely_link`.
+	 * @since 3.1.0 Moved to class-utils.php. Renamed from `cannot_show_parsely_link`.
 	 *
 	 * @param WP_Post $post    Which post object or ID to check.
 	 * @param Parsely $parsely Parsely object.

--- a/tests/Integration/DashboardLinkTest.php
+++ b/tests/Integration/DashboardLinkTest.php
@@ -52,7 +52,7 @@ final class DashboardLinkTest extends TestCase {
 	 * Test if logic for showing Parse.ly row action accounts for actions not being an array.
 	 *
 	 * @since 2.6.0
-	 * @since 3.2.0 Moved to `DashboardLinkTest.php`
+	 * @since 3.1.0 Moved to `DashboardLinkTest.php`
 	 *
 	 * @covers \Parsely\UI\Row_Actions::cannot_show_parsely_link
 	 * @uses \Parsely\Parsely::api_key_is_set
@@ -73,7 +73,7 @@ final class DashboardLinkTest extends TestCase {
 	 * Test if logic for showing Parse.ly row action accounts for post having trackable status.
 	 *
 	 * @since 2.6.0
-	 * @since 3.2.0 Moved to `DashboardLinkTest.php`
+	 * @since 3.1.0 Moved to `DashboardLinkTest.php`
 	 *
 	 * @covers \Parsely\UI\Row_Actions::cannot_show_parsely_link
 	 * @uses \Parsely\Parsely::api_key_is_set
@@ -95,7 +95,7 @@ final class DashboardLinkTest extends TestCase {
 	 * Test if logic for showing Parse.ly row action accounts for post not having a viewable type.
 	 *
 	 * @since 2.6.0
-	 * @since 3.2.0 Moved to `DashboardLinkTest.php`
+	 * @since 3.1.0 Moved to `DashboardLinkTest.php`
 	 *
 	 * @covers \Parsely\UI\Row_Actions::cannot_show_parsely_link
 	 * @uses \Parsely\Parsely::api_key_is_set
@@ -117,7 +117,7 @@ final class DashboardLinkTest extends TestCase {
 	 * Test if logic for showing Parse.ly row action accounts for API key option being saved or not.
 	 *
 	 * @since 2.6.0
-	 * @since 3.2.0 Moved to `DashboardLinkTest.php`
+	 * @since 3.1.0 Moved to `DashboardLinkTest.php`
 	 *
 	 * @covers \Parsely\UI\Row_Actions::cannot_show_parsely_link
 	 * @uses \Parsely\Parsely::api_key_is_set

--- a/tests/Integration/UI/AdminBarTest.php
+++ b/tests/Integration/UI/AdminBarTest.php
@@ -16,7 +16,7 @@ use Parsely\UI\Admin_Bar;
 /**
  * Admin bar modifications tests.
  *
- * @since 3.2.0
+ * @since 3.1.0
  */
 final class AdminBarTest extends TestCase {
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

These annotations were released in version 3.1.0, but erroneously cite version 3.2.0 (which is not yet released).

To make this PR, I did:

* `git checkout 3.1.0`
* `git checkout -b fix/since-annotations-3.1.0`
* search replace for `@since 3.2.0` in my IDE
* added and committed the changes
* `git rebase origin/develop`
* `git push origin fix/since-annotations-3.1.0`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Keeping our inline documentation as correct as possbile.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)
