### PR TITLE
Expose the wp-env script as-is in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
 		"test:unit": "wp-scripts test-unit-js",
 		"test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache",
 		"test:unit:help": "wp-scripts test-unit-js --help",
-		"test:unit:watch": "wp-scripts test-unit-js --watch"
+		"test:unit:watch": "wp-scripts test-unit-js --watch",
+		"wp-env": "wp-env"
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Expose a script wrapper called `wp-env` which just points to the locally installed npm package.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We already have `dev:*` scripts which are wrappers, this just makes it easier to access the entirety of what `wp-env` offers without having to call to `./node_modules/.bin/wp-env` to do it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

e.g.
`npm run wp-env install-path` 

## Screenshots (if appropriate)
