### PR TITLE
Adding tests for multiple WordPress versions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -38,4 +38,5 @@
 /phpstan.neon                    export-ignore
 /phpunit.xml.dist                export-ignore
 /phpunit-integration.xml.dist    export-ignore
+/phpunit-experimental.xml.dist   export-ignore
 /webpack.config.js               export-ignore

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,6 +29,7 @@ jobs:
       # PHP 7.4 uses PHPUnit 9.5.10
       # PHP 8.0 uses PHPUnit 9.5.10
       # PHP 8.1 uses PHPUnit 9.5.10
+      # PHP 8.2 uses PHPUnit 9.5.10
       # Keys:
       # - coverage: Whether to run the tests with code coverage.
       # - experimental: Whether the build is "allowed to fail".

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     env:
-      WP_VERSION: latest
+      WP_VERSION: ${{ matrix.wp }}
 
     strategy:
       # PHP 7.1 uses PHPUnit 7.5.20
@@ -33,22 +33,24 @@ jobs:
       # - coverage: Whether to run the tests with code coverage.
       # - experimental: Whether the build is "allowed to fail".
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4']
+        php: [ '7.2', '7.3', '7.4', '8.1']
+        wp: ['latest']
         coverage: [none]
         experimental: [false]
         include:
-          # Separate out PHP 8.0, so it can run with code coverage.
+          - php: '7.1'
+            wp: '5.8.3'
+            coverage: none
+            experimental: false
           - php: '8.0'
             coverage: pcov
             extensions: pcov
             ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
             experimental: false
-          - php: '8.1'
+          - php: '8.2'
+            wp: 'trunk'
             coverage: none
-            experimental: false
-          # - php: '8.2'
-          #  coverage: none
-          #  experimental: true
+            experimental: true
       fail-fast: false
     continue-on-error: ${{ matrix.experimental }}
     steps:
@@ -70,13 +72,14 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install Composer dependencies
+        if: ${{ matrix.php < 8.2 }}
         uses: ramsey/composer-install@v2
 
-      # - name: Install Composer dependencies for PHP >= 8.2
-      #  if: ${{ matrix.php >= 8.2 }}
-      #  uses: ramsey/composer-install@v2
-      #  with:
-      #    composer-options: --ignore-platform-reqs
+      - name: Install Composer dependencies for PHP >= 8.2
+        if: ${{ matrix.php >= 8.2 }}
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: --ignore-platform-reqs
 
       - name: Start MySQL Service
         run: sudo systemctl start mysql.service
@@ -89,10 +92,15 @@ jobs:
         run: composer prepare-ci --no-interaction
 
       - name: Run integration tests (single site)
-        if: ${{ matrix.php != 8.0 }}
+        if: ${{ matrix.php != 8.0 && ! matrix.experimental }}
         run: composer testwp --no-interaction
 
+      - name: Run integration tests experimental
+        if: ${{ matrix.experimental }}
+        run: composer testwp-experimental --no-interaction
+
       - name: Run integration tests (multi site)
+        if: ${{ ! matrix.experimental }}
         run: composer testwp-ms --no-interaction
 
       - name: Run integration tests (multisite site with code coverage)

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -9,7 +9,9 @@ DB_NAME=$1
 DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
-WP_VERSION=${5-latest}
+if [ -z "${WP_VERSION}" ]; then
+	WP_VERSION=${5-latest}
+fi
 SKIP_DB_CREATE=${6-false}
 
 TMPDIR=${TMPDIR-/tmp}

