### PR TITLE
Improving e2e reliability

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,11 +33,14 @@ jobs:
         run: |
           npm ci
 
-      - name: Install WordPress
+      - name: Start up WordPress environment
         run: |
           npm run dev:start
 
       - name: Running the tests
         run: |
-          $( npm bin )/wp-scripts test-e2e --listTests > ~/.jest-e2e-tests
-          $( npm bin )/wp-scripts test-e2e --cacheDirectory="$HOME/.jest-cache"
+          npm run test:e2e
+
+      - name: Stop WordPress environment
+        run: |
+          npm run dev:stop

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -39,7 +39,8 @@ jobs:
 
       - name: Running the tests
         run: |
-          npm run test:e2e
+          npm run test:e2e -- --listTests > ~/.jest-e2e-tests
+          npm run test:e2e -- --cacheDirectory="$HOME/.jest-cache"
 
       - name: Stop WordPress environment
         run: |

--- a/tests/e2e/specs/activation-flow.spec.js
+++ b/tests/e2e/specs/activation-flow.spec.js
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	activatePlugin,
-	loginUser,
-	visitAdminPage,
-} from '@wordpress/e2e-test-utils';
+import { visitAdminPage } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
@@ -15,14 +11,11 @@ import {
 	checkH2DoesNotExist,
 	deactivatePluginApiKey,
 	waitForWpAdmin,
-	selectScreenOptions,
+	selectScreenOptions, startUpTest,
 } from '../utils';
 
 describe( 'Activation flow', () => {
-	beforeEach( async () => {
-		await loginUser();
-		await activatePlugin( 'wp-parsely' );
-	} );
+	beforeAll( startUpTest );
 
 	it( 'Should progress as intended', async () => {
 		await deactivatePluginApiKey();

--- a/tests/e2e/specs/activation-flow.spec.js
+++ b/tests/e2e/specs/activation-flow.spec.js
@@ -11,7 +11,8 @@ import {
 	checkH2DoesNotExist,
 	deactivatePluginApiKey,
 	waitForWpAdmin,
-	selectScreenOptions, startUpTest,
+	selectScreenOptions,
+	startUpTest,
 } from '../utils';
 
 describe( 'Activation flow', () => {

--- a/tests/e2e/specs/browse-logo-button.spec.js
+++ b/tests/e2e/specs/browse-logo-button.spec.js
@@ -2,16 +2,12 @@
  * External dependencies
  */
 import * as path from 'path';
-import {
-	activatePlugin,
-	loginUser,
-	visitAdminPage,
-} from '@wordpress/e2e-test-utils';
+import { visitAdminPage } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
  */
-import { waitForWpAdmin } from '../utils';
+import { startUpTest, waitForWpAdmin } from '../utils';
 
 // General initializations.
 const imageLocalPath = path.resolve( __dirname, '../../../.wordpress-org/icon-256x256.png' );
@@ -33,13 +29,7 @@ const modalDeleteAttachmentLink = `${ modalEditAttachment } button.delete-attach
  * Browse button tests
  */
 describe( 'Browse for logo button', () => {
-	/**
-	 * Login and activate the Parse.ly plugin.
-	 */
-	beforeAll( async () => {
-		await loginUser();
-		await activatePlugin( 'wp-parsely' );
-	} );
+	beforeAll( startUpTest );
 
 	/**
 	 * Remove the uploaded image.

--- a/tests/e2e/specs/front-end-code.spec.js
+++ b/tests/e2e/specs/front-end-code.spec.js
@@ -1,17 +1,13 @@
 /**
  * External dependencies
  */
-import {
-	activatePlugin,
-	createURL,
-	loginUser,
-} from '@wordpress/e2e-test-utils';
+import { createURL } from '@wordpress/e2e-test-utils';
 import * as fs from 'fs';
 
 /**
  * Internal dependencies
  */
-import { changeKeysState, PLUGIN_VERSION } from '../utils';
+import { changeKeysState, PLUGIN_VERSION, startUpTest } from '../utils';
 
 const getAssetVersion = () => {
 	const data = fs.readFileSync( 'build/loader.asset.php', { encoding: 'utf8', flag: 'r' } );
@@ -22,9 +18,9 @@ const getAssetVersion = () => {
 };
 
 describe( 'Front end code insertion', () => {
+	beforeAll( startUpTest );
+
 	it( 'Should inject loading script homepage', async () => {
-		await loginUser();
-		await activatePlugin( 'wp-parsely' );
 		await changeKeysState( true, false );
 
 		await page.goto( createURL( '/' ) );
@@ -39,8 +35,6 @@ describe( 'Front end code insertion', () => {
 	} );
 
 	it( 'Should inject loading script homepage and extra variable', async () => {
-		await loginUser();
-		await activatePlugin( 'wp-parsely' );
 		await changeKeysState( true, true );
 
 		await page.goto( createURL( '/' ) );

--- a/tests/e2e/specs/plugin-action-link.spec.js
+++ b/tests/e2e/specs/plugin-action-link.spec.js
@@ -1,23 +1,18 @@
 /**
  * External dependencies
  */
-import {
-	activatePlugin,
-	loginUser,
-	visitAdminPage,
-} from '@wordpress/e2e-test-utils';
+import { visitAdminPage } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
  */
-import { waitForWpAdmin } from '../utils';
+import { startUpTest, waitForWpAdmin } from '../utils';
 
 describe( 'Plugin action link', () => {
-	it( 'Should link to plugin settings page', async () => {
-		await loginUser();
-		await activatePlugin( 'wp-parsely' );
-		await visitAdminPage( '/plugins.php', '' );
+	beforeAll( startUpTest );
 
+	it( 'Should link to plugin settings page', async () => {
+		await visitAdminPage( '/plugins.php', '' );
 		await waitForWpAdmin();
 
 		await expect( page ).toClick( '[data-slug=wp-parsely] .settings>a', { text: 'Settings' } );

--- a/tests/e2e/specs/recommended-widget.spec.js
+++ b/tests/e2e/specs/recommended-widget.spec.js
@@ -7,7 +7,8 @@ import { activateTheme, visitAdminPage } from '@wordpress/e2e-test-utils';
  * Internal dependencies
  */
 import {
-	changeKeysState, startUpTest,
+	changeKeysState,
+	startUpTest,
 	waitForWpAdmin,
 } from '../utils';
 

--- a/tests/e2e/specs/recommended-widget.spec.js
+++ b/tests/e2e/specs/recommended-widget.spec.js
@@ -1,18 +1,13 @@
 /**
  * External dependencies
  */
-import {
-	activateTheme,
-	activatePlugin,
-	loginUser,
-	visitAdminPage,
-} from '@wordpress/e2e-test-utils';
+import { activateTheme, visitAdminPage } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
  */
 import {
-	changeKeysState,
+	changeKeysState, startUpTest,
 	waitForWpAdmin,
 } from '../utils';
 
@@ -49,19 +44,16 @@ const getNonActiveWidgetText = async () => {
 };
 
 describe( 'Recommended widget', () => {
-	beforeAll( () => {
+	beforeAll( async () => {
 		page.on( 'dialog', async function( dialog ) {
 			await dialog.accept();
 		} );
-	} );
 
-	beforeEach( async () => {
-		await loginUser();
+		await startUpTest();
 		await activateTheme( 'twentytwentyone' );
-		await activatePlugin( 'wp-parsely' );
 	} );
 
-	afterEach( async () => {
+	afterAll( async () => {
 		await activateTheme( 'twentytwentytwo' );
 	} );
 

--- a/tests/e2e/specs/settings-track-post-types-as.js
+++ b/tests/e2e/specs/settings-track-post-types-as.js
@@ -8,7 +8,8 @@ import { visitAdminPage } from '@wordpress/e2e-test-utils';
  */
 import {
 	saveSettingsAndHardRefresh,
-	selectScreenOptions, startUpTest,
+	selectScreenOptions,
+	startUpTest,
 	waitForWpAdmin,
 } from '../utils';
 

--- a/tests/e2e/specs/settings-track-post-types-as.js
+++ b/tests/e2e/specs/settings-track-post-types-as.js
@@ -1,18 +1,14 @@
 /**
  * External dependencies
  */
-import {
-	activatePlugin,
-	loginUser,
-	visitAdminPage,
-} from '@wordpress/e2e-test-utils';
+import { visitAdminPage } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
  */
 import {
 	saveSettingsAndHardRefresh,
-	selectScreenOptions,
+	selectScreenOptions, startUpTest,
 	waitForWpAdmin,
 } from '../utils';
 
@@ -35,8 +31,8 @@ describe( 'Track Post Types as', () => {
 	 * Login, activate the Parse.ly plugin and show recrawl settings.
 	 */
 	beforeAll( async () => {
-		await loginUser();
-		await activatePlugin( 'wp-parsely' );
+		await startUpTest();
+
 		await visitAdminPage( '/options-general.php', '?page=parsely' );
 		await waitForWpAdmin();
 		await selectScreenOptions( { recrawl: true, advanced: false } );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -1,4 +1,4 @@
-import { visitAdminPage } from '@wordpress/e2e-test-utils';
+import { activatePlugin, loginUser, visitAdminPage } from '@wordpress/e2e-test-utils';
 
 export const PLUGIN_VERSION = '3.1.1';
 
@@ -86,4 +86,15 @@ export const saveSettingsAndHardRefresh = async () => {
 		location.reload( true );
 	} );
 	await page.waitForSelector( '#submit' );
+};
+
+/**
+ * Some common actions to do before starting tests.
+ *
+ * @return {Promise<void>}
+ */
+export const startUpTest = async () => {
+	await loginUser();
+	await activatePlugin( 'wp-parsely' );
+	await waitForWpAdmin();
 };


### PR DESCRIPTION
## Description

This PR aims to improve the reliability of end to end tests on the CI environment (GitHub Actions). We have:

- Changed the way tests are executed, using the `npm` command.
- Added a cleanup stage in the pipeline.
- Unifying setup for functions and moving repetitive actions from `beforeEach` to `beforeAll`.
- Adding preventive waits.

## Motivation and Context

E2E tests have been very flaky lately.

## How Has This Been Tested?

Pushes to this branch consistently pass CI.