### PR TITLE
Update some outdated references in function comments

### DIFF
--- a/src/class-dashboard-link.php
+++ b/src/class-dashboard-link.php
@@ -47,7 +47,7 @@ class Dashboard_Link {
 	 * Determine whether Parse.ly dashboard link should be shown or not.
 	 *
 	 * @since 2.6.0
-	 * @since 3.1.0 Moved to class-utils.php. Renamed from `cannot_show_parsely_link`.
+	 * @since 3.1.0 Moved to class-dashboard-link.php. Renamed from `cannot_show_parsely_link`.
 	 *
 	 * @param WP_Post $post    Which post object or ID to check.
 	 * @param Parsely $parsely Parsely object.

--- a/tests/Integration/DashboardLinkTest.php
+++ b/tests/Integration/DashboardLinkTest.php
@@ -54,7 +54,7 @@ final class DashboardLinkTest extends TestCase {
 	 * @since 2.6.0
 	 * @since 3.1.0 Moved to `DashboardLinkTest.php`
 	 *
-	 * @covers \Parsely\UI\Row_Actions::cannot_show_parsely_link
+	 * @covers \Parsely\Dashboard_Link::can_show_link
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::get_options
@@ -75,7 +75,7 @@ final class DashboardLinkTest extends TestCase {
 	 * @since 2.6.0
 	 * @since 3.1.0 Moved to `DashboardLinkTest.php`
 	 *
-	 * @covers \Parsely\UI\Row_Actions::cannot_show_parsely_link
+	 * @covers \Parsely\Dashboard_Link::can_show_link
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::get_options
@@ -97,7 +97,7 @@ final class DashboardLinkTest extends TestCase {
 	 * @since 2.6.0
 	 * @since 3.1.0 Moved to `DashboardLinkTest.php`
 	 *
-	 * @covers \Parsely\UI\Row_Actions::cannot_show_parsely_link
+	 * @covers \Parsely\Dashboard_Link::can_show_link
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::get_options
@@ -119,7 +119,7 @@ final class DashboardLinkTest extends TestCase {
 	 * @since 2.6.0
 	 * @since 3.1.0 Moved to `DashboardLinkTest.php`
 	 *
-	 * @covers \Parsely\UI\Row_Actions::cannot_show_parsely_link
+	 * @covers \Parsely\Dashboard_Link::can_show_link
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::get_options

--- a/tests/Integration/UI/RowActionsTest.php
+++ b/tests/Integration/UI/RowActionsTest.php
@@ -78,8 +78,8 @@ final class RowActionsTest extends TestCase {
 	 * @covers \Parsely\UI\Row_Actions::row_actions_add_parsely_link
 	 * @covers \Parsely\UI\Row_Actions::generate_aria_label_for_post
 	 * @covers \Parsely\UI\Row_Actions::generate_link_to_parsely
-	 * @covers \Parsely\UI\Row_Actions::generate_url
-	 * @uses \Parsely\UI\Row_Actions::cannot_show_parsely_link
+	 * @covers \Parsely\Dashboard_Link::generate_url
+	 * @uses \Parsely\Dashboard_Link::can_show_link
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::get_api_key
@@ -114,8 +114,8 @@ final class RowActionsTest extends TestCase {
 	 * @covers \Parsely\UI\Row_Actions::row_actions_add_parsely_link
 	 * @covers \Parsely\UI\Row_Actions::generate_aria_label_for_post
 	 * @covers \Parsely\UI\Row_Actions::generate_link_to_parsely
-	 * @covers \Parsely\UI\Row_Actions::generate_url
-	 * @uses \Parsely\UI\Row_Actions::cannot_show_parsely_link
+	 * @covers \Parsely\Dashboard_Link::generate_url
+	 * @uses \Parsely\Dashboard_Link::can_show_link
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::get_api_key


### PR DESCRIPTION
## Description
While skimming code, I found function comments that were referring to a non-existent file and some functions that had been since renamed. This PR fixes this by pointing everything to their current names.

## Motivation and Context
Pointing to non-existent functions or files in comments can become confusing.