### PR TITLE
Fix recommended widget on WordPress 5.9

### DIFF
--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -45,18 +45,18 @@ final class Recommended_Widget extends WP_Widget {
 	 *
 	 * @since 2.5.0
 	 *
-	 * @param string $api_key          Publisher Site ID (API key).
-	 * @param int    $published_within Publication filter start date; see https://www.parse.ly/help/api/time for
+	 * @param string      $api_key          Publisher Site ID (API key).
+	 * @param int|null    $published_within Publication filter start date; see https://www.parse.ly/help/api/time for
 	 *                                 formatting details. No restriction by default.
-	 * @param string $sort             What to sort the results by. There are currently 2 valid options: `score`, which
+	 * @param string|null $sort             What to sort the results by. There are currently 2 valid options: `score`, which
 	 *                                 will sort articles by overall relevance and `pub_date` which will sort results by
 	 *                                 their publication date. The default is `score`.
-	 * @param string $boost            Available for sort=score only. Sub-sort value to re-rank relevant posts that
+	 * @param string|null $boost            Available for sort=score only. Sub-sort value to re-rank relevant posts that
 	 *                                 received high e.g. views; default is undefined.
-	 * @param int    $return_limit     Number of records to retrieve; defaults to "10".
+	 * @param int         $return_limit     Number of records to retrieve; defaults to "10".
 	 * @return string API URL.
 	 */
-	private function get_api_url( string $api_key, int $published_within, string $sort, string $boost, int $return_limit ): string {
+	private function get_api_url( string $api_key, ?int $published_within, ?string $sort, ?string $boost, int $return_limit ): string {
 		$related_api_endpoint = 'https://api.parsely.com/v2/related';
 
 		$query_args = array(
@@ -69,7 +69,7 @@ final class Recommended_Widget extends WP_Widget {
 			$query_args['boost'] = $boost;
 		}
 
-		if ( 0 !== $published_within ) {
+		if ( null !== $published_within && 0 !== $published_within ) {
 			$query_args['pub_date_start'] = $published_within . 'd';
 		}
 


### PR DESCRIPTION
## Description

The recommended widget would not work in wp-admin for WordPress 5.9 and newer installations. This was being caused by some parameters being passed as null. Our current code is completely fine with those being null, so this PR weakens the type definitions to improve compatibility.

This PR is targeted to `develop` but it will be cherry-picked to `trunk` to release 3.1.1.

## Motivation and Context

New users wouldn't be able to add the recommended widget.

## How Has This Been Tested?

The recommended widget can now be added to sites.

## Screenshots (if appropriate)

Previous error:

<img width="921" alt="Screen Shot 2022-02-09 at 10 02 29 AM" src="https://user-images.githubusercontent.com/7188409/153161460-c8f2bc22-301f-4de5-97fc-2c0051d3290e.png">