### PR TITLE
Remove phased-out boost parameters from Recommended Widget

### DIFF
--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -278,7 +278,7 @@ final class Recommended_Widget extends WP_Widget {
 	 *
 	 * @since 2.5.0
 	 *
-	 * @return array Boost parameters values and labels.
+	 * @return array<string, string> Boost parameters values and labels.
 	 */
 	private function get_boost_params(): array {
 		return array(

--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -297,12 +297,10 @@ final class Recommended_Widget extends WP_Widget {
 			'social_interactions'   => __( 'Total for Facebook, Twitter, LinkedIn, and Pinterest', 'wp-parsely' ),
 			'fb_interactions'       => __( 'Count of Facebook shares, likes, and comments', 'wp-parsely' ),
 			'tw_interactions'       => __( 'Count of Twitter tweets and retweets', 'wp-parsely' ),
-			'li_interactions'       => __( 'Count of LinkedIn social interactions', 'wp-parsely' ),
 			'pi_interactions'       => __( 'Count of Pinterest pins', 'wp-parsely' ),
 			'social_referrals'      => __( 'Page views where the referrer was any social network', 'wp-parsely' ),
 			'fb_referrals'          => __( 'Page views where the referrer was facebook.com', 'wp-parsely' ),
 			'tw_referrals'          => __( 'Page views where the referrer was twitter.com', 'wp-parsely' ),
-			'li_referrals'          => __( 'Page views where the referrer was linkedin.com', 'wp-parsely' ),
 			'pi_referrals'          => __( 'Page views where the referrer was pinterest.com', 'wp-parsely' ),
 		);
 	}


### PR DESCRIPTION
## Description
We've been informed that the `li_interactions` and `li_referrals` boost parameters have been phased-out and are now unsupported. This PR removes these parameters from the Recommended Widget.

## Motivation and Context
Avoid unexpected/buggy behavior and not showing outdated options to plugin users.

## How Has This Been Tested?
Automated tests pass.