### PR TITLE
Fix generating URL for invalid permalinks

### DIFF
--- a/src/UI/class-admin-bar.php
+++ b/src/UI/class-admin-bar.php
@@ -67,7 +67,7 @@ final class Admin_Bar {
 	public function admin_bar_parsely_stats_button( WP_Admin_Bar $admin_bar ): void {
 		$current_object = $GLOBALS['wp_the_query']->get_queried_object();
 
-		if ( empty( $current_object ) || empty( $current_object->post_type ) ) {
+		if ( null === $current_object || empty( $current_object->post_type ) ) {
 			return;
 		}
 

--- a/src/UI/class-admin-bar.php
+++ b/src/UI/class-admin-bar.php
@@ -72,14 +72,19 @@ final class Admin_Bar {
 		}
 
 		$post_type_object = get_post_type_object( $current_object->post_type );
-		if ( $post_type_object && $post_type_object->show_in_admin_bar && Dashboard_Link::can_show_link( $current_object, $this->parsely ) ) {
-			$admin_bar->add_node(
-				array(
-					'id'    => 'parsely-stats',
-					'title' => __( 'Parse.ly Stats', 'wp-parsely' ),
-					'href'  => Dashboard_Link::generate_url( $current_object, $this->parsely->get_api_key(), 'wp-page-single', 'admin-bar' ),
-				)
-			);
+		if ( null !== $post_type_object && $post_type_object->show_in_admin_bar && Dashboard_Link::can_show_link( $current_object, $this->parsely ) ) {
+			$href = Dashboard_Link::generate_url( $current_object, $this->parsely->get_api_key(), 'wp-page-single', 'admin-bar' );
+
+			// Not adding the link if there were issues generating the URL.
+			if ( '' !== $href ) {
+				$admin_bar->add_node(
+					array(
+						'id'    => 'parsely-stats',
+						'title' => __( 'Parse.ly Stats', 'wp-parsely' ),
+						'href'  => $href,
+					)
+				);
+			}
 		}
 	}
 }

--- a/src/UI/class-row-actions.php
+++ b/src/UI/class-row-actions.php
@@ -77,7 +77,10 @@ final class Row_Actions {
 			return $actions;
 		}
 
-		$actions['find_in_parsely'] = $this->generate_link_to_parsely( $post );
+		$url = Dashboard_Link::generate_url( $post, $this->parsely->get_api_key(), 'wp-admin-posts-list', 'wp-admin' );
+		if ( '' !== $url ) {
+			$actions['find_in_parsely'] = $this->generate_link_to_parsely( $post, $url );
+		}
 
 		return $actions;
 	}
@@ -86,14 +89,16 @@ final class Row_Actions {
 	 * Generate the HTML link to Parse.ly.
 	 *
 	 * @since 2.6.0
+	 * @since 3.1.2 Added `url` parameter.
 	 *
 	 * @param WP_Post $post Which post object or ID to add link to.
+	 * @param string  $url Generated URL for the post.
 	 * @return string The HTML for the link to Parse.ly.
 	 */
-	private function generate_link_to_parsely( WP_Post $post ): string {
+	private function generate_link_to_parsely( WP_Post $post, string $url ): string {
 		return sprintf(
 			'<a href="%1$s" aria-label="%2$s">%3$s</a>',
-			esc_url( Dashboard_Link::generate_url( $post, $this->parsely->get_api_key(), 'wp-admin-posts-list', 'wp-admin' ) ),
+			esc_url( $url ),
 			esc_attr( $this->generate_aria_label_for_post( $post ) ),
 			esc_html__( 'Parse.ly&nbsp;Stats', 'wp-parsely' )
 		);

--- a/src/class-dashboard-link.php
+++ b/src/class-dashboard-link.php
@@ -19,7 +19,7 @@ use WP_Post;
  */
 class Dashboard_Link {
 	/**
-	 * Generate the Parse.ly dashboard URL for the post.
+	 * Generate the Parse.ly dashboard URL for the post. Returns an empty string if the URL could not be generated.
 	 *
 	 * @since 2.6.0
 	 * @since 3.1.0 Moved to class-dashboard-link.php. Added source parameter.
@@ -31,8 +31,13 @@ class Dashboard_Link {
 	 * @return string
 	 */
 	public static function generate_url( WP_Post $post, string $apikey, string $campaign, string $source ): string {
+		$permalink = get_permalink( $post );
+		if ( ! is_string( $permalink ) ) {
+			return '';
+		}
+
 		$query_args = array(
-			'url'          => rawurlencode( get_permalink( $post ) ),
+			'url'          => rawurlencode( $permalink ),
 			'utm_campaign' => $campaign,
 			'utm_source'   => $source,
 			'utm_medium'   => 'wp-parsely',

--- a/tests/Integration/DashboardLinkTest.php
+++ b/tests/Integration/DashboardLinkTest.php
@@ -49,6 +49,26 @@ final class DashboardLinkTest extends TestCase {
 	}
 
 	/**
+	 * Test generating a URL for a post that doesn't exist.
+	 *
+	 * @since 3.1.2
+	 *
+	 * @covers \Parsely\Dashboard_Link::generate_url
+	 */
+	public function test_generate_invalid_post_url(): void {
+		add_filter( 'post_link', '__return_false' );
+
+		$post_id = self::factory()->post->create();
+		$post    = get_post( $post_id );
+		$apikey  = 'demo-api-key';
+
+		$expected = '';
+		$actual   = Dashboard_Link::generate_url( $post, $apikey, 'wp-admin-posts-list', 'wp-admin' );
+
+		self::assertSame( $expected, $actual );
+	}
+
+	/**
 	 * Test if logic for showing Parse.ly row action accounts for actions not being an array.
 	 *
 	 * @since 2.6.0


### PR DESCRIPTION
## Description

Whenever we couldn't generate a link for the Open on Parse.ly URL, the site would fatal. This PR adds some additional checks to, instead of failing, we simply don't display the link.

## Motivation and Context

Closes #693 

## How Has This Been Tested?

The code prevents the issue on the affected site.