### PR TITLE
Adding additional wait on activation flow E2E

### DIFF
--- a/tests/e2e/specs/activation-flow.spec.js
+++ b/tests/e2e/specs/activation-flow.spec.js
@@ -45,6 +45,7 @@ describe( 'Activation flow', () => {
 
 	it( 'Should display all admin sections', async () => {
 		await visitAdminPage( '/options-general.php', '?page=parsely' );
+		await waitForWpAdmin();
 
 		// Set initial state
 		await selectScreenOptions( { recrawl: false, advanced: false } );


### PR DESCRIPTION
## Description

Sometimes the activation flow end-to-end test would fail due to the page not being fully loaded before resetting the state. This PR adds an additional wait to ensure that we're in the correct page.

## Motivation and Context

Less flaky E2E tests.

## How Has This Been Tested?

E2E pass consistently locally and on GitHub.