### PR TITLE
Add Admin Bar filter

### DIFF
--- a/src/UI/class-admin-bar.php
+++ b/src/UI/class-admin-bar.php
@@ -44,8 +44,17 @@ final class Admin_Bar {
 	 * @return void
 	 */
 	public function run(): void {
-		// Priority 201 to load after Core's admin bar secondary groups (200).
-		add_action( 'admin_bar_menu', array( $this, 'admin_bar_parsely_stats_button' ), 201 );
+		/**
+		 * Filter whether the Open on Parse.ly button is enabled or not on the admin bar menu.
+		 *
+		 * @since 3.1.2
+		 *
+		 * @param bool $enabled True if enabled, false if not.
+		 */
+		if ( apply_filters( 'wp_parsely_enable_admin_bar', true ) ) {
+			// Priority 201 to load after Core's admin bar secondary groups (200).
+			add_action( 'admin_bar_menu', array( $this, 'admin_bar_parsely_stats_button' ), 201 );
+		}
 	}
 
 	/**

--- a/tests/Integration/UI/AdminBarTest.php
+++ b/tests/Integration/UI/AdminBarTest.php
@@ -45,4 +45,17 @@ final class AdminBarTest extends TestCase {
 
 		self::assertEquals( 201, has_filter( 'admin_bar_menu', array( self::$admin_bar, 'admin_bar_parsely_stats_button' ) ) );
 	}
+
+	/**
+	 * Check that the function to render the stats button is not enqueued on the admin menu when there's the filter.
+	 *
+	 * @covers \Parsely\UI\Admin_Bar::run
+	 */
+	public function test_admin_bar_not_enqueued_with_filter(): void {
+		add_filter( 'wp_parsely_enable_admin_bar', '__return_false' );
+
+		self::$admin_bar->run();
+
+		self::assertFalse( has_filter( 'admin_bar_menu', array( self::$admin_bar, 'admin_bar_parsely_stats_button' ) ) );
+	}
 }


### PR DESCRIPTION
## Description

This PR provides a filter to enable or disable the Open on Parse.ly button in the admin bar.

## Motivation and Context

See https://github.com/Parsely/wp-parsely/issues/618

## How Has This Been Tested?

Add the following filter. The admin bar button shouldn't be rendered:

```
add_filter( 'wp_parsely_enable_admin_bar', '__return_false' );
```