### PR TITLE
Don't return metadata on REST if no API key

### DIFF
--- a/src/class-rest.php
+++ b/src/class-rest.php
@@ -86,18 +86,18 @@ class Rest {
 	 * the `parsely` object in the REST API.
 	 *
 	 * @param array $object The WordPress object to extract to render the metadata for, usually a post or a page.
-	 * @return array The `parsely` object to be rendered in the REST API. Contains a version number describing the
+	 * @return array<string, mixed> The `parsely` object to be rendered in the REST API. Contains a version number describing the
 	 * response and the `meta` object containing the actual metadata.
 	 */
 	public function get_callback( array $object ): array {
 		$post_id = $object['ID'] ?? $object['id'] ?? 0;
-		$options = $this->parsely->get_options();
 		$post    = WP_Post::get_instance( $post_id );
 
-		if ( false === $post ) {
+		if ( false === $post || $this->parsely->api_key_is_missing() ) {
 			$meta = '';
 		} else {
-			$meta = $this->parsely->construct_parsely_metadata( $options, $post );
+			$options = $this->parsely->get_options();
+			$meta    = $this->parsely->construct_parsely_metadata( $options, $post );
 		}
 
 		$response = array(

--- a/tests/Integration/RestTest.php
+++ b/tests/Integration/RestTest.php
@@ -115,6 +115,7 @@ final class RestTest extends TestCase {
 	 * @covers \Parsely\Rest::get_callback
 	 */
 	public function test_get_callback(): void {
+		self::set_options( array( 'apikey' => 'testkey' ) );
 		$post_id = self::factory()->post->create();
 
 		$meta_object = self::$rest->get_callback( get_post( $post_id, 'ARRAY_A' ) );
@@ -128,13 +129,31 @@ final class RestTest extends TestCase {
 	}
 
 	/**
+	 * Test that the get_rest_callback method does not generate metadata when there is no API key.
+	 *
+	 * @covers \Parsely\Rest::get_callback
+	 */
+	public function test_get_callback_no_api_key(): void {
+		$post_id = self::factory()->post->create();
+
+		$meta_object = self::$rest->get_callback( get_post( $post_id, 'ARRAY_A' ) );
+		$expected    = array(
+			'version'  => '1.0.0',
+			'meta'     => '',
+			'rendered' => '',
+		);
+
+		self::assertEquals( $expected, $meta_object );
+	}
+
+	/**
 	 * Test that the get_rest_callback method is able to generate the `parsely` object for the REST API.
 	 *
 	 * @covers \Parsely\Rest::get_callback
 	 */
 	public function test_get_callback_with_filter(): void {
 		add_filter( 'wp_parsely_enable_rest_rendered_support', '__return_false' );
-
+		self::set_options( array( 'apikey' => 'testkey' ) );
 		$post_id = self::factory()->post->create();
 
 		$meta_object = self::$rest->get_callback( get_post( $post_id, 'ARRAY_A' ) );


### PR DESCRIPTION
## Description

This PR makes the REST API fields consistently behave when no API key is set. We used to return some data if no API key was set on the `meta` field, but with this change we only do that after the API key check.

## Motivation and Context

Consistency on the REST API behavior.

## How Has This Been Tested?

An additional integration test has been added.