### PR TITLE
Adding GraphQL support

### DIFF
--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -222,7 +222,6 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	 * @since 3.2.0
 	 *
 	 * @param array<string, mixed> $meta Page metadata array.
-	 *
 	 * @return array<string, mixed>
 	 */
 	private function process_meta_for_graphql( array $meta ): array {

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -180,7 +180,7 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 				self::FIELD_NAME,
 				array(
 					'type'        => self::GRAPHQL_CONTAINER_TYPE,
-					'description' => 'Parse.ly metadata fields, to be rendered in the front-end so they can be parsed by the crawler. See https://www.parse.ly/help/integration/crawler.',
+					'description' => __( 'Parse.ly metadata fields, to be rendered in the front-end so they can be parsed by the crawler. See https://www.parse.ly/help/integration/crawler.', 'wp-parsely' ),
 					'resolve'     => function ( $graphql_post ) {
 						$post_id = $graphql_post->__get( 'ID' );
 						$post    = WP_Post::get_instance( $post_id );

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -170,7 +170,7 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 		$object_types = apply_filters( 'wp_parsely_graphql_object_types', $object_types );
 
 		$resolve = function ( \WPGraphQL\Model\Post $graphql_post ) {
-			$post_id = $graphql_post->__get( 'ID' );
+			$post_id = $graphql_post->ID;
 			$post    = WP_Post::get_instance( $post_id );
 
 			if ( false === $post ) {

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -180,15 +180,6 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 			$meta = $this->parsely->construct_parsely_metadata( $this->parsely->get_options(), $post );
 			$meta = $this->process_meta_for_graphql( $meta );
 
-			/**
-			 * Filters the array with the actual metadata that is exposed through GraphQL.
-			 *
-			 * @see https://wpgraphqldocs.gatsbyjs.io/functions/register_graphql_field/
-			 * @since 3.2.0
-			 *
-			 * @param array $meta Array with the fields of the new type.
-			 */
-			$meta = apply_filters( 'wp_parsely_graphql_meta_object', $meta );
 
 			return array(
 				'version'  => self::GRAPHQL_VERSION,

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -124,7 +124,7 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 				'scriptUrl'     => $this->parsely->get_tracker_url(),
 				'repeatedMetas' => self::get_rendered_meta( 'repeated_metas' ),
 				'jsonLd'        => self::get_rendered_meta( 'json_ld' ),
-				'isTracked'     => is_string( $current_object_type ) && array_key_exists( $current_object_type, $object_types ),
+				'isTracked'     => in_array( $current_object_type, $object_types, true ),
 			);
 		};
 

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -65,18 +65,22 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 		$container_type = array(
 			'description' => __( 'Parse.ly Metadata root type.', 'wp-parsely' ),
 			'fields'      => array(
-				'version'  => array(
+				'version'   => array(
 					'type'        => 'String',
 					'description' => __( 'Revision of the metadata format.', 'wp-parsely' ),
 				),
-				'metaTags' => array(
+				'scriptUrl' => array(
+					'type'        => 'String',
+					'description' => __( 'URL of the Parse.ly tracking script, specific to the site.', 'wp-parsely' ),
+				),
+				'metaTags'  => array(
 					'type'        => 'String',
 					'description' => __(
 						'HTML string containing the metadata in JSON-LD. Intended to be rendered in the front-end as is.',
 						'wp-parsely'
 					),
 				),
-				'jsonLd'   => array(
+				'jsonLd'    => array(
 					'type'        => 'String',
 					'description' => __(
 						'HTML string containing the metadata in JSON-LD. Intended to be rendered in the front-end as is.',
@@ -120,9 +124,10 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 			$meta = $this->process_meta_for_graphql( $meta );
 
 			return array(
-				'version'  => self::GRAPHQL_VERSION,
-				'metaTags' => self::get_rendered_meta( 'meta_tags' ),
-				'jsonLd'   => self::get_rendered_meta( 'json_ld' ),
+				'version'   => self::GRAPHQL_VERSION,
+				'scriptUrl' => $this->parsely->get_tracker_url(),
+				'metaTags'  => self::get_rendered_meta( 'meta_tags' ),
+				'jsonLd'    => self::get_rendered_meta( 'json_ld' ),
 			);
 		};
 

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * GraphQL support class.
+ * Note: this class will only work if the WPGraphQL plugin is installed.
+ *
+ * @package Parsely
+ * @since 3.2.0
+ */
+
+declare(strict_types=1);
+
+namespace Parsely\Endpoints;
+
+use WP_Post;
+
+/**
+ * Injects Parse.ly Metadata to the GraphQL outputs
+ *
+ * @since 3.2.0
+ */
+class GraphQL_Metadata extends Metadata_Endpoint {
+	private const GRAPHQL_VERSION          = '1.0.0';
+	private const GRAPHQL_CONTAINER_TYPE   = 'ParselyMetaContainer';
+	private const GRAPHQL_AUTHOR_TYPE      = 'ParselyAuthor';
+	private const GRAPHQL_MAIN_ENTITY_TYPE = 'ParselyMainEntityOfPage';
+	private const GRAPHQL_IMAGE_TYPE       = 'ParselyImage';
+	private const GRAPHQL_PUBLISHER_TYPE   = 'ParselyPublisher';
+	private const GRAPHQL_META_TYPE        = 'ParselyMeta';
+
+	/**
+	 * Register fields in WPGraphQL plugin
+	 *
+	 * @since 3.2.0
+	 *
+	 * @return void
+	 */
+	public function run(): void {
+		if ( class_exists( 'WPGraphQL' ) ) {
+			/**
+			 * Filter whether GraphQL support is enabled or not.
+			 *
+			 * @since 3.2.0
+			 *
+			 * @param bool $enabled True if enabled, false if not.
+			 */
+			if ( apply_filters( 'wp_parsely_enable_graphql_support', true ) && $this->parsely->api_key_is_set() ) {
+				add_action( 'graphql_register_types', array( $this, 'register_meta' ) );
+			}
+		}
+	}
+
+	/**
+	 * Registers the meta field on the appropriate resource types in the REST API.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @return void
+	 */
+	public function register_meta(): void {
+		$this->register_object_types();
+		$this->register_fields();
+	}
+
+	/**
+	 * Registers the new custom types for Parse.ly Metadata into the GraphQL instance.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @return void
+	 */
+	private function register_object_types(): void {
+		$author_type = array(
+			'description' => __( 'Parse.ly container type for author meta object.', 'wp-parsely' ),
+			'fields'      => array(
+				'name' => array( 'type' => 'String' ),
+				'type' => array( 'type' => 'String' ),
+			),
+		);
+		register_graphql_object_type( self::GRAPHQL_AUTHOR_TYPE, $author_type );
+
+		$main_entity_type = array(
+			'description' => __( 'Parse.ly container type for main entity meta object.', 'wp-parsely' ),
+			'fields'      => array(
+				'id'   => array( 'type' => 'String' ),
+				'type' => array( 'type' => 'String' ),
+			),
+		);
+		register_graphql_object_type( self::GRAPHQL_MAIN_ENTITY_TYPE, $main_entity_type );
+
+		$image_type = array(
+			'description' => __( 'Parse.ly container type for image meta object.', 'wp-parsely' ),
+			'fields'      => array(
+				'type' => array( 'type' => 'String' ),
+				'url'  => array( 'type' => 'String' ),
+			),
+		);
+		register_graphql_object_type( self::GRAPHQL_IMAGE_TYPE, $image_type );
+
+		$publisher_type = array(
+			'description' => __( 'Parse.ly container type for publisher meta object.', 'wp-parsely' ),
+			'fields'      => array(
+				'logo' => array( 'type' => 'String' ),
+				'name' => array( 'type' => 'String' ),
+				'type' => array( 'type' => 'String' ),
+			),
+		);
+		register_graphql_object_type( self::GRAPHQL_PUBLISHER_TYPE, $publisher_type );
+
+		$meta_type = array(
+			'description' => __( 'Metadata fields to be rendered in the front-end. They follow Parse.ly\'s metadata structure. See https://www.parse.ly/help/integration/category/metadata', 'wp-parsely' ),
+			'fields'      => array(
+				'articleSection'   => array( 'type' => 'String' ),
+				'author'           => array( 'type' => array( 'list_of' => self::GRAPHQL_AUTHOR_TYPE ) ),
+				'context'          => array( 'type' => 'String' ),
+				'creator'          => array( 'type' => 'String' ),
+				'headline'         => array( 'type' => 'String' ),
+				'image'            => array( 'type' => self::GRAPHQL_IMAGE_TYPE ),
+				'keywords'         => array( 'type' => array( 'list_of' => 'String' ) ),
+				'mainEntityOfPage' => array( 'type' => self::GRAPHQL_MAIN_ENTITY_TYPE ),
+				'publisher'        => array( 'type' => self::GRAPHQL_PUBLISHER_TYPE ),
+				'thumbnailUrl'     => array( 'type' => 'String' ),
+				'type'             => array( 'type' => 'String' ),
+				'url'              => array( 'type' => 'String' ),
+			),
+		);
+		/**
+		 * Filters the array for the custom type to represent metadata on GraphQL.
+		 *
+		 * @see https://wpgraphqldocs.gatsbyjs.io/functions/register_graphql_object_type/
+		 * @since 3.2.0
+		 *
+		 * @param array $meta_type Array with the fields of the new type.
+		 */
+		$meta_type = apply_filters( 'wp_parsely_graphql_meta_type', $meta_type );
+		register_graphql_object_type( self::GRAPHQL_META_TYPE, $meta_type );
+
+		$container_type = array(
+			'description' => __( 'Parse.ly Metadata root type.', 'wp-parsely' ),
+			'fields'      => array(
+				'version'  => array(
+					'type'        => 'String',
+					'description' => __( 'Revision of the metadata format.', 'wp-parsely' ),
+				),
+				'meta'     => array(
+					'type'        => 'ParselyMeta',
+					'description' => __( 'Structured and filterable metadata.', 'wp-parsely' ),
+				),
+				'rendered' => array(
+					'type'        => 'String',
+					'description' => __( 'HTML string containing the metadata. Intended to be rendered in the front-end as is.', 'wp-parsely' ),
+				),
+			),
+		);
+		register_graphql_object_type( self::GRAPHQL_CONTAINER_TYPE, $container_type );
+	}
+
+	/**
+	 * Register the custom metadata fields so they can be queried in GraphQL.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @return void
+	 */
+	private function register_fields(): void {
+		$options      = $this->parsely->get_options();
+		$object_types = array_unique( array_merge( $options['track_post_types'], $options['track_page_types'] ) );
+
+		/**
+		 * Filters the list of post object types that the Parse.ly GraphQL API is hooked into.
+		 *
+		 * @since 3.2.0
+		 *
+		 * @param string[] $object_types Array of strings containing the object types, i.e. `page`, `post`, `term`.
+		 */
+		$object_types = apply_filters( 'wp_parsely_graphql_object_types', $object_types );
+
+		foreach ( $object_types as $object_type ) {
+			$post_type_object = get_post_type_object( $object_type );
+
+			register_graphql_field(
+				$post_type_object->graphql_single_name,
+				self::FIELD_NAME,
+				array(
+					'type'        => self::GRAPHQL_CONTAINER_TYPE,
+					'description' => 'Parse.ly metadata fields, to be rendered in the front-end so they can be parsed by the crawler. See https://www.parse.ly/help/integration/crawler.',
+					'resolve'     => function ( $graphql_post ) {
+						$post_id = $graphql_post->__get( 'ID' );
+						$post    = WP_Post::get_instance( $post_id );
+
+						if ( false === $post ) {
+							return array();
+						}
+
+						$meta = $this->parsely->construct_parsely_metadata( $this->parsely->get_options(), $post );
+						$meta = $this->process_meta_for_graphql( $meta );
+
+						/**
+						 * Filters the array with the actual metadata that is exposed through GraphQL.
+						 *
+						 * @see https://wpgraphqldocs.gatsbyjs.io/functions/register_graphql_field/
+						 * @since 3.2.0
+						 *
+						 * @param array $meta Array with the fields of the new type.
+						 */
+						$meta = apply_filters( 'wp_parsely_graphql_meta_object', $meta );
+
+						return array(
+							'version'  => self::GRAPHQL_VERSION,
+							'meta'     => $meta,
+							'rendered' => self::get_rendered_meta(),
+						);
+					},
+				)
+			);
+		}
+	}
+
+	/**
+	 * Adapts an array of metadata to GraphQL. Namely, all keys with a leading `@` symbol are duplicated by the same
+	 * key without the symbol.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @param array<string, mixed> $meta Page metadata array.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function process_meta_for_graphql( array $meta ): array {
+		$meta = $this->add_type_key( $meta );
+
+		$meta['context'] = $meta['@context'];
+
+		if ( array_key_exists( 'author', $meta ) ) {
+			$meta['author'] = array_map( array( $this, 'add_type_key' ), $meta['author'] );
+		}
+
+		if ( array_key_exists( 'mainEntityofPage', $meta ) ) {
+			$meta['mainEntityOfPage'] = array(
+				'type' => $meta['mainEntityOfPage']['@type'],
+				'id'   => $meta['mainEntityOfPage']['@id'],
+			);
+		}
+
+		if ( array_key_exists( 'publisher', $meta ) ) {
+			$meta['publisher'] = $this->add_type_key( $meta['publisher'] );
+		}
+
+		return $meta;
+	}
+
+	/**
+	 * Adds the `type` key in an array, sourcing its value from `@type` if that key exists.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @param array<string, mixed> $data Some array that may or may not contain the `@type` key.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function add_type_key( array $data ): array {
+		if ( array_key_exists( '@type', $data ) ) {
+			$data['type'] = $data['@type'];
+		}
+		return $data;
+	}
+}

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -254,7 +254,6 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	 * @since 3.2.0
 	 *
 	 * @param array<string, mixed> $data Some array that may or may not contain the `@type` key.
-	 *
 	 * @return array<string, mixed>
 	 */
 	private function add_type_key( array $data ): array {

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -124,15 +124,6 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 				'url'              => array( 'type' => 'String' ),
 			),
 		);
-		/**
-		 * Filters the array for the custom type to represent metadata on GraphQL.
-		 *
-		 * @see https://wpgraphqldocs.gatsbyjs.io/functions/register_graphql_object_type/
-		 * @since 3.2.0
-		 *
-		 * @param array $meta_type Array with the fields of the new type.
-		 */
-		$meta_type = apply_filters( 'wp_parsely_graphql_meta_type', $meta_type );
 		register_graphql_object_type( self::GRAPHQL_META_TYPE, $meta_type );
 
 		$container_type = array(

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -140,9 +140,9 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 			$current_object_type = get_post_type( $post );
 
 			return array(
-				'version'       => self::GRAPHQL_VERSION,
-				'scriptUrl'     => $this->parsely->get_tracker_url(),
-				'isTracked'     => in_array( $current_object_type, $object_types, true ),
+				'version'   => self::GRAPHQL_VERSION,
+				'scriptUrl' => $this->parsely->get_tracker_url(),
+				'isTracked' => in_array( $current_object_type, $object_types, true ),
 			);
 		};
 

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -65,29 +65,29 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 		$container_type = array(
 			'description' => __( 'Parse.ly Metadata root type.', 'wp-parsely' ),
 			'fields'      => array(
-				'version'   => array(
+				'version'       => array(
 					'type'        => 'String',
 					'description' => __( 'Revision of the metadata format.', 'wp-parsely' ),
 				),
-				'scriptUrl' => array(
+				'scriptUrl'     => array(
 					'type'        => 'String',
 					'description' => __( 'URL of the Parse.ly tracking script, specific to the site.', 'wp-parsely' ),
 				),
-				'metaTags'  => array(
+				'repeatedMetas' => array(
 					'type'        => 'String',
 					'description' => __(
 						'HTML string containing the metadata in JSON-LD. Intended to be rendered in the front-end as is.',
 						'wp-parsely'
 					),
 				),
-				'jsonLd'    => array(
+				'jsonLd'        => array(
 					'type'        => 'String',
 					'description' => __(
 						'HTML string containing the metadata in JSON-LD. Intended to be rendered in the front-end as is.',
 						'wp-parsely'
 					),
 				),
-				'isTracked' => array(
+				'isTracked'     => array(
 					'type'        => 'Boolean',
 					'description' => __(
 						'Boolean indicating whether the current object\'s page type should be tracked according to user\'s settings.',
@@ -120,11 +120,11 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 			$current_object_type = get_post_type( $post );
 
 			return array(
-				'version'   => self::GRAPHQL_VERSION,
-				'scriptUrl' => $this->parsely->get_tracker_url(),
-				'metaTags'  => self::get_rendered_meta( 'meta_tags' ),
-				'jsonLd'    => self::get_rendered_meta( 'json_ld' ),
-				'isTracked' => is_string( $current_object_type ) && array_key_exists( $current_object_type, $object_types ),
+				'version'       => self::GRAPHQL_VERSION,
+				'scriptUrl'     => $this->parsely->get_tracker_url(),
+				'repeatedMetas' => self::get_rendered_meta( 'repeated_metas' ),
+				'jsonLd'        => self::get_rendered_meta( 'json_ld' ),
+				'isTracked'     => is_string( $current_object_type ) && array_key_exists( $current_object_type, $object_types ),
 			);
 		};
 

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -35,17 +35,15 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	 * @return void
 	 */
 	public function run(): void {
-		if ( class_exists( 'WPGraphQL' ) ) {
-			/**
-			 * Filter whether GraphQL support is enabled or not.
-			 *
-			 * @since 3.2.0
-			 *
-			 * @param bool $enabled True if enabled, false if not.
-			 */
-			if ( apply_filters( 'wp_parsely_enable_graphql_support', true ) && $this->parsely->api_key_is_set() ) {
-				add_action( 'graphql_register_types', array( $this, 'register_meta' ) );
-			}
+		/**
+		 * Filter whether GraphQL support is enabled or not.
+		 *
+		 * @since 3.2.0
+		 *
+		 * @param bool $enabled True if enabled, false if not.
+		 */
+		if ( apply_filters( 'wp_parsely_enable_graphql_support', true ) && $this->parsely->api_key_is_set() ) {
+			add_action( 'graphql_register_types', array( $this, 'register_meta' ) );
 		}
 	}
 

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -105,7 +105,10 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 		register_graphql_object_type( self::GRAPHQL_PUBLISHER_TYPE, $publisher_type );
 
 		$meta_type = array(
-			'description' => __( 'Metadata fields to be rendered in the front-end. They follow Parse.ly\'s metadata structure. See https://www.parse.ly/help/integration/category/metadata', 'wp-parsely' ),
+			'description' => __(
+				'Metadata fields to be rendered in the front-end. They follow Parse.ly\'s metadata structure. See https://www.parse.ly/help/integration/category/metadata',
+				'wp-parsely'
+			),
 			'fields'      => array(
 				'articleSection'   => array( 'type' => 'String' ),
 				'author'           => array( 'type' => array( 'list_of' => self::GRAPHQL_AUTHOR_TYPE ) ),
@@ -145,7 +148,10 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 				),
 				'rendered' => array(
 					'type'        => 'String',
-					'description' => __( 'HTML string containing the metadata. Intended to be rendered in the front-end as is.', 'wp-parsely' ),
+					'description' => __(
+						'HTML string containing the metadata. Intended to be rendered in the front-end as is.',
+						'wp-parsely'
+					),
 				),
 			),
 		);
@@ -202,16 +208,15 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 
 		foreach ( $object_types as $object_type ) {
 			$post_type_object = get_post_type_object( $object_type );
-
-			register_graphql_field(
-				$post_type_object->graphql_single_name,
-				self::FIELD_NAME,
-				array(
-					'type'        => self::GRAPHQL_CONTAINER_TYPE,
-					'description' => __( 'Parse.ly metadata fields, to be rendered in the front-end so they can be parsed by the crawler. See https://www.parse.ly/help/integration/crawler.', 'wp-parsely' ),
-					'resolve'     => $resolve,
-				)
+			$config           = array(
+				'type'        => self::GRAPHQL_CONTAINER_TYPE,
+				'description' => __(
+					'Parse.ly metadata fields, to be rendered in the front-end so they can be parsed by the crawler. See https://www.parse.ly/help/integration/crawler.',
+					'wp-parsely'
+				),
+				'resolve'     => $resolve,
 			);
+			register_graphql_field( $post_type_object->graphql_single_name, self::FIELD_NAME, $config );
 		}
 	}
 

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -23,7 +23,7 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	private const GRAPHQL_CONTAINER_TYPE = 'ParselyMetaContainer';
 
 	/**
-	 * Register fields in WPGraphQL plugin
+	 * Register fields in WPGraphQL plugin.
 	 *
 	 * @since 3.2.0
 	 *
@@ -43,7 +43,7 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	}
 
 	/**
-	 * Registers the meta field on the appropriate resource types in the REST API.
+	 * Register the meta field on the appropriate resource types in the REST API.
 	 *
 	 * @since 3.2.0
 	 *
@@ -55,7 +55,7 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	}
 
 	/**
-	 * Registers the new custom types for Parse.ly Metadata into the GraphQL instance.
+	 * Register the new custom types for Parse.ly Metadata into the GraphQL instance.
 	 *
 	 * @since 3.2.0
 	 *

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -180,7 +180,6 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 			$meta = $this->parsely->construct_parsely_metadata( $this->parsely->get_options(), $post );
 			$meta = $this->process_meta_for_graphql( $meta );
 
-
 			return array(
 				'version'  => self::GRAPHQL_VERSION,
 				'meta'     => $meta,

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -14,7 +14,7 @@ namespace Parsely\Endpoints;
 use WP_Post;
 
 /**
- * Injects Parse.ly Metadata to the GraphQL outputs
+ * Add Parse.ly metadata fields to the WP GraphQL server.
  *
  * @since 3.2.0
  */

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -79,13 +79,33 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 						'HTML string containing the metadata in JSON-LD. Intended to be rendered in the front-end as is.',
 						'wp-parsely'
 					),
+					'resolve'     => function() {
+						return self::get_rendered_meta( 'repeated_metas' );
+					},
 				),
 				'jsonLd'        => array(
 					'type'        => 'String',
+					'args'        => array(
+						'removeWrappingTag' => array(
+							'type'        => 'Boolean',
+							'description' => __( 'Return rendered tags without the `script` wrapping tags.', 'wp-parsely' ),
+						),
+					),
 					'description' => __(
 						'HTML string containing the metadata in JSON-LD. Intended to be rendered in the front-end as is.',
 						'wp-parsely'
 					),
+					'resolve'     => function( array $parsely_meta, array $args ) {
+						$json_ld = self::get_rendered_meta( 'json_ld' );
+
+						if ( isset( $args['removeWrappingTag'] ) && true === $args['removeWrappingTag'] ) {
+							// phpcs:ignore WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter
+							$json_ld = strip_tags( $json_ld );
+							$json_ld = trim( $json_ld );
+						}
+
+						return $json_ld;
+					},
 				),
 				'isTracked'     => array(
 					'type'        => 'Boolean',
@@ -107,42 +127,27 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	 * @return void
 	 */
 	private function register_fields(): void {
-		$resolve = function ( \WPGraphQL\Model\Post $graphql_post, array $args ) {
+		$resolve = function ( \WPGraphQL\Model\Post $graphql_post ) {
 			$post_id = $graphql_post->ID;
 			$post    = WP_Post::get_instance( $post_id );
 
 			if ( false === $post ) {
-				return array();
+				return null;
 			}
 
 			$options             = $this->parsely->get_options();
 			$object_types        = array_unique( array_merge( $options['track_post_types'], $options['track_page_types'] ) );
 			$current_object_type = get_post_type( $post );
-			$json_ld             = self::get_rendered_meta( 'json_ld' );
-
-			if ( isset( $args['removeWrappingTag'] ) && true === $args['removeWrappingTag'] ) {
-				// phpcs:ignore WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter
-				$json_ld = strip_tags( $json_ld );
-				$json_ld = trim( $json_ld );
-			}
 
 			return array(
 				'version'       => self::GRAPHQL_VERSION,
 				'scriptUrl'     => $this->parsely->get_tracker_url(),
-				'repeatedMetas' => self::get_rendered_meta( 'repeated_metas' ),
-				'jsonLd'        => $json_ld,
 				'isTracked'     => in_array( $current_object_type, $object_types, true ),
 			);
 		};
 
 		$config = array(
 			'type'        => self::GRAPHQL_CONTAINER_TYPE,
-			'args'        => array(
-				'removeWrappingTag' => array(
-					'type'        => 'Boolean',
-					'description' => __( 'Return rendered tags without the `script` wrapping tags.', 'wp-parsely' ),
-				),
-			),
 			'description' => __(
 				'Parse.ly metadata fields, to be rendered in the front-end so they can be parsed by the crawler. See https://www.parse.ly/help/integration/crawler.',
 				'wp-parsely'

--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -59,7 +59,7 @@ abstract class Metadata_Endpoint {
 	 *
 	 * @since 3.2.0
 	 *
-	 * @param string $meta_type `json_ld` or `meta_tags`.
+	 * @param string $meta_type `json_ld` or `repeated_metas`.
 	 * @return string Contains the metadata as HTML code that can be directly inserted into the page.
 	 */
 	public function get_rendered_meta( string $meta_type ): string {

--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -60,7 +60,7 @@ abstract class Metadata_Endpoint {
 	 * @since 3.2.0
 	 *
 	 * @param string $meta_type `json_ld` or `repeated_metas`.
-	 * @return string Contains the metadata as HTML code that can be directly inserted into the page.
+	 * @return string The metadata as HTML code.
 	 */
 	public function get_rendered_meta( string $meta_type ): string {
 		ob_start();

--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -65,6 +65,12 @@ abstract class Metadata_Endpoint {
 	public function get_rendered_meta( string $meta_type ): string {
 		ob_start();
 		$this->parsely->render_metadata( $meta_type );
-		return ob_get_clean();
+		$out = ob_get_clean();
+
+		if ( false === $out ) {
+			return '';
+		}
+
+		return trim( $out );
 	}
 }

--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -59,11 +59,12 @@ abstract class Metadata_Endpoint {
 	 *
 	 * @since 3.2.0
 	 *
+	 * @param string $meta_type `json_ld` or `meta_tags`.
 	 * @return string Contains the metadata as HTML code that can be directly inserted into the page.
 	 */
-	public function get_rendered_meta(): string {
+	public function get_rendered_meta( string $meta_type ): string {
 		ob_start();
-		$this->parsely->insert_page_header_metadata();
+		$this->parsely->render_metadata( $meta_type );
 		return ob_get_clean();
 	}
 }

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -76,12 +76,12 @@ class Rest_Metadata extends Metadata_Endpoint {
 	public function get_callback( array $object ): array {
 		$post_id = $object['ID'] ?? $object['id'] ?? 0;
 		$post    = WP_Post::get_instance( $post_id );
+		$options = $this->parsely->get_options();
 
 		if ( false === $post ) {
 			$meta = '';
 		} else {
-			$options = $this->parsely->get_options();
-			$meta    = $this->parsely->construct_parsely_metadata( $options, $post );
+			$meta = $this->parsely->construct_parsely_metadata( $options, $post );
 		}
 
 		$response = array(

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -97,7 +97,7 @@ class Rest_Metadata extends Metadata_Endpoint {
 		 * @param bool $enabled True if enabled, false if not.
 		 */
 		if ( apply_filters( 'wp_parsely_enable_rest_rendered_support', true, $post ) ) {
-			$response['rendered'] = $this->get_rendered_meta();
+			$response['rendered'] = $this->get_rendered_meta( $options['meta_type'] );
 		}
 
 		return $response;

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -130,6 +130,21 @@ class Parsely {
 	}
 
 	/**
+	 * Gets the full URL of the JavaScript tracker file for the site. If not api is set, returns an empty string.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @return string
+	 */
+	public function get_tracker_url(): string {
+		if ( $this->api_key_is_set() ) {
+			$tracker_url = 'https://cdn.parsely.com/keys/' . $this->get_api_key() . '/p.js';
+			return esc_url( $tracker_url );
+		}
+		return '';
+	}
+
+	/**
 	 * Actually inserts the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
 	 *
 	 * @since 3.2.0

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -149,7 +149,7 @@ class Parsely {
 	 *
 	 * @since 3.2.0
 	 *
-	 * @param string $meta_type `json_ld` or `meta_tags`.
+	 * @param string $meta_type `json_ld` or `repeated_metas`.
 	 * @return void
 	 */
 	public function render_metadata( string $meta_type ): void {

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -130,7 +130,7 @@ class Parsely {
 	}
 
 	/**
-	 * Gets the full URL of the JavaScript tracker file for the site. If not api is set, returns an empty string.
+	 * Get the full URL of the JavaScript tracker file for the site. If an API key is not set, return an empty string.
 	 *
 	 * @since 3.2.0
 	 *
@@ -145,7 +145,7 @@ class Parsely {
 	}
 
 	/**
-	 * Actually inserts the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
+	 * Insert the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
 	 *
 	 * @since 3.2.0
 	 *
@@ -154,7 +154,7 @@ class Parsely {
 	 */
 	public function render_metadata( string $meta_type ): void {
 		/**
-		 * Filters whether the Parse.ly meta tags should be inserted in the page.
+		 * Filter whether the Parse.ly meta tags should be inserted in the page.
 		 *
 		 * By default, the tags are inserted.
 		 *
@@ -237,7 +237,7 @@ class Parsely {
 	}
 
 	/**
-	 * Actually inserts the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
+	 * Insert the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
 	 *
 	 * @since 3.0.0
 	 *
@@ -249,7 +249,7 @@ class Parsely {
 	}
 
 	/**
-	 * Deprecated. Echoes the metadata into the page, and returns the inserted values.
+	 * Deprecated. Echo the metadata into the page, and return the inserted values.
 	 *
 	 * To just echo the metadata, use the `insert_page_header_metadata()` method.
 	 * To get the metadata to be inserted, use the `construct_parsely_metadata()` method.
@@ -274,12 +274,12 @@ class Parsely {
 	}
 
 	/**
-	 * Function to be used in `array_filter` to clean up repeated metas
+	 * Function to be used in `array_filter` to clean up repeated metas.
 	 *
 	 * @since 2.6.0
 	 *
 	 * @param mixed $var Value to filter from the array.
-	 * @return bool Returns true if the variable is not empty, and it's a string
+	 * @return bool True if the variable is not empty, and it's a string.
 	 */
 	private static function filter_empty_and_not_string_from_array( $var ): bool {
 		return is_string( $var ) && '' !== $var;

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -132,11 +132,12 @@ class Parsely {
 	/**
 	 * Actually inserts the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
 	 *
-	 * @since 3.0.0
+	 * @since 3.2.0
 	 *
+	 * @param string $meta_type `json_ld` or `meta_tags`.
 	 * @return void
 	 */
-	public function insert_page_header_metadata(): void {
+	public function render_metadata( string $meta_type ): void {
 		/**
 		 * Filters whether the Parse.ly meta tags should be inserted in the page.
 		 *
@@ -170,10 +171,6 @@ class Parsely {
 		global $post;
 
 		// We can't construct the metadata without a valid post object.
-		if ( empty( $post ) ) {
-			return;
-		}
-
 		$parsed_post = get_post( $post );
 		if ( ! $parsed_post instanceof WP_Post ) {
 			return;
@@ -184,12 +181,12 @@ class Parsely {
 		$parsely_page = $this->construct_parsely_metadata( $parsely_options, $parsed_post );
 
 		// Something went wrong - abort.
-		if ( empty( $parsely_page ) || ! isset( $parsely_page['headline'] ) ) {
+		if ( 0 === count( $parsely_page ) || ! isset( $parsely_page['headline'] ) ) {
 			return;
 		}
 
 		// Insert JSON-LD or repeated metas.
-		if ( 'json_ld' === $parsely_options['meta_type'] ) {
+		if ( 'json_ld' === $meta_type ) {
 			include plugin_dir_path( PARSELY_FILE ) . 'views/json-ld.php';
 		} else {
 			// Assume `meta_type` is `repeated_metas`.
@@ -225,6 +222,18 @@ class Parsely {
 	}
 
 	/**
+	 * Actually inserts the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return void
+	 */
+	public function insert_page_header_metadata(): void {
+		$parsely_options = $this->get_options();
+		$this->render_metadata( $parsely_options['meta_type'] );
+	}
+
+	/**
 	 * Deprecated. Echoes the metadata into the page, and returns the inserted values.
 	 *
 	 * To just echo the metadata, use the `insert_page_header_metadata()` method.
@@ -252,11 +261,13 @@ class Parsely {
 	/**
 	 * Function to be used in `array_filter` to clean up repeated metas
 	 *
+	 * @since 2.6.0
+	 *
 	 * @param mixed $var Value to filter from the array.
 	 * @return bool Returns true if the variable is not empty, and it's a string
 	 */
 	private static function filter_empty_and_not_string_from_array( $var ): bool {
-		return ! empty( $var ) && is_string( $var );
+		return is_string( $var ) && '' !== $var;
 	}
 
 	/**
@@ -1049,13 +1060,14 @@ class Parsely {
 	 * Otherwise, for "non-posts" and unknown types, "index" is returned.
 	 *
 	 * @since 2.5.0
+	 * @since 3.2.0 Moved to private method.
 	 *
 	 * @see https://www.parse.ly/help/integration/metatags#field-description
 	 *
 	 * @param string $type JSON-LD type.
 	 * @return string "post" or "index".
 	 */
-	public function convert_jsonld_to_parsely_type( string $type ): string {
+	private function convert_jsonld_to_parsely_type( string $type ): string {
 		return in_array( $type, $this->supported_jsonld_post_types, true ) ? 'post' : 'index';
 	}
 

--- a/src/class-scripts.php
+++ b/src/class-scripts.php
@@ -57,11 +57,9 @@ class Scripts {
 	 * @return void
 	 */
 	public function register_scripts(): void {
-		$tracker_url = 'https://cdn.parsely.com/keys/' . $this->parsely->get_api_key() . '/p.js';
-		$tracker_url = esc_url( $tracker_url );
 		wp_register_script(
 			'wp-parsely-tracker',
-			$tracker_url,
+			$this->parsely->get_tracker_url(),
 			array(),
 			PARSELY_VERSION,
 			true

--- a/tests/Integration/Endpoints/GraphQLMetadataTest.php
+++ b/tests/Integration/Endpoints/GraphQLMetadataTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely GraphQL Metadata tests.
+ * Parse.ly GraphQL Metadata tests.
  *
  * @package Parsely\Tests
  */
@@ -32,7 +32,7 @@ final class GraphQLMetadataTest extends TestCase {
 	private static $parsely;
 
 	/**
-	 * The setUp run before each test
+	 * The setup run before each test.
 	 */
 	public function set_up(): void {
 		parent::set_up();

--- a/tests/Integration/Endpoints/GraphQLMetadataTest.php
+++ b/tests/Integration/Endpoints/GraphQLMetadataTest.php
@@ -18,16 +18,6 @@ use Parsely\Tests\Integration\TestCase;
  */
 final class GraphQLMetadataTest extends TestCase {
 	/**
-	 * Stores
-	 *
-	 * @var array<string, mixed> $call_history
-	 */
-	public static $call_history = array(
-		'register_graphql_object_type' => false,
-		'register_graphql_field'       => false,
-	);
-
-	/**
 	 * Internal variable
 	 *
 	 * @var GraphQL_Metadata $graphql Holds the GraphQL object
@@ -91,66 +81,4 @@ final class GraphQLMetadataTest extends TestCase {
 		self::$graphql->run();
 		self::assertFalse( has_filter( 'graphql_register_types', array( self::$graphql, 'register_meta' ) ) );
 	}
-
-	/**
-	 * Tests if the functions to register items into GraphQL have been called.
-	 *
-	 * @since 3.2.0
-	 *
-	 * @covers \Parsely\Endpoints\GraphQL_Metadata::register_meta
-	 * @uses \Parsely\Endpoints\GraphQL_Metadata::register_object_types()
-	 * @uses \Parsely\Endpoints\GraphQL_Metadata::register_fields()
-	 */
-	public function test_graphql_registers_types(): void {
-		self::$graphql->register_meta();
-
-		self::assertEquals( 'ParselyMetaContainer', self::$call_history['register_graphql_object_type']['type_name'] );
-		self::assertEquals( 'ContentNode', self::$call_history['register_graphql_field']['type_name'] );
-		self::assertEquals( 'parsely', self::$call_history['register_graphql_field']['field_name'] );
-
-		self::$call_history['register_graphql_object_type'] = false;
-		self::$call_history['register_graphql_field']       = false;
-	}
-}
-
-
-/**
- * Mock WPGraphQL functions. The plugin is not installed by default with wp-parsely.
- */
-namespace Parsely\Endpoints;
-
-/**
- * Mock function.
- *
- * @see https://wpgraphqldocs.gatsbyjs.io/functions/register_graphql_object_type/
- *
- * @param string $type_name The name of the Type. This must be unique across all Types of any kind in the GraphQL Schema.
- * @param array  $config Configuration for the field.
- *
- * @return void
- */
-function register_graphql_object_type( string $type_name, array $config ) {
-	\Parsely\Tests\Integration\Endpoints\GraphQLMetadataTest::$call_history['register_graphql_object_type'] = array(
-		'type_name' => $type_name,
-		'config'    => $config,
-	);
-}
-
-/**
- * Mock function.
- *
- * @see https://wpgraphqldocs.gatsbyjs.io/functions/register_graphql_field/
- *
- * @param string $type_name The name of the GraphQL Type in the Schema to register the field to.
- * @param string $field_name The name of the field. Should be unique to the Type the field is being registered to.
- * @param array  $config Configuration for the field.
- *
- * @return void
- */
-function register_graphql_field( string $type_name, string $field_name, array $config ): void {
-	\Parsely\Tests\Integration\Endpoints\GraphQLMetadataTest::$call_history['register_graphql_field'] = array(
-		'type_name'  => $type_name,
-		'field_name' => $field_name,
-		'config'     => $config,
-	);
 }

--- a/tests/Integration/Endpoints/GraphQLMetadataTest.php
+++ b/tests/Integration/Endpoints/GraphQLMetadataTest.php
@@ -18,6 +18,16 @@ use Parsely\Tests\Integration\TestCase;
  */
 final class GraphQLMetadataTest extends TestCase {
 	/**
+	 * Stores
+	 *
+	 * @var array<string, mixed> $call_history
+	 */
+	public static $call_history = array(
+		'register_graphql_object_type' => false,
+		'register_graphql_field'       => false,
+	);
+
+	/**
 	 * Internal variable
 	 *
 	 * @var GraphQL_Metadata $graphql Holds the GraphQL object
@@ -81,4 +91,66 @@ final class GraphQLMetadataTest extends TestCase {
 		self::$graphql->run();
 		self::assertFalse( has_filter( 'graphql_register_types', array( self::$graphql, 'register_meta' ) ) );
 	}
+
+	/**
+	 * Tests if the functions to register items into GraphQL have been called.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @covers \Parsely\Endpoints\GraphQL_Metadata::register_meta
+	 * @uses \Parsely\Endpoints\GraphQL_Metadata::register_object_types()
+	 * @uses \Parsely\Endpoints\GraphQL_Metadata::register_fields()
+	 */
+	public function test_graphql_registers_types(): void {
+		self::$graphql->register_meta();
+
+		self::assertEquals( 'ParselyMetaContainer', self::$call_history['register_graphql_object_type']['type_name'] );
+		self::assertEquals( 'ContentNode', self::$call_history['register_graphql_field']['type_name'] );
+		self::assertEquals( 'parsely', self::$call_history['register_graphql_field']['field_name'] );
+
+		self::$call_history['register_graphql_object_type'] = false;
+		self::$call_history['register_graphql_field']       = false;
+	}
+}
+
+
+/**
+ * Mock WPGraphQL functions. The plugin is not installed by default with wp-parsely.
+ */
+namespace Parsely\Endpoints;
+
+/**
+ * Mock function.
+ *
+ * @see https://wpgraphqldocs.gatsbyjs.io/functions/register_graphql_object_type/
+ *
+ * @param string $type_name The name of the Type. This must be unique across all Types of any kind in the GraphQL Schema.
+ * @param array  $config Configuration for the field.
+ *
+ * @return void
+ */
+function register_graphql_object_type( string $type_name, array $config ) {
+	\Parsely\Tests\Integration\Endpoints\GraphQLMetadataTest::$call_history['register_graphql_object_type'] = array(
+		'type_name' => $type_name,
+		'config'    => $config,
+	);
+}
+
+/**
+ * Mock function.
+ *
+ * @see https://wpgraphqldocs.gatsbyjs.io/functions/register_graphql_field/
+ *
+ * @param string $type_name The name of the GraphQL Type in the Schema to register the field to.
+ * @param string $field_name The name of the field. Should be unique to the Type the field is being registered to.
+ * @param array  $config Configuration for the field.
+ *
+ * @return void
+ */
+function register_graphql_field( string $type_name, string $field_name, array $config ): void {
+	\Parsely\Tests\Integration\Endpoints\GraphQLMetadataTest::$call_history['register_graphql_field'] = array(
+		'type_name'  => $type_name,
+		'field_name' => $field_name,
+		'config'     => $config,
+	);
 }

--- a/tests/Integration/Endpoints/GraphQLMetadataTest.php
+++ b/tests/Integration/Endpoints/GraphQLMetadataTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Parsely GraphQL Metadata tests.
+ *
+ * @package Parsely\Tests
+ */
+
+declare(strict_types=1);
+
+namespace Parsely\Tests\Integration\Endpoints;
+
+use Parsely\Parsely;
+use Parsely\Endpoints\GraphQL_Metadata;
+use Parsely\Tests\Integration\TestCase;
+
+/**
+ * Parse.ly GraphQL Metadata tests.
+ */
+final class GraphQLMetadataTest extends TestCase {
+	/**
+	 * Internal variable
+	 *
+	 * @var GraphQL_Metadata $graphql Holds the GraphQL object
+	 */
+	private static $graphql;
+
+	/**
+	 * Internal Parsely variable
+	 *
+	 * @var Parsely $parsely Holds the Parsely object
+	 */
+	private static $parsely;
+
+	/**
+	 * The setUp run before each test
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		self::$parsely = new Parsely();
+		self::$graphql = new GraphQL_Metadata( self::$parsely );
+	}
+
+	/**
+	 * Test that GraphQL types are set to be registered if there's an API key defined.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @covers \Parsely\Endpoints\GraphQL_Metadata::run
+	 */
+	public function test_graphql_enqueued(): void {
+		self::set_options( array( 'apikey' => 'testkey' ) );
+
+		self::$graphql->run();
+		self::assertEquals( 10, has_filter( 'graphql_register_types', array( self::$graphql, 'register_meta' ) ) );
+	}
+
+	/**
+	 * Test that GraphQL types are not registered if there's a filter.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @covers \Parsely\Endpoints\GraphQL_Metadata::run
+	 */
+	public function test_graphql_enqueued_filter(): void {
+		self::set_options( array( 'apikey' => 'testkey' ) );
+		add_filter( 'wp_parsely_enable_graphql_support', '__return_false' );
+
+		self::$graphql->run();
+		self::assertFalse( has_filter( 'graphql_register_types', array( self::$graphql, 'register_meta' ) ) );
+	}
+
+	/**
+	 * Test that GraphQL types are not registered if there's no API key.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @covers \Parsely\Endpoints\GraphQL_Metadata::run
+	 */
+	public function test_graphql_enqueued_no_api_key(): void {
+		self::$graphql->run();
+		self::assertFalse( has_filter( 'graphql_register_types', array( self::$graphql, 'register_meta' ) ) );
+	}
+}

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -212,8 +212,7 @@ final class RestMetadataTest extends TestCase {
 		$meta_string = self::$rest->get_rendered_meta( 'json_ld' );
 		$expected    = '<script type="application/ld+json">
 {"@context":"http:\/\/schema.org","@type":"NewsArticle","mainEntityOfPage":{"@type":"WebPage","@id":"http:\/\/example.org\/?p=' . $post_id . '"},"headline":"My test_get_rendered_meta_json_ld title","url":"http:\/\/example.org\/?p=' . $post_id . '","thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"dateCreated":"' . $date . '","datePublished":"' . $date . '","dateModified":"' . $date . '","articleSection":"Uncategorized","author":[],"creator":[],"publisher":{"@type":"Organization","name":"Test Blog","logo":""},"keywords":[]}
-</script>
-';
+</script>';
 		self::assertEquals( $expected, $meta_string );
 	}
 
@@ -242,8 +241,7 @@ final class RestMetadataTest extends TestCase {
 <meta name="parsely-link" content="http://example.org/?p=' . $post_id . '" />
 <meta name="parsely-type" content="post" />
 <meta name="parsely-pub-date" content="' . $date . '" />
-<meta name="parsely-section" content="Uncategorized" />
-';
+<meta name="parsely-section" content="Uncategorized" />';
 		self::assertEquals( $expected, $meta_string );
 	}
 

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely REST API tests.
+ * Parsely REST API Metadata tests.
  *
  * @package Parsely\Tests
  */
@@ -15,7 +15,7 @@ use Parsely\Tests\Integration\TestCase;
 
 
 /**
- * Parsely REST API tests.
+ * Parsely REST API Metadata tests.
  */
 final class RestMetadataTest extends TestCase {
 	/**

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -146,7 +146,7 @@ final class RestMetadataTest extends TestCase {
 		$expected    = array(
 			'version'  => '1.0.0',
 			'meta'     => self::$parsely->construct_parsely_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
-			'rendered' => self::$rest->get_rendered_meta(),
+			'rendered' => self::$rest->get_rendered_meta( 'json_ld' ),
 		);
 
 		self::assertEquals( $expected, $meta_object );
@@ -209,7 +209,7 @@ final class RestMetadataTest extends TestCase {
 		$post = get_post( $post_id );
 		$date = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );
 
-		$meta_string = self::$rest->get_rendered_meta();
+		$meta_string = self::$rest->get_rendered_meta( 'json_ld' );
 		$expected    = '<script type="application/ld+json">
 {"@context":"http:\/\/schema.org","@type":"NewsArticle","mainEntityOfPage":{"@type":"WebPage","@id":"http:\/\/example.org\/?p=' . $post_id . '"},"headline":"My test_get_rendered_meta_json_ld title","url":"http:\/\/example.org\/?p=' . $post_id . '","thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"dateCreated":"' . $date . '","datePublished":"' . $date . '","dateModified":"' . $date . '","articleSection":"Uncategorized","author":[],"creator":[],"publisher":{"@type":"Organization","name":"Test Blog","logo":""},"keywords":[]}
 </script>
@@ -223,12 +223,10 @@ final class RestMetadataTest extends TestCase {
 	 * @covers \Parsely\Endpoints\Rest_Metadata::get_rendered_meta
 	 */
 	public function test_get_rendered_repeated_metas(): void {
-		// Set the default options prior to each test.
-		TestCase::set_options(
-			array( 'meta_type' => 'repeated_metas' )
-		);
-
 		global $post;
+
+		self::set_options( array( 'apikey' => 'testkey' ) );
+
 		$post_id = self::factory()->post->create(
 			array(
 				'post_title' => 'My test_get_rendered_repeated_metas title',
@@ -239,7 +237,7 @@ final class RestMetadataTest extends TestCase {
 		$post = get_post( $post_id );
 		$date = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );
 
-		$meta_string = self::$rest->get_rendered_meta();
+		$meta_string = self::$rest->get_rendered_meta( 'repeated_metas' );
 		$expected    = '<meta name="parsely-title" content="My test_get_rendered_repeated_metas title" />
 <meta name="parsely-link" content="http://example.org/?p=' . $post_id . '" />
 <meta name="parsely-type" content="post" />

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -247,7 +247,7 @@ final class OtherTest extends TestCase {
 	}
 
 	/**
-	 * Tests if the tracker URL is correctly generated with a set API key.
+	 * Test if the tracker URL is correctly generated with a set API key.
 	 *
 	 * @since 3.2.0
 	 *
@@ -259,7 +259,7 @@ final class OtherTest extends TestCase {
 	}
 
 	/**
-	 * Tests if the tracker URL is an empty string when there's no API key.
+	 * Test if the tracker URL is an empty string when there's no API key.
 	 *
 	 * @since 3.2.0
 	 *

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -19,7 +19,7 @@ final class OtherTest extends TestCase {
 	/**
 	 * Internal variables
 	 *
-	 * @var string $parsely Holds the Parsely object.
+	 * @var Parsely $parsely Holds the Parsely object.
 	 */
 	private static $parsely;
 
@@ -244,5 +244,30 @@ final class OtherTest extends TestCase {
 
 		$result = Parsely::post_has_trackable_status( $post );
 		self::assertTrue( $result );
+	}
+
+	/**
+	 * Tests if the tracker URL is correctly generated with a set API key.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @covers \Parsely\Parsely::get_tracker_url
+	 */
+	public function test_get_tracker_url(): void {
+		$expected = 'https://cdn.parsely.com/keys/blog.parsely.com/p.js';
+		self::assertEquals( $expected, self::$parsely->get_tracker_url() );
+	}
+
+	/**
+	 * Tests if the tracker URL is an empty string when there's no API key.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @covers \Parsely\Parsely::get_tracker_url
+	 */
+	public function test_get_tracker_no_api_key(): void {
+		self::set_options( array( 'apikey' => '' ) );
+		$expected = '';
+		self::assertEquals( $expected, self::$parsely->get_tracker_url() );
 	}
 }

--- a/tests/Unit/Endpoints/GraphQLMetadataTest.php
+++ b/tests/Unit/Endpoints/GraphQLMetadataTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Parsely GraphQL Metadata tests.
+ *
+ * @package Parsely\Tests
+ */
+
+declare(strict_types=1);
+
+namespace Parsely\Tests\Unit\Endpoints;
+
+use Mockery;
+use Parsely\Parsely;
+use Parsely\Endpoints\GraphQL_Metadata;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use Brain\Monkey\Functions;
+
+/**
+ * Parse.ly GraphQL Metadata tests.
+ */
+final class GraphQLMetadataTest extends TestCase {
+	/**
+	 * Internal variable
+	 *
+	 * @var GraphQL_Metadata $graphql Holds the GraphQL object
+	 */
+	private static $graphql;
+
+	/**
+	 * Internal Parsely variable
+	 *
+	 * @var Parsely $parsely Holds the Parsely object
+	 */
+	private static $parsely;
+
+	/**
+	 * The setUp run before each test
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		self::$parsely = new Parsely();
+		self::$graphql = new GraphQL_Metadata( self::$parsely );
+	}
+
+	/**
+	 * Tests if the functions to register items into GraphQL have been called.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @covers \Parsely\Endpoints\GraphQL_Metadata::register_meta
+	 */
+	public function test_graphql_registers_types(): void {
+		// Arrange.
+		Functions\when( '__' )->returnArg( 1 );
+
+		// Assert (set expectations).
+		Functions\expect( 'register_graphql_object_type' )
+			->once()
+			->with( 'ParselyMetaContainer', Mockery::type( 'array' ) );
+		Functions\expect( 'register_graphql_field' )
+			->once()
+			->with( 'ContentNode', 'parsely', Mockery::type( 'array' ) );
+
+		// Act.
+		self::$graphql->register_meta();
+	}
+}

--- a/tests/Unit/Endpoints/GraphQLMetadataTest.php
+++ b/tests/Unit/Endpoints/GraphQLMetadataTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely GraphQL Metadata tests.
+ * Parse.ly GraphQL Metadata tests.
  *
  * @package Parsely\Tests
  */
@@ -34,7 +34,7 @@ final class GraphQLMetadataTest extends TestCase {
 	private static $parsely;
 
 	/**
-	 * The setUp run before each test
+	 * The setup run before each test.
 	 */
 	public function set_up(): void {
 		parent::set_up();
@@ -44,7 +44,7 @@ final class GraphQLMetadataTest extends TestCase {
 	}
 
 	/**
-	 * Tests if the functions to register items into GraphQL have been called.
+	 * Test if the functions to register items into GraphQL have been called.
 	 *
 	 * @since 3.2.0
 	 *

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -7,10 +7,18 @@
 
 declare(strict_types=1);
 
-namespace Parsely\Tests\Unit;
+namespace Parsely\Tests\Unit {
 
-/**
- * Require BrainMonkey files and autoload the plugin code.
- */
-require_once dirname( __DIR__ ) . '/../vendor/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';
-require_once dirname( __DIR__ ) . '/../vendor/autoload.php';
+	/**
+	 * Require BrainMonkey files and autoload the plugin code.
+	 */
+	require_once dirname( __DIR__ ) . '/../vendor/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';
+	require_once dirname( __DIR__ ) . '/../vendor/autoload.php';
+
+}
+
+// Plugin root file is not included during tests, so define the namespaced constants here.
+namespace Parsely {
+	const PARSELY_VERSION = '123456.78.9';
+	const PARSELY_FILE    = __DIR__ . '/../../wp-parsely.php';
+}

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -68,8 +68,10 @@ function parsely_initialize_plugin(): void {
 	$GLOBALS['parsely'] = new Parsely();
 	$GLOBALS['parsely']->run();
 
-	$graphql = new GraphQL_Metadata( $GLOBALS['parsely'] );
-	$graphql->run();
+	if ( class_exists( 'WPGraphQL' ) ) {
+		$graphql = new GraphQL_Metadata( $GLOBALS['parsely'] );
+		$graphql->run();
+	}
 
 	$scripts = new Scripts( $GLOBALS['parsely'] );
 	$scripts->run();

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace Parsely;
 
 use Parsely\Endpoints\Related_API_Proxy;
+use Parsely\Endpoints\GraphQL_Metadata;
 use Parsely\Endpoints\Rest_Metadata;
 use Parsely\Integrations\Amp;
 use Parsely\Integrations\Facebook_Instant_Articles;
@@ -54,6 +55,8 @@ require __DIR__ . '/src/class-parsely.php';
 require __DIR__ . '/src/class-scripts.php';
 require __DIR__ . '/src/class-dashboard-link.php';
 require __DIR__ . '/src/UI/class-admin-bar.php';
+require __DIR__ . '/src/Endpoints/class-metadata-endpoint.php';
+require __DIR__ . '/src/Endpoints/class-graphql-metadata.php';
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\parsely_initialize_plugin' );
 /**
@@ -64,6 +67,9 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\\parsely_initialize_plugin' );
 function parsely_initialize_plugin(): void {
 	$GLOBALS['parsely'] = new Parsely();
 	$GLOBALS['parsely']->run();
+
+	$graphql = new GraphQL_Metadata( $GLOBALS['parsely'] );
+	$graphql->run();
 
 	$scripts = new Scripts( $GLOBALS['parsely'] );
 	$scripts->run();
@@ -117,7 +123,6 @@ require __DIR__ . '/src/RemoteAPI/class-cached-proxy.php';
 require __DIR__ . '/src/RemoteAPI/class-related-proxy.php';
 require __DIR__ . '/src/RemoteAPI/class-wordpress-cache.php';
 require __DIR__ . '/src/Endpoints/class-related-api-proxy.php';
-require __DIR__ . '/src/Endpoints/class-metadata-endpoint.php';
 require __DIR__ . '/src/Endpoints/class-rest-metadata.php';
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\\parsely_rest_api_init' );


### PR DESCRIPTION
## Description

This PR adds GraphQL support to output metadata. We are doing so by extending the WPGraphQL plugin (thus, it is a requirement that it is installed). If it's not installed, wp-parsely will continue to work normally but without GraphQL support.

Since GraphQL is strongly typed, we have had to define the types of our metadata. Therefore, in this change we're registering a number of custom types that support our metadata (see screenshots). Then, we are registering the `parsely` field in all fields that should be tracked (added by the user).

In this implementation, we've also added a few filters so user can build on top of our default support.

## Motivation and Context

Closes #190 

## How Has This Been Tested?

1. Install WPGraphQL plugin.
2. Make sure wp-parsely is enabled and with an API key.
3. Perform queries on GraphiQL in wp-admin (see screenshots for examples).

## Screenshots (if appropriate)

<img width="406" alt="Screen Shot 2022-03-09 at 12 15 20 PM" src="https://user-images.githubusercontent.com/7188409/157431042-4a33828c-ddf4-42fb-8472-ddab72d9b062.png">

<img width="389" alt="Screen Shot 2022-03-09 at 12 18 59 PM" src="https://user-images.githubusercontent.com/7188409/157431552-11512dc7-d189-4985-8f7d-135f950352d5.png">

<img width="1656" alt="Screen Shot 2022-03-09 at 12 18 19 PM" src="https://user-images.githubusercontent.com/7188409/157431455-36e74e1c-f86e-491d-a46d-afec53ca774d.png">