### PR TITLE
Decrease default e2e timeout

### DIFF
--- a/jest-e2e.config.js
+++ b/jest-e2e.config.js
@@ -1,0 +1,10 @@
+/**
+ * Updating Gutenberg's default E2E configuration to have a lower timeout (i.e. we want tests to fail fast).
+ * Notice that this jest configuration only applies to E2E tests (as per the `-e2e` suffix).
+ */
+const baseConfig = require( '@wordpress/scripts/config/jest-e2e.config' );
+
+module.exports = {
+	...baseConfig,
+	testTimeout: 10000,
+};


### PR DESCRIPTION
## Description

We are decreasing the Jest timeout for end to end tests from Gutenberg's 30 second default to 10 seconds. The aim of this is to make tests fail fast in case they fail -- in our experience, if a test doesn't complete in less than 10 seconds, it means it's waiting for a condition that will never happen. Hence, we're just wasting time until we get to 30 seconds.

Because we're using the `-e2e` suffix, this default Jest configuration change does not affect other tests.

This timeout is per individual test.

## Motivation and Context

Reduce the amount of time we waste with flaky end-to-end tests.

## How Has This Been Tested?

Add a condition that is never going to happen in a test, for instance `page.waitForSelector('#asdf')`. This test should timeout in 10 seconds instead of 30.