--- a/composer.json
+++ b/composer.json
@@ -75,13 +75,13 @@
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --checkstyle"
 		],
 		"prepare-ci": [
-			"bash bin/install-wp-tests.sh wordpress_test root root localhost trunk"
+			"bash bin/install-wp-tests.sh wordpress_test root root localhost"
 		],
 		"test": [
 			"@php ./vendor/bin/phpunit --no-coverage --order-by=random"
 		],
 	   	"static-analysis": [
-		  "@php ./vendor/bin/phpstan analyze --memory-limit 536870912"
+			"@php ./vendor/bin/phpstan analyze --memory-limit 536870912"
 		],
 		"test-ms": [
 			"@putenv WP_MULTISITE=1",
@@ -89,6 +89,9 @@
 		],
 		"testwp": [
 			"@php ./vendor/bin/phpunit --no-coverage --order-by=random -c phpunit-integration.xml.dist"
+		],
+		"testwp-experimental": [
+		  "@php ./vendor/bin/phpunit --no-coverage --order-by=random -c phpunit-experimental.xml.dist"
 		],
 		"testwp-ms": [
 			"@putenv WP_MULTISITE=1",

--- a/phpunit-experimental.xml.dist
+++ b/phpunit-experimental.xml.dist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Same of normal integration config, but we don't want to fail on deprecations -->
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+	bootstrap="./tests/Integration/bootstrap.php"
+	backupGlobals="false"
+	beStrictAboutCoversAnnotation="true"
+	beStrictAboutTestsThatDoNotTestAnything="false"
+	colors="true"
+	convertDeprecationsToExceptions="false"
+	forceCoversAnnotation="true"
+	testdox="true"
+	>
+	<php>
+		<server name="SERVER_PORT" value="80"/>
+		<server name="HTTP_HOST" value="localhost"/>
+		<server name="REMOTE_ADDR" value="127.0.0.1"/>
+	</php>
+	<testsuites>
+		<testsuite name="integration">
+			<directory>./tests/Integration</directory>
+		</testsuite>
+	</testsuites>
+	<coverage>
+		<include>
+			<directory suffix=".php">src</directory>
+			<file>wp-parsely.php</file>
+		</include>
+		<report>
+			<text outputFile="php://stdout"/>
+		</report>
+	</coverage>
+</phpunit>

--- a/phpunit-experimental.xml.dist
+++ b/phpunit-experimental.xml.dist
@@ -6,7 +6,7 @@
 	bootstrap="./tests/Integration/bootstrap.php"
 	backupGlobals="false"
 	beStrictAboutCoversAnnotation="true"
-	beStrictAboutTestsThatDoNotTestAnything="false"
+	beStrictAboutTestsThatDoNotTestAnything="true"
 	colors="true"
 	convertDeprecationsToExceptions="false"
 	forceCoversAnnotation="true"

--- a/phpunit-integration.xml.dist
+++ b/phpunit-integration.xml.dist
@@ -5,7 +5,7 @@
 	bootstrap="./tests/Integration/bootstrap.php"
 	backupGlobals="false"
 	beStrictAboutCoversAnnotation="true"
-	beStrictAboutTestsThatDoNotTestAnything="false"
+	beStrictAboutTestsThatDoNotTestAnything="true"
 	colors="true"
 	convertDeprecationsToExceptions="true"
 	forceCoversAnnotation="true"

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -388,16 +388,10 @@ final class ScriptsTest extends TestCase {
 
 		$loader_asset = require plugin_dir_path( PARSELY_FILE ) . 'build/loader.asset.php';
 
-		// @codingStandardsIgnoreStart
-		$expected = "<script type='text/javascript' src='http://example.org/wp-includes/js/dist/vendor/regenerator-runtime.min.js?ver=0.13.9' id='regenerator-runtime-js'></script>
-<script type='text/javascript' src='http://example.org/wp-includes/js/dist/vendor/wp-polyfill.min.js?ver=3.15.0' id='wp-polyfill-js'></script>
-<script type='text/javascript' src='http://example.org/wp-includes/js/dist/hooks.min.js?ver=1e58c8c5a32b2e97491080c5b10dc71c' id='wp-hooks-js'></script>
-<script data-cfasync=\"false\" type='text/javascript' src='http://example.org/wp-content/plugins/wp-parsely/tests/Integration/../../build/loader.js?ver=" . $loader_asset['version'] . "' id='wp-parsely-loader-js'></script>
-<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=123456.78.9' id=\"parsely-cfg\"></script>
-";
-		// @codingStandardsIgnoreEnd
-
-		self::assertSame( $expected, $output, 'Tracker script tag was not printed correctly' );
+		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		self::assertStringContainsString( "<script data-cfasync=\"false\" type='text/javascript' src='http://example.org/wp-content/plugins/wp-parsely/tests/Integration/../../build/loader.js?ver=" . $loader_asset['version'] . "' id='wp-parsely-loader-js'></script>", $output );
+		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		self::assertStringContainsString( "<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=123456.78.9' id=\"parsely-cfg\"></script>", $output );
 	}
 
 	/**

--- a/tests/Integration/UI/AdminWarningTest.php
+++ b/tests/Integration/UI/AdminWarningTest.php
@@ -43,8 +43,28 @@ final class AdminWarningTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_display_admin_warning_without_key(): void {
+		if ( version_compare( get_bloginfo( 'version' ), '5.9', '<' ) ) {
+			self::markTestSkipped( "This test can't run below 5.9" );
+		}
+
 		$should_display_admin_warning = self::getMethod( 'should_display_admin_warning', Admin_Warning::class );
 		$this->set_options( array( 'apikey' => '' ) );
+
+		$response = $should_display_admin_warning->invoke( self::$admin_warning );
+		self::assertTrue( $response );
+	}
+
+	/**
+	 * Test that test_display_admin_warning action returns a warning when there is no key
+	 *
+	 * @covers \Parsely\UI\Admin_Warning::should_display_admin_warning
+	 * @uses \Parsely\UI\Admin_Warning::__construct
+	 * @uses \Parsely\Parsely::get_options
+	 */
+	public function test_display_admin_warning_without_key_old_wp(): void {
+		$should_display_admin_warning = self::getMethod( 'should_display_admin_warning', Admin_Warning::class );
+		$this->set_options( array( 'apikey' => '' ) );
+		set_current_screen( 'settings_page_parsely' );
 
 		$response = $should_display_admin_warning->invoke( self::$admin_warning );
 		self::assertTrue( $response );


### PR DESCRIPTION
## Description

This PR adds support for testing multiple WordPress versions on the integration pipeline. Currently, we're only testing against `trunk`. This PR changes:

- Most of the tests go against WP `latest`.
- PHP 7.1 is tested against WP `5.8.3`.
- PHP 8.2 gets readded and tested against `trunk`. Notice that we've added an experimental configuration that doesn't fail on deprecation warnings.

## Motivation and Context

Closes #407 

## How Has This Been Tested?

All integration tests pass on CI.