### PR TITLE
Checking for API key existence in REST API earlier

### DIFF
--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -36,7 +36,7 @@ class Rest_Metadata extends Metadata_Endpoint {
 		 *
 		 * @param bool $enabled True if enabled, false if not.
 		 */
-		if ( apply_filters( 'wp_parsely_enable_rest_api_support', true ) ) {
+		if ( apply_filters( 'wp_parsely_enable_rest_api_support', true ) && $this->parsely->api_key_is_set() ) {
 			$this->register_meta();
 		}
 	}
@@ -53,7 +53,7 @@ class Rest_Metadata extends Metadata_Endpoint {
 		$object_types = array_unique( array_merge( $options['track_post_types'], $options['track_page_types'] ) );
 
 		/**
-		 * Filters the list of author object types that the Parse.ly REST API is hooked into.
+		 * Filters the list of object types that the Parse.ly REST API is hooked into.
 		 *
 		 * @since 3.1.0
 		 *
@@ -77,7 +77,7 @@ class Rest_Metadata extends Metadata_Endpoint {
 		$post_id = $object['ID'] ?? $object['id'] ?? 0;
 		$post    = WP_Post::get_instance( $post_id );
 
-		if ( false === $post || $this->parsely->api_key_is_missing() ) {
+		if ( false === $post ) {
 			$meta = '';
 		} else {
 			$options = $this->parsely->get_options();

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -69,6 +69,7 @@ final class RestMetadataTest extends TestCase {
 	public function test_register_enqueued_rest_init_filter(): void {
 		global $wp_rest_additional_fields;
 
+		self::set_options( array( 'apikey' => 'testkey' ) );
 		add_filter( 'wp_parsely_enable_rest_api_support', '__return_false' );
 		self::$rest->run();
 

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -62,7 +62,7 @@ final class RestMetadataTest extends TestCase {
 	}
 
 	/**
-	 * Test whether the logic has been enqueued in the when the `run` method is called with a filter that disables it.
+	 * Test whether the logic has been enqueued when the `run` method is called with a filter that disables it.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::run
 	 */

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -62,7 +62,7 @@ final class RestMetadataTest extends TestCase {
 	}
 
 	/**
-	 * Test whether the logic has been enqueued when the `run` method is called with a filter that disables it.
+	 * Verify that the logic has not been enqueued when the `run` method is called with a filter that disables it.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::run
 	 */

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -76,7 +76,7 @@ final class RestMetadataTest extends TestCase {
 	}
 
 	/**
-	 * Test whether the logic has been enqueued when the `run` method is called with no API key.
+	 * Verify that the logic has not been enqueued when the `run` method is called with no API key.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::run
 	 */

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -76,7 +76,7 @@ final class RestMetadataTest extends TestCase {
 	}
 
 	/**
-	 * Test whether the logic has been enqueued in the when the `run` method is called with no API key.
+	 * Test whether the logic has been enqueued when the `run` method is called with no API key.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::run
 	 */

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -43,7 +43,7 @@ final class RestMetadataTest extends TestCase {
 	}
 
 	/**
-	 * Test whether the logic has been enqueued in the when the `run` method is called.
+	 * Test whether the logic has been enqueued when the `run` method is called.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::run
 	 * @uses \Parsely\Endpoints\Rest_Metadata::register_meta


### PR DESCRIPTION
## Description

If the API key is not set, we don't want to return Parse.ly data on the REST API. Instead of having to check for this condition each time we render a field (which can happen multiple times in a single request), this PR moves the check at initialization time of the class.

Some tests are added to check for this condition.

## Motivation and Context

More efficient checks.

## How Has This Been Tested?

Remove the API key from your test site and try to fetch metadata from the REST API. It shouldn't appear. Then, add the key back and it should appear.