### PR TITLE
Improve reliability of E2E tests

### DIFF
--- a/tests/e2e/specs/activation-flow.spec.js
+++ b/tests/e2e/specs/activation-flow.spec.js
@@ -63,6 +63,9 @@ describe( 'Activation flow', () => {
 	it( 'Should display all admin sections', async () => {
 		await visitAdminPage( '/options-general.php', '?page=parsely' );
 
+		// Set initial state
+		await selectScreenOptions( { recrawl: false, advanced: false } );
+
 		await page.waitForXPath( '//h2[contains(text(), "Basic Settings")]' );
 		expect( await checkH2DoesNotExist( 'Requires Recrawl Settings' ) ).toBe( true );
 		expect( await checkH2DoesNotExist( 'Advanced Settings' ) ).toBe( true );

--- a/tests/e2e/specs/activation-flow.spec.js
+++ b/tests/e2e/specs/activation-flow.spec.js
@@ -18,16 +18,16 @@ const selectScreenOptions = async ( sections ) => {
 
 	await page.waitForSelector( '#requires-recrawl' );
 
-	if ( sections.recrawl ) {
-		await page.evaluate( () => {
-			document.querySelector( '#requires-recrawl' ).parentElement.click();
-		} );
+	const recrawlInput = await page.$( '#requires-recrawl' );
+	const isRecrawlChecked = await ( await recrawlInput.getProperty( 'checked' ) ).jsonValue();
+	if ( ( sections.recrawl && ! isRecrawlChecked ) || ( ! sections.recrawl && isRecrawlChecked ) ) {
+		await recrawlInput.click();
 	}
 
-	if ( sections.advanced ) {
-		await page.evaluate( () => {
-			document.querySelector( '#advanced' ).parentElement.click();
-		} );
+	const advancedInput = await page.$( '#advanced' );
+	const isAdvancedChecked = await ( await advancedInput.getProperty( 'checked' ) ).jsonValue();
+	if ( ( sections.advanced && ! isAdvancedChecked ) || ( ! sections.advanced && isAdvancedChecked ) ) {
+		await advancedInput.click();
 	}
 
 	const [ input ] = await page.$x( '//p[contains(@class, \'submit\')]//input[contains(@name, \'screen-options-apply\')]' );
@@ -73,13 +73,13 @@ describe( 'Activation flow', () => {
 		await page.waitForXPath( '//h2[contains(text(), "Requires Recrawl Settings")]' );
 		await page.waitForXPath( '//h2[contains(text(), "Advanced Settings")]' );
 
-		await selectScreenOptions( { recrawl: false, advanced: true } );
+		await selectScreenOptions( { recrawl: true, advanced: false } );
 
 		await page.waitForXPath( '//h2[contains(text(), "Basic Settings")]' );
 		await page.waitForXPath( '//h2[contains(text(), "Requires Recrawl Settings")]' );
 		expect( await checkH2DoesNotExist( 'Advanced Settings' ) ).toBe( true );
 
 		// Reverting to initial state
-		await selectScreenOptions( { recrawl: true, advanced: false } );
+		await selectScreenOptions( { recrawl: false, advanced: false } );
 	} );
 } );

--- a/tests/e2e/specs/activation-flow.spec.js
+++ b/tests/e2e/specs/activation-flow.spec.js
@@ -12,6 +12,12 @@ import {
  */
 import { activatePluginApiKey, checkH2DoesNotExist, deactivatePluginApiKey, waitForWpAdmin } from '../utils';
 
+/**
+ * Set the visible sections in the array to their values `true` for visible and `false` for not visible.
+ *
+ * @param {Object} sections Dictionary containing the desired sections to change. Currently, `recrawl` and `advanced`.
+ * @return {Promise<void>}
+ */
 const selectScreenOptions = async ( sections ) => {
 	const [ button ] = await page.$x( '//button[@id="show-settings-link"]' );
 	await button.click();

--- a/tests/e2e/specs/front-end-code.spec.js
+++ b/tests/e2e/specs/front-end-code.spec.js
@@ -6,11 +6,19 @@ import {
 	createURL,
 	loginUser,
 } from '@wordpress/e2e-test-utils';
+import * as fs from 'fs';
 
 /**
  * Internal dependencies
  */
 import { changeKeysState, PLUGIN_VERSION } from '../utils';
+
+const getAssetVersion = () => {
+	const data = fs.readFileSync( 'build/init-api.asset.php', { encoding: 'utf8', flag: 'r' } );
+	const re = new RegExp( "\'version\' => \'(.*)\'" );
+	const r = data.match( re );
+	return r[ 1 ];
+};
 
 describe( 'Front end code insertion', () => {
 	it( 'Should inject loading script homepage', async () => {
@@ -42,6 +50,6 @@ describe( 'Front end code insertion', () => {
 		expect( content ).toContain( `<script data-parsely-site="e2etest.example.com" src="https://cdn.parsely.com/keys/e2etest.example.com/p.js?ver=${ PLUGIN_VERSION }" id="parsely-cfg"></script>` );
 		expect( content ).toContain( '<script id="wp-parsely-api-js-extra">' );
 		expect( content ).toContain( 'var wpParsely = {"apikey":"e2etest.example.com"};' );
-		expect( content ).toContain( '<script src="http://localhost:8889/wp-content/plugins/wp-parsely/build/init-api.js?ver=f68f5afd116c18f188eb32c9cd990d80" id="wp-parsely-api-js"></script>' );
+		expect( content ).toContain( `<script src="http://localhost:8889/wp-content/plugins/wp-parsely/build/init-api.js?ver=${ getAssetVersion() }" id="wp-parsely-api-js"></script>` );
 	} );
 } );

--- a/tests/e2e/specs/front-end-code.spec.js
+++ b/tests/e2e/specs/front-end-code.spec.js
@@ -17,6 +17,7 @@ const getAssetVersion = () => {
 	const data = fs.readFileSync( 'build/init-api.asset.php', { encoding: 'utf8', flag: 'r' } );
 	const re = new RegExp( "\'version\' => \'(.*)\'" );
 	const r = data.match( re );
+	expect( r[ 1 ].length ).toBeGreaterThanOrEqual( 1 );
 	return r[ 1 ];
 };
 

--- a/tests/e2e/specs/front-end-code.spec.js
+++ b/tests/e2e/specs/front-end-code.spec.js
@@ -26,6 +26,7 @@ describe( 'Front end code insertion', () => {
 		expect( content ).toContain( `<script data-parsely-site="e2etest.example.com" src="https://cdn.parsely.com/keys/e2etest.example.com/p.js?ver=${ PLUGIN_VERSION }" id="parsely-cfg"></script>` );
 		expect( content ).not.toContain( '<script id="wp-parsely-api-js-extra">' );
 		expect( content ).not.toContain( 'var wpParsely' );
+		expect( content ).not.toContain( 'init-api.js' );
 	} );
 
 	it( 'Should inject loading script homepage and extra variable', async () => {
@@ -41,5 +42,6 @@ describe( 'Front end code insertion', () => {
 		expect( content ).toContain( `<script data-parsely-site="e2etest.example.com" src="https://cdn.parsely.com/keys/e2etest.example.com/p.js?ver=${ PLUGIN_VERSION }" id="parsely-cfg"></script>` );
 		expect( content ).toContain( '<script id="wp-parsely-api-js-extra">' );
 		expect( content ).toContain( 'var wpParsely = {"apikey":"e2etest.example.com"};' );
+		expect( content ).toContain( '<script src="http://localhost:8889/wp-content/plugins/wp-parsely/build/init-api.js?ver=f68f5afd116c18f188eb32c9cd990d80" id="wp-parsely-api-js"></script>' );
 	} );
 } );


### PR DESCRIPTION
## Description

The screen options test might be left on a broken state, hence always failing to pass the tests. This was caused by the fact that the screen options was always clicked, instead of checking the value that the checkbox contains. Hence, if the script clicks and the value was true, the result would be false (which seems counterintuitive).

This PR makes the helper function a bit smarter and only clicks the input in case it's needed.

## Motivation and Context

Improve reliability of the E2E tests.

## How Has This Been Tested?

Tests pass consistently locally and on GitHub.