### PR TITLE
Fix API key empty checks

### DIFF
--- a/src/Endpoints/class-related-api-proxy.php
+++ b/src/Endpoints/class-related-api-proxy.php
@@ -95,11 +95,9 @@ final class Related_API_Proxy {
 	 * @return stdClass
 	 */
 	public function get_items( WP_REST_Request $request ) {
-		$options = $this->parsely->get_options();
-		$apikey  = $options['apikey'];
-		$params  = $request->get_params();
+		$params = $request->get_params();
 
-		if ( empty( $apikey ) ) {
+		if ( $this->parsely->api_key_is_missing() ) {
 			return (object) array(
 				'data'  => array(),
 				'error' => new WP_Error( 400, __( 'A Parse.ly API Key must be set in site options to use this endpoint', 'wp-parsely' ) ),

--- a/src/UI/class-admin-warning.php
+++ b/src/UI/class-admin-warning.php
@@ -77,7 +77,6 @@ final class Admin_Warning {
 			return false;
 		}
 
-		$options = $this->parsely->get_options();
-		return empty( $options['apikey'] );
+		return $this->parsely->api_key_is_missing();
 	}
 }


### PR DESCRIPTION
## Description

This PR changes some manual access to the options object and uses of the `empty` construct to check if the API key existed for the canonical method on the `Parsely` class.

## Motivation and Context

Checking for the presence of API keys consistently through the codebase.

## How Has This Been Tested?

The code behaves correctly when no API key is set.