### PR TITLE
Fix integration test on Windows

### DIFF
--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -17,7 +17,7 @@ foreach ( $parsely_metas as $parsely_meta_key => $parsely_meta_val ) {
 		'<meta name="%s" content="%s" />%s',
 		esc_attr( 'parsely-' . $parsely_meta_key ),
 		esc_attr( $parsely_meta_val ),
-		PHP_EOL
+		"\n"
 	);
 }
 
@@ -26,7 +26,7 @@ if ( isset( $parsely_page_authors ) ) {
 		printf(
 			'<meta name="parsely-author" content="%s" />%s',
 			esc_attr( $parsely_author_name ),
-			PHP_EOL
+			"\n"
 		);
 	}
 }


### PR DESCRIPTION
## Description
We've had some integration tests failing on Windows environments due to line feed differences, as described in #630.

PR #677 addressed this by removing certain `PHP_EOL` calls, but `repeated-metas.php` still used `PHP_EOL` which made one integration test fail on Windows. As we probably do want the line feed in this case, I've opted for replacing `PHP_EOL` with `"\n"`. Else we can just remove those.

## Motivation and Context
Fix #630

## How Has This Been Tested?
All integration tests pass on a local Windows environment