### PR TITLE
CI: Update e2e invocations

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Running the tests
         run: |
           npm run test:e2e -- --listTests > ~/.jest-e2e-tests
-          npm run test:e2e -- --cacheDirectory="$HOME/.jest-cache-${{ hashFiles('package-lock.json') }}"
+          npm run test:e2e -- --cacheDirectory="$HOME/.jest-cache-${{ github.sha }}"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Running the tests
         run: |
           npm run test:e2e -- --listTests > ~/.jest-e2e-tests
-          npm run test:e2e -- --cacheDirectory="$HOME/.jest-cache"
+          npm run test:e2e -- --cacheDirectory="$HOME/.jest-cache-${{ hashFiles('package-lock.json') }}"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -39,5 +39,5 @@ jobs:
 
       - name: Running the tests
         run: |
-          $( npm bin )/wp-scripts test-e2e --listTests > ~/.jest-e2e-tests
-          $( npm bin )/wp-scripts test-e2e --cacheDirectory="$HOME/.jest-cache"
+          npm run test:e2e -- --listTests > ~/.jest-e2e-tests
+          npm run test:e2e -- --cacheDirectory="$HOME/.jest-cache"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
       - name: Use desired version of NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
         with:
           node-version: 16
           cache: npm


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* Vary the jest cache for the puppeteer run on a hash of the package-lock.json file
* Use our npm scripts to kick off the e2e runs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We've been seeing intermittent e2e test failures. The theory behind this change is that concurrent runs were polluting the jest cache leading to an inconsistent state.  This seeks to avoid such and make the tests more reliable by using a separate cache for separate javascript package environments.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)
