### PR TITLE
Moving Rest endpoint to Rest Metadata

### DIFF
--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -3,7 +3,7 @@
  * Metadata endpoint abstract class
  *
  * @package Parsely\Endpoints
- * @since 3.3.0
+ * @since 3.2.0
  */
 
 declare(strict_types=1);
@@ -15,7 +15,7 @@ use Parsely\Parsely;
 /**
  * Metadata endpoint classes are expected to implement the remaining functions of the class.
  *
- * @since 3.3.0
+ * @since 3.2.0
  */
 abstract class Metadata_Endpoint {
 	protected const VERSION    = '1.0.0';
@@ -40,7 +40,7 @@ abstract class Metadata_Endpoint {
 	/**
 	 * Function to start up the class and enqueue necessary actions.
 	 *
-	 * @since 3.3.0
+	 * @since 3.2.0
 	 *
 	 * @return void
 	 */
@@ -58,7 +58,7 @@ abstract class Metadata_Endpoint {
 	/**
 	 * Get the metadata in string format.
 	 *
-	 * @since 3.3.0
+	 * @since 3.2.0
 	 *
 	 * @return string String containing the metadata as HTML code that can be directly inserted in into the page.
 	 */

--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Metadata endpoint abstract class
+ *
+ * @package Parsely\Endpoints
+ * @since 3.3.0
+ */
+
+declare(strict_types=1);
+
+namespace Parsely\Endpoints;
+
+use Parsely\Parsely;
+
+/**
+ * Metadata endpoint classes are expected to implement the remaining functions of the class.
+ *
+ * @since 3.3.0
+ */
+abstract class Metadata_Endpoint {
+	protected const VERSION    = '1.0.0';
+	protected const FIELD_NAME = 'parsely';
+
+	/**
+	 * Instance of Parsely class.
+	 *
+	 * @var Parsely
+	 */
+	protected $parsely;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Parsely $parsely Instance of Parsely class.
+	 */
+	public function __construct( Parsely $parsely ) {
+		$this->parsely = $parsely;
+	}
+
+	/**
+	 * Register metadata fields in the endpoints
+	 *
+	 * @since 3.3.0
+	 *
+	 * @return void
+	 */
+	abstract public function run(): void;
+
+	/**
+	 * Get the metadata in string format.
+	 *
+	 * @since 3.3.0
+	 *
+	 * @return string String containing the metadata as HTML code that can be directly inserted in into the page.
+	 */
+	public function get_rendered_meta(): string {
+		ob_start();
+		$this->parsely->insert_page_header_metadata();
+		return ob_get_clean();
+	}
+}

--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -49,7 +49,7 @@ abstract class Metadata_Endpoint {
 	/**
 	 * Registers the metadata fields on the appropriate resource types.
 	 *
-	 * @since 3.1.0
+	 * @since 3.2.0
 	 *
 	 * @return void
 	 */

--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -18,7 +18,6 @@ use Parsely\Parsely;
  * @since 3.2.0
  */
 abstract class Metadata_Endpoint {
-	protected const VERSION    = '1.0.0';
 	protected const FIELD_NAME = 'parsely';
 
 	/**

--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -60,7 +60,7 @@ abstract class Metadata_Endpoint {
 	 *
 	 * @since 3.2.0
 	 *
-	 * @return string String containing the metadata as HTML code that can be directly inserted in into the page.
+	 * @return string Contains the metadata as HTML code that can be directly inserted into the page.
 	 */
 	public function get_rendered_meta(): string {
 		ob_start();

--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -38,13 +38,22 @@ abstract class Metadata_Endpoint {
 	}
 
 	/**
-	 * Register metadata fields in the endpoints
+	 * Function to start up the class and enqueue necessary actions.
 	 *
 	 * @since 3.3.0
 	 *
 	 * @return void
 	 */
 	abstract public function run(): void;
+
+	/**
+	 * Registers the metadata fields on the appropriate resource types.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @return void
+	 */
+	abstract public function register_meta(): void;
 
 	/**
 	 * Get the metadata in string format.

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace Parsely\Endpoints;
 
-use Parsely\Parsely;
 use WP_Post;
 
 /**
@@ -19,26 +18,7 @@ use WP_Post;
  * @since 3.1.0
  * @since 3.3.0 Renamed to from `Rest` to `Rest_Metadata`
  */
-class Rest_Metadata {
-	private const REST_VERSION    = '1.0.0';
-	private const REST_FIELD_NAME = 'parsely';
-
-	/**
-	 * Instance of Parsely class.
-	 *
-	 * @var Parsely
-	 */
-	private $parsely;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param Parsely $parsely Instance of Parsely class.
-	 */
-	public function __construct( Parsely $parsely ) {
-		$this->parsely = $parsely;
-	}
-
+class Rest_Metadata extends Metadata_Endpoint {
 	/**
 	 * Register fields in WordPress REST API
 	 *
@@ -80,7 +60,7 @@ class Rest_Metadata {
 		$object_types = apply_filters( 'wp_parsely_rest_object_types', $object_types );
 
 		$args = array( 'get_callback' => array( $this, 'get_callback' ) );
-		register_rest_field( $object_types, self::REST_FIELD_NAME, $args );
+		register_rest_field( $object_types, self::FIELD_NAME, $args );
 	}
 
 	/**
@@ -103,7 +83,7 @@ class Rest_Metadata {
 		}
 
 		$response = array(
-			'version' => self::REST_VERSION,
+			'version' => self::VERSION,
 			'meta'    => $meta,
 		);
 
@@ -119,16 +99,5 @@ class Rest_Metadata {
 		}
 
 		return $response;
-	}
-
-	/**
-	 * Get the metadata in string format.
-	 *
-	 * @return string String containing the metadata as HTML code that can be directly inserted in into the page.
-	 */
-	public function get_rendered_meta(): string {
-		ob_start();
-		$this->parsely->insert_page_header_metadata();
-		return ob_get_clean();
 	}
 }

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -16,7 +16,7 @@ use WP_Post;
  * Injects Parse.ly Metadata to WordPress REST API
  *
  * @since 3.1.0
- * @since 3.3.0 Renamed to from `Rest` to `Rest_Metadata`
+ * @since 3.3.0 Renamed FQCN from `Parsely\Rest` to `Parsely\Endpoints\Rest_Metadata`.
  */
 class Rest_Metadata extends Metadata_Endpoint {
 	/**

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -16,7 +16,7 @@ use WP_Post;
  * Injects Parse.ly Metadata to WordPress REST API
  *
  * @since 3.1.0
- * @since 3.3.0 Renamed FQCN from `Parsely\Rest` to `Parsely\Endpoints\Rest_Metadata`.
+ * @since 3.2.0 Renamed FQCN from `Parsely\Rest` to `Parsely\Endpoints\Rest_Metadata`.
  */
 class Rest_Metadata extends Metadata_Endpoint {
 	/**

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -8,16 +8,18 @@
 
 declare(strict_types=1);
 
-namespace Parsely;
+namespace Parsely\Endpoints;
 
+use Parsely\Parsely;
 use WP_Post;
 
 /**
  * Injects Parse.ly Metadata to WordPress REST API
  *
  * @since 3.1.0
+ * @since 3.3.0 Renamed to from `Rest` to `Rest_Metadata`
  */
-class Rest {
+class Rest_Metadata {
 	private const REST_VERSION    = '1.0.0';
 	private const REST_FIELD_NAME = 'parsely';
 
@@ -53,7 +55,7 @@ class Rest {
 		 * @param bool $enabled True if enabled, false if not.
 		 */
 		if ( apply_filters( 'wp_parsely_enable_rest_api_support', true ) ) {
-			add_action( 'rest_api_init', array( $this, 'register_meta' ) );
+			$this->register_meta();
 		}
 	}
 

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -19,6 +19,8 @@ use WP_Post;
  * @since 3.2.0 Renamed FQCN from `Parsely\Rest` to `Parsely\Endpoints\Rest_Metadata`.
  */
 class Rest_Metadata extends Metadata_Endpoint {
+	private const REST_VERSION = '1.0.0';
+
 	/**
 	 * Register fields in WordPress REST API
 	 *
@@ -83,7 +85,7 @@ class Rest_Metadata extends Metadata_Endpoint {
 		}
 
 		$response = array(
-			'version' => self::VERSION,
+			'version' => self::REST_VERSION,
 			'meta'    => $meta,
 		);
 

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -12,9 +12,6 @@ namespace Parsely\Tests\Integration\Endpoints;
 use Parsely\Parsely;
 use Parsely\Endpoints\Rest_Metadata;
 use Parsely\Tests\Integration\TestCase;
-use function add_filter;
-use function get_post;
-use function has_action;
 
 
 /**
@@ -48,7 +45,7 @@ final class RestMetadataTest extends TestCase {
 	/**
 	 * Test whether the logic has been enqueued in the `rest_api_init` hook with a filter that disables it.
 	 *
-	 * @covers \Parsely\Rest_Metadata::run
+	 * @covers \Parsely\Endpoints\Rest_Metadata::run
 	 */
 	public function test_register_enqueued_rest_init_filter(): void {
 		add_filter( 'wp_parsely_enable_rest_api_support', '__return_false' );
@@ -59,7 +56,7 @@ final class RestMetadataTest extends TestCase {
 	/**
 	 * Test that the REST fields are registered to WordPress REST API.
 	 *
-	 * @covers \Parsely\Rest_Metadata::register_meta
+	 * @covers \Parsely\Endpoints\Rest_Metadata::register_meta
 	 */
 	public function test_register_meta_registers_fields(): void {
 		global $wp_rest_additional_fields;
@@ -76,7 +73,7 @@ final class RestMetadataTest extends TestCase {
 	/**
 	 * Test that the REST fields are can be modified using the `wp_parsely_rest_object_types` filter.
 	 *
-	 * @covers \Parsely\Rest_Metadata::register_meta
+	 * @covers \Parsely\Endpoints\Rest_Metadata::register_meta
 	 */
 	public function test_register_meta_with_filter(): void {
 		global $wp_rest_additional_fields;
@@ -103,7 +100,7 @@ final class RestMetadataTest extends TestCase {
 	/**
 	 * Test that the get_rest_callback method is able to generate the `parsely` object for the REST API.
 	 *
-	 * @covers \Parsely\Rest_Metadata::get_callback
+	 * @covers \Parsely\Endpoints\Rest_Metadata::get_callback
 	 */
 	public function test_get_callback(): void {
 		self::set_options( array( 'apikey' => 'testkey' ) );
@@ -122,7 +119,7 @@ final class RestMetadataTest extends TestCase {
 	/**
 	 * Test that the get_rest_callback method does not generate metadata when there is no API key.
 	 *
-	 * @covers \Parsely\Rest_Metadata::get_callback
+	 * @covers \Parsely\Endpoints\Rest_Metadata::get_callback
 	 */
 	public function test_get_callback_no_api_key(): void {
 		$post_id = self::factory()->post->create();
@@ -140,7 +137,7 @@ final class RestMetadataTest extends TestCase {
 	/**
 	 * Test that the get_rest_callback method is able to generate the `parsely` object for the REST API.
 	 *
-	 * @covers \Parsely\Rest_Metadata::get_callback
+	 * @covers \Parsely\Endpoints\Rest_Metadata::get_callback
 	 */
 	public function test_get_callback_with_filter(): void {
 		add_filter( 'wp_parsely_enable_rest_rendered_support', '__return_false' );
@@ -159,7 +156,7 @@ final class RestMetadataTest extends TestCase {
 	/**
 	 * Test that the get_rest_callback method doesn't crash when the post does not exist.
 	 *
-	 * @covers \Parsely\Rest_Metadata::get_callback
+	 * @covers \Parsely\Endpoints\Rest_Metadata::get_callback
 	 */
 	public function test_get_callback_with_non_existent_post(): void {
 		$meta_object = self::$rest->get_callback( array() );
@@ -175,7 +172,7 @@ final class RestMetadataTest extends TestCase {
 	/**
 	 * Test that the rendered meta function returns the meta HTML string with json ld.
 	 *
-	 * @covers \Parsely\Rest_Metadata::get_rendered_meta
+	 * @covers \Parsely\Endpoints\Rest_Metadata::get_rendered_meta
 	 */
 	public function test_get_rendered_meta_json_ld(): void {
 		// Set the default options prior to each test.
@@ -203,7 +200,7 @@ final class RestMetadataTest extends TestCase {
 	/**
 	 * Test that the rendered meta function returns the meta HTML string with json ld.
 	 *
-	 * @covers \Parsely\Rest_Metadata::get_rendered_meta
+	 * @covers \Parsely\Endpoints\Rest_Metadata::get_rendered_meta
 	 */
 	public function test_get_rendered_repeated_metas(): void {
 		// Set the default options prior to each test.

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Parsely\Tests\Integration\Endpoints;
 
 use Parsely\Parsely;
-use Parsely\Rest_Metadata;
+use Parsely\Endpoints\Rest_Metadata;
 use Parsely\Tests\Integration\TestCase;
 use function add_filter;
 use function get_post;
@@ -43,19 +43,6 @@ final class RestMetadataTest extends TestCase {
 
 		self::$parsely = new Parsely();
 		self::$rest    = new Rest_Metadata( self::$parsely );
-	}
-
-	/**
-	 * Test whether the logic has been enqueued in the `rest_api_init` hook.
-	 *
-	 * @covers \Parsely\Rest_Metadata::run
-	 */
-	public function test_register_enqueued_rest_init(): void {
-		self::$rest->run();
-		self::assertSame(
-			10,
-			has_action( 'rest_api_init', array( self::$rest, 'register_meta' ) )
-		);
 	}
 
 	/**

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -7,20 +7,24 @@
 
 declare(strict_types=1);
 
-namespace Parsely\Tests\Integration;
+namespace Parsely\Tests\Integration\Endpoints;
 
 use Parsely\Parsely;
-use Parsely\Rest;
+use Parsely\Rest_Metadata;
+use Parsely\Tests\Integration\TestCase;
+use function add_filter;
+use function get_post;
+use function has_action;
 
 
 /**
  * Parsely REST API tests.
  */
-final class RestTest extends TestCase {
+final class RestMetadataTest extends TestCase {
 	/**
 	 * Internal variable
 	 *
-	 * @var Rest $rest Holds the Rest object
+	 * @var Rest_Metadata $rest Holds the Rest object
 	 */
 	private static $rest;
 
@@ -38,13 +42,13 @@ final class RestTest extends TestCase {
 		parent::set_up();
 
 		self::$parsely = new Parsely();
-		self::$rest    = new Rest( self::$parsely );
+		self::$rest    = new Rest_Metadata( self::$parsely );
 	}
 
 	/**
 	 * Test whether the logic has been enqueued in the `rest_api_init` hook.
 	 *
-	 * @covers \Parsely\Rest::run
+	 * @covers \Parsely\Rest_Metadata::run
 	 */
 	public function test_register_enqueued_rest_init(): void {
 		self::$rest->run();
@@ -57,7 +61,7 @@ final class RestTest extends TestCase {
 	/**
 	 * Test whether the logic has been enqueued in the `rest_api_init` hook with a filter that disables it.
 	 *
-	 * @covers \Parsely\Rest::run
+	 * @covers \Parsely\Rest_Metadata::run
 	 */
 	public function test_register_enqueued_rest_init_filter(): void {
 		add_filter( 'wp_parsely_enable_rest_api_support', '__return_false' );
@@ -68,7 +72,7 @@ final class RestTest extends TestCase {
 	/**
 	 * Test that the REST fields are registered to WordPress REST API.
 	 *
-	 * @covers \Parsely\Rest::register_meta
+	 * @covers \Parsely\Rest_Metadata::register_meta
 	 */
 	public function test_register_meta_registers_fields(): void {
 		global $wp_rest_additional_fields;
@@ -85,7 +89,7 @@ final class RestTest extends TestCase {
 	/**
 	 * Test that the REST fields are can be modified using the `wp_parsely_rest_object_types` filter.
 	 *
-	 * @covers \Parsely\Rest::register_meta
+	 * @covers \Parsely\Rest_Metadata::register_meta
 	 */
 	public function test_register_meta_with_filter(): void {
 		global $wp_rest_additional_fields;
@@ -112,7 +116,7 @@ final class RestTest extends TestCase {
 	/**
 	 * Test that the get_rest_callback method is able to generate the `parsely` object for the REST API.
 	 *
-	 * @covers \Parsely\Rest::get_callback
+	 * @covers \Parsely\Rest_Metadata::get_callback
 	 */
 	public function test_get_callback(): void {
 		self::set_options( array( 'apikey' => 'testkey' ) );
@@ -131,7 +135,7 @@ final class RestTest extends TestCase {
 	/**
 	 * Test that the get_rest_callback method does not generate metadata when there is no API key.
 	 *
-	 * @covers \Parsely\Rest::get_callback
+	 * @covers \Parsely\Rest_Metadata::get_callback
 	 */
 	public function test_get_callback_no_api_key(): void {
 		$post_id = self::factory()->post->create();
@@ -149,7 +153,7 @@ final class RestTest extends TestCase {
 	/**
 	 * Test that the get_rest_callback method is able to generate the `parsely` object for the REST API.
 	 *
-	 * @covers \Parsely\Rest::get_callback
+	 * @covers \Parsely\Rest_Metadata::get_callback
 	 */
 	public function test_get_callback_with_filter(): void {
 		add_filter( 'wp_parsely_enable_rest_rendered_support', '__return_false' );
@@ -168,7 +172,7 @@ final class RestTest extends TestCase {
 	/**
 	 * Test that the get_rest_callback method doesn't crash when the post does not exist.
 	 *
-	 * @covers \Parsely\Rest::get_callback
+	 * @covers \Parsely\Rest_Metadata::get_callback
 	 */
 	public function test_get_callback_with_non_existent_post(): void {
 		$meta_object = self::$rest->get_callback( array() );
@@ -184,7 +188,7 @@ final class RestTest extends TestCase {
 	/**
 	 * Test that the rendered meta function returns the meta HTML string with json ld.
 	 *
-	 * @covers \Parsely\Rest::get_rendered_meta
+	 * @covers \Parsely\Rest_Metadata::get_rendered_meta
 	 */
 	public function test_get_rendered_meta_json_ld(): void {
 		// Set the default options prior to each test.
@@ -212,7 +216,7 @@ final class RestTest extends TestCase {
 	/**
 	 * Test that the rendered meta function returns the meta HTML string with json ld.
 	 *
-	 * @covers \Parsely\Rest::get_rendered_meta
+	 * @covers \Parsely\Rest_Metadata::get_rendered_meta
 	 */
 	public function test_get_rendered_repeated_metas(): void {
 		// Set the default options prior to each test.

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -117,6 +117,7 @@ require __DIR__ . '/src/RemoteAPI/class-cached-proxy.php';
 require __DIR__ . '/src/RemoteAPI/class-related-proxy.php';
 require __DIR__ . '/src/RemoteAPI/class-wordpress-cache.php';
 require __DIR__ . '/src/Endpoints/class-related-api-proxy.php';
+require __DIR__ . '/src/Endpoints/class-metadata-endpoint.php';
 require __DIR__ . '/src/Endpoints/class-rest-metadata.php';
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\\rest_api_init_proxies' );

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace Parsely;
 
 use Parsely\Endpoints\Related_API_Proxy;
+use Parsely\Endpoints\Rest_Metadata;
 use Parsely\Integrations\Amp;
 use Parsely\Integrations\Facebook_Instant_Articles;
 use Parsely\Integrations\Google_Web_Stories;
@@ -50,7 +51,6 @@ const PARSELY_VERSION = '3.1.2';
 const PARSELY_FILE    = __FILE__;
 
 require __DIR__ . '/src/class-parsely.php';
-require __DIR__ . '/src/class-rest.php';
 require __DIR__ . '/src/class-scripts.php';
 require __DIR__ . '/src/class-dashboard-link.php';
 require __DIR__ . '/src/UI/class-admin-bar.php';
@@ -64,9 +64,6 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\\parsely_initialize_plugin' );
 function parsely_initialize_plugin(): void {
 	$GLOBALS['parsely'] = new Parsely();
 	$GLOBALS['parsely']->run();
-
-	$rest = new Rest( $GLOBALS['parsely'] );
-	$rest->run();
 
 	$scripts = new Scripts( $GLOBALS['parsely'] );
 	$scripts->run();
@@ -120,6 +117,7 @@ require __DIR__ . '/src/RemoteAPI/class-cached-proxy.php';
 require __DIR__ . '/src/RemoteAPI/class-related-proxy.php';
 require __DIR__ . '/src/RemoteAPI/class-wordpress-cache.php';
 require __DIR__ . '/src/Endpoints/class-related-api-proxy.php';
+require __DIR__ . '/src/Endpoints/class-rest-metadata.php';
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\\rest_api_init_proxies' );
 /**
@@ -131,6 +129,9 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\\rest_api_init_proxies' );
  * @return void
  */
 function rest_api_init_proxies(): void {
+	$rest = new Rest_Metadata( $GLOBALS['parsely'] );
+	$rest->run();
+
 	$proxy        = new Related_Proxy( $GLOBALS['parsely'] );
 	$cached_proxy = new Cached_Proxy( $proxy, new WordPress_Cache( $GLOBALS['wp_object_cache'] ) );
 	$endpoint     = new Related_API_Proxy( $GLOBALS['parsely'], $cached_proxy );

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -120,7 +120,7 @@ require __DIR__ . '/src/Endpoints/class-related-api-proxy.php';
 require __DIR__ . '/src/Endpoints/class-metadata-endpoint.php';
 require __DIR__ . '/src/Endpoints/class-rest-metadata.php';
 
-add_action( 'rest_api_init', __NAMESPACE__ . '\\rest_api_init_proxies' );
+add_action( 'rest_api_init', __NAMESPACE__ . '\\parsely_rest_api_init' );
 /**
  * Register REST Endpoints that act as a proxy to the Parse.ly API.
  * This is needed to get around a CORS issues with Firefox.
@@ -129,7 +129,7 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\\rest_api_init_proxies' );
  *
  * @return void
  */
-function rest_api_init_proxies(): void {
+function parsely_rest_api_init(): void {
 	$rest = new Rest_Metadata( $GLOBALS['parsely'] );
 	$rest->run();
 


### PR DESCRIPTION
## Description

This PR moves the `Rest` class into the `Endpoints` package. Given its generic name, the class has been renamed `Rest_Metadata` to better reflect what's doing, exposing metadata on the REST endpoint. We are also adding an abstract class for implementing metadata endpoints. We're doing this in preparation for the GraphQL work, which is going to expose the same metadata on GraphQL.

## Motivation and Context

See #190 

## How Has This Been Tested?

Go to any of the usual REST API endpoints and check that data is returned the same way. For instance, `http://localhost:8888/?rest_route=/wp/v2/posts/1`