### PR TITLE
Not installing wp-env globally on GitHub Actions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,11 +32,10 @@ jobs:
       - name: Npm install
         run: |
           npm ci
-          npm install -g @wordpress/env
 
       - name: Install WordPress
         run: |
-          wp-env start
+          npm run dev:start
 
       - name: Running the tests
         run: |


### PR DESCRIPTION
## Description

This PR removes a redundant install of wp-env on the e2e tests pipeline.

## Motivation and Context

Fix failing E2E tests.