### PR TITLE
Removing redundant EOL

### DIFF
--- a/src/Integrations/class-google-web-stories.php
+++ b/src/Integrations/class-google-web-stories.php
@@ -46,7 +46,7 @@ final class Google_Web_Stories implements Integration {
 					<?php
 					// Output contains the API key, and it's already escaped in the construct_amp_json function.
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo $json . PHP_EOL;
+					echo $json;
 					?>
 				</script>
 			</amp-analytics>

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -188,8 +188,6 @@ class Parsely {
 			return;
 		}
 
-		echo PHP_EOL;
-
 		// Insert JSON-LD or repeated metas.
 		if ( 'json_ld' === $parsely_options['meta_type'] ) {
 			include plugin_dir_path( PARSELY_FILE ) . 'views/json-ld.php';
@@ -224,8 +222,6 @@ class Parsely {
 		if ( isset( $parsely_page['custom_metadata'] ) ) {
 			include plugin_dir_path( PARSELY_FILE ) . 'views/custom-metadata.php';
 		}
-
-		echo PHP_EOL;
 	}
 
 	/**

--- a/tests/Integration/Integrations/GoogleWebStoriesTest.php
+++ b/tests/Integration/Integrations/GoogleWebStoriesTest.php
@@ -73,8 +73,7 @@ final class GoogleWebStoriesTest extends TestCase {
 	public function test_render_amp_analytics_tracker(): void {
 		$expected = '			<amp-analytics type="parsely">
 				<script type="application/json">
-					{"vars":{"apikey":"blog.parsely.com"}}
-				</script>
+					{"vars":{"apikey":"blog.parsely.com"}}				</script>
 			</amp-analytics>
 			';
 

--- a/tests/Integration/RestTest.php
+++ b/tests/Integration/RestTest.php
@@ -183,11 +183,9 @@ final class RestTest extends TestCase {
 		$date = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );
 
 		$meta_string = self::$rest->get_rendered_meta();
-		$expected    = '
-<script type="application/ld+json">
+		$expected    = '<script type="application/ld+json">
 {"@context":"http:\/\/schema.org","@type":"NewsArticle","mainEntityOfPage":{"@type":"WebPage","@id":"http:\/\/example.org\/?p=' . $post_id . '"},"headline":"My test_get_rendered_meta_json_ld title","url":"http:\/\/example.org\/?p=' . $post_id . '","thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"dateCreated":"' . $date . '","datePublished":"' . $date . '","dateModified":"' . $date . '","articleSection":"Uncategorized","author":[],"creator":[],"publisher":{"@type":"Organization","name":"Test Blog","logo":""},"keywords":[]}
 </script>
-
 ';
 		self::assertEquals( $expected, $meta_string );
 	}
@@ -215,13 +213,11 @@ final class RestTest extends TestCase {
 		$date = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );
 
 		$meta_string = self::$rest->get_rendered_meta();
-		$expected    = '
-<meta name="parsely-title" content="My test_get_rendered_repeated_metas title" />
+		$expected    = '<meta name="parsely-title" content="My test_get_rendered_repeated_metas title" />
 <meta name="parsely-link" content="http://example.org/?p=' . $post_id . '" />
 <meta name="parsely-type" content="post" />
 <meta name="parsely-pub-date" content="' . $date . '" />
 <meta name="parsely-section" content="Uncategorized" />
-
 ';
 		self::assertEquals( $expected, $meta_string );
 	}


### PR DESCRIPTION
## Description

This PR removes some line breaks that we have in our code that do not add any value and are redundant.

## Motivation and Context

We've been exploring how to have EOLs in our code, but the best way is to not have them :) 

## How Has This Been Tested?

Code still renders with sufficient line breaks on the front end

## Screenshots

** Old**
<img width="611" alt="Screen Shot 2022-02-17 at 10 44 26 AM" src="https://user-images.githubusercontent.com/7188409/154449045-b0ab37bb-7e5d-4194-93c5-89a49f42449f.png">

** New **

<img width="607" alt="Screen Shot 2022-02-17 at 10 44 01 AM" src="https://user-images.githubusercontent.com/7188409/154448976-4944c524-5578-4116-bcdd-aa223bf2d691.png">