### PR TITLE
Improving type support on categories metadata

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -668,7 +668,7 @@ class Parsely {
 	 *
 	 * @param int    $post_id The id of the post you're trying to get categories for.
 	 * @param string $delimiter What character will delimit the categories.
-	 * @return string[] All the child categories of the current post.
+	 * @return array<string> All the child categories of the current post.
 	 */
 	private function get_categories( int $post_id, string $delimiter = '/' ): array {
 		$tags = array();

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -804,7 +804,7 @@ class Parsely {
 	 * Get all term values from custom taxonomies.
 	 *
 	 * @param WP_Post $post_obj The post object.
-	 * @return string[]
+	 * @return array<string>
 	 */
 	private function get_custom_taxonomy_values( WP_Post $post_obj ): array {
 		// filter out default WordPress taxonomies.

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -382,7 +382,7 @@ class Parsely {
 			if ( $parsely_options['cats_as_tags'] ) {
 				$tags = array_merge( $tags, $this->get_categories( $post->ID ) );
 				// add custom taxonomy values.
-				$tags = array_merge( $tags, $this->get_custom_taxonomy_values( $post, $parsely_options ) );
+				$tags = array_merge( $tags, $this->get_custom_taxonomy_values( $post ) );
 			}
 			// the function 'mb_strtolower' is not enabled by default in php, so this check
 			// falls back to the native php function 'strtolower' if necessary.
@@ -668,7 +668,7 @@ class Parsely {
 	 *
 	 * @param int    $post_id The id of the post you're trying to get categories for.
 	 * @param string $delimiter What character will delimit the categories.
-	 * @return array All the child categories of the current post.
+	 * @return string[] All the child categories of the current post.
 	 */
 	private function get_categories( int $post_id, string $delimiter = '/' ): array {
 		$tags = array();
@@ -681,7 +681,7 @@ class Parsely {
 		// take last element in the hierarchy, a string representing the full parent->child tree,
 		// and split it into individual category names.
 		$last_tag = end( $tags );
-		if ( $last_tag ) {
+		if ( false !== $last_tag ) {
 			$tags = explode( '/', $last_tag );
 		}
 
@@ -804,24 +804,22 @@ class Parsely {
 	 * Get all term values from custom taxonomies.
 	 *
 	 * @param WP_Post $post_obj The post object.
-	 * @param array   $parsely_options Unused? The parsely options.
-	 * @return array
+	 * @return string[]
 	 */
-	private function get_custom_taxonomy_values( WP_Post $post_obj, array $parsely_options ): array {
+	private function get_custom_taxonomy_values( WP_Post $post_obj ): array {
 		// filter out default WordPress taxonomies.
 		$all_taxonomies = array_diff( get_taxonomies(), array( 'post_tag', 'nav_menu', 'author', 'link_category', 'post_format' ) );
 		$all_values     = array();
 
-		if ( is_array( $all_taxonomies ) ) {
-			foreach ( $all_taxonomies as $taxonomy ) {
-				$custom_taxonomy_objects = get_the_terms( $post_obj->ID, $taxonomy );
-				if ( is_array( $custom_taxonomy_objects ) ) {
-					foreach ( $custom_taxonomy_objects as $custom_taxonomy_object ) {
-						array_push( $all_values, $custom_taxonomy_object->name );
-					}
+		foreach ( $all_taxonomies as $taxonomy ) {
+			$custom_taxonomy_objects = get_the_terms( $post_obj->ID, $taxonomy );
+			if ( is_array( $custom_taxonomy_objects ) ) {
+				foreach ( $custom_taxonomy_objects as $custom_taxonomy_object ) {
+					$all_values[] = $custom_taxonomy_object->name;
 				}
 			}
 		}
+
 		return $all_values;
 	}
 


### PR DESCRIPTION
## Description

This PR improves the type safety on two private functions we use to generate categories metadata in `class-parsely.php`.  Specifically, we are getting rid of an unused parameter and we're fixing some PHPStan issues by making type definitions stricter.

## Motivation and Context

More predictable code behavior through stricter types.

## How Has This Been Tested?

Enable categories as tags in Parse.ly wp-admin. Check that categories get rendered correctly as metadata.