### PR TITLE
Moving metadata generation to external class

### DIFF
--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -1,0 +1,632 @@
+<?php
+/**
+ * Metadata class
+ *
+ * @package Parsely
+ * @since 3.3.0
+ */
+
+declare(strict_types=1);
+
+namespace Parsely;
+
+use WP_User;
+use WP_Post;
+
+/**
+ * Generates and inserts metadata readable by the Parse.ly Crawler.
+ *
+ * @since 1.0.0
+ * @since 3.3.0 Moved from class-parsely to separate file
+ */
+class Metadata {
+	/**
+	 * Instance of Parsely class.
+	 *
+	 * @var Parsely
+	 */
+	private $parsely;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Parsely $parsely Instance of Parsely class.
+	 */
+	public function __construct( Parsely $parsely ) {
+		$this->parsely = $parsely;
+	}
+
+	/**
+	 * Creates parsely metadata object from post metadata.
+	 *
+	 * @param array<string, mixed> $parsely_options parsely_options array.
+	 * @param WP_Post              $post object.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function construct_metadata( array $parsely_options, WP_Post $post ): array {
+		$parsely_page      = array(
+			'@context' => 'http://schema.org',
+			'@type'    => 'WebPage',
+		);
+		$current_url       = $this->get_current_url();
+		$queried_object_id = get_queried_object_id();
+
+		if ( is_front_page() && ! is_paged() ) {
+			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_bloginfo( 'name', 'raw' ) );
+			$parsely_page['url']      = home_url();
+		} elseif ( is_front_page() && is_paged() ) {
+			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_bloginfo( 'name', 'raw' ) );
+			$parsely_page['url']      = $current_url;
+		} elseif (
+			is_home() && (
+				! ( 'page' === get_option( 'show_on_front' ) && ! get_option( 'page_on_front' ) ) ||
+				$queried_object_id && (int) get_option( 'page_for_posts' ) === $queried_object_id
+			)
+		) {
+			$parsely_page['headline'] = get_the_title( get_option( 'page_for_posts', true ) );
+			$parsely_page['url']      = $current_url;
+		} elseif ( is_author() ) {
+			// TODO: why can't we have something like a WP_User object for all the other cases? Much nicer to deal with than functions.
+			$author                   = ( get_query_var( 'author_name' ) ) ? get_user_by( 'slug', get_query_var( 'author_name' ) ) : get_userdata( get_query_var( 'author' ) );
+			$parsely_page['headline'] = $this->get_clean_parsely_page_value( 'Author - ' . $author->data->display_name );
+			$parsely_page['url']      = $current_url;
+		} elseif ( is_category() || is_post_type_archive() || is_tax() ) {
+			$category                 = get_queried_object();
+			$parsely_page['headline'] = $this->get_clean_parsely_page_value( $category->name );
+			$parsely_page['url']      = $current_url;
+		} elseif ( is_date() ) {
+			if ( is_year() ) {
+				/* translators: %s: Archive year */
+				$parsely_page['headline'] = sprintf( __( 'Yearly Archive - %s', 'wp-parsely' ), get_the_time( 'Y' ) );
+			} elseif ( is_month() ) {
+				/* translators: %s: Archive month, formatted as F, Y */
+				$parsely_page['headline'] = sprintf( __( 'Monthly Archive - %s', 'wp-parsely' ), get_the_time( 'F, Y' ) );
+			} elseif ( is_day() ) {
+				/* translators: %s: Archive day, formatted as F jS, Y */
+				$parsely_page['headline'] = sprintf( __( 'Daily Archive - %s', 'wp-parsely' ), get_the_time( 'F jS, Y' ) );
+			} elseif ( is_time() ) {
+				/* translators: %s: Archive time, formatted as F jS g:i:s A */
+				$parsely_page['headline'] = sprintf( __( 'Hourly, Minutely, or Secondly Archive - %s', 'wp-parsely' ), get_the_time( 'F jS g:i:s A' ) );
+			}
+			$parsely_page['url'] = $current_url;
+		} elseif ( is_tag() ) {
+			$tag = single_tag_title( '', false );
+			if ( empty( $tag ) ) {
+				$tag = single_term_title( '', false );
+			}
+			/* translators: %s: Tag name */
+			$parsely_page['headline'] = $this->get_clean_parsely_page_value( sprintf( __( 'Tagged - %s', 'wp-parsely' ), $tag ) );
+			$parsely_page['url']      = $current_url;
+		} elseif ( in_array( get_post_type( $post ), $parsely_options['track_post_types'], true ) && Parsely::post_has_trackable_status( $post ) ) {
+			$authors  = $this->get_author_names( $post );
+			$category = $this->get_category_name( $post, $parsely_options );
+
+			if ( has_post_thumbnail( $post ) ) {
+				$image_id  = get_post_thumbnail_id( $post );
+				$image_url = wp_get_attachment_image_src( $image_id );
+				$image_url = $image_url[0];
+			} else {
+				$image_url = $this->get_first_image( $post );
+			}
+
+			$tags = $this->get_tags( $post->ID );
+			if ( $parsely_options['cats_as_tags'] ) {
+				$tags = array_merge( $tags, $this->get_categories( $post->ID ) );
+				// add custom taxonomy values.
+				$tags = array_merge( $tags, $this->get_custom_taxonomy_values( $post ) );
+			}
+			// The function 'mb_strtolower' is not enabled by default in php, so this check
+			// falls back to the native php function 'strtolower' if necessary.
+			if ( function_exists( 'mb_strtolower' ) ) {
+				$lowercase_callback = 'mb_strtolower';
+			} else {
+				$lowercase_callback = 'strtolower';
+			}
+			if ( $parsely_options['lowercase_tags'] ) {
+				$tags = array_map( $lowercase_callback, $tags );
+			}
+
+			/**
+			 * Filters the post tags that are used as metadata keywords.
+			 *
+			 * @param string[] $tags Post tags.
+			 * @param int $ID Post ID.
+			 *
+			 * @since 1.8.0
+			 */
+			$tags = apply_filters( 'wp_parsely_post_tags', $tags, $post->ID );
+			$tags = array_map( array( $this, 'get_clean_parsely_page_value' ), $tags );
+			$tags = array_values( array_unique( $tags ) );
+
+			/**
+			 * Filters the JSON-LD @type.
+			 *
+			 * @param array $jsonld_type JSON-LD @type value, default is NewsArticle.
+			 * @param int $id Post ID.
+			 * @param string $post_type The Post type in WordPress.
+			 *
+			 * @since 2.5.0
+			 */
+			$type = (string) apply_filters( 'wp_parsely_post_type', 'NewsArticle', $post->ID, $post->post_type );
+
+			// TODO: Merge only once, not every execution.
+			$supported_types = array_merge( Parsely::SUPPORTED_JSONLD_POST_TYPES, Parsely::SUPPORTED_JSONLD_NON_POST_TYPES );
+
+			// Validate type before passing it further as an invalid type will not be recognized by Parse.ly.
+			if ( ! in_array( $type, $supported_types, true ) ) {
+				$error = sprintf(
+				/* translators: 1: JSON @type like NewsArticle, 2: URL */
+					__( '@type %1$s is not supported by Parse.ly. Please use a type mentioned in %2$s', 'wp-parsely' ),
+					$type,
+					'https://www.parse.ly/help/integration/jsonld#distinguishing-between-posts-and-pages'
+				);
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+				trigger_error( esc_html( $error ), E_USER_WARNING );
+				$type = 'NewsArticle';
+			}
+
+			$parsely_page['@type']            = $type;
+			$parsely_page['mainEntityOfPage'] = array(
+				'@type' => 'WebPage',
+				'@id'   => $this->get_current_url( 'post' ),
+			);
+			$parsely_page['headline']         = $this->get_clean_parsely_page_value( get_the_title( $post ) );
+			$parsely_page['url']              = $this->get_current_url( 'post', $post->ID );
+			$parsely_page['thumbnailUrl']     = $image_url;
+			$parsely_page['image']            = array(
+				'@type' => 'ImageObject',
+				'url'   => $image_url,
+			);
+
+			$this->set_metadata_post_times( $parsely_page, $post );
+
+			$parsely_page['articleSection'] = $category;
+			$author_objects                 = array();
+			foreach ( $authors as $author ) {
+				$author_tag       = array(
+					'@type' => 'Person',
+					'name'  => $author,
+				);
+				$author_objects[] = $author_tag;
+			}
+			$parsely_page['author']    = $author_objects;
+			$parsely_page['creator']   = $authors;
+			$parsely_page['publisher'] = array(
+				'@type' => 'Organization',
+				'name'  => get_bloginfo( 'name' ),
+				'logo'  => $parsely_options['logo'],
+			);
+			$parsely_page['keywords']  = $tags;
+		} elseif ( in_array( get_post_type(), $parsely_options['track_page_types'], true ) && Parsely::post_has_trackable_status( $post ) ) {
+			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_the_title( $post ) );
+			$parsely_page['url']      = $this->get_current_url( 'post' );
+		} elseif ( 'page' === get_option( 'show_on_front' ) && ! get_option( 'page_on_front' ) ) {
+			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_bloginfo( 'name', 'raw' ) );
+			$parsely_page['url']      = home_url();
+		}
+
+		/**
+		 * Filters the structured metadata.
+		 *
+		 * @param array $parsely_page Existing structured metadata for a page.
+		 * @param WP_Post $post Post object.
+		 * @param array $parsely_options The Parsely options.
+		 *
+		 * @since 2.5.0
+		 */
+		$filtered = apply_filters( 'wp_parsely_metadata', $parsely_page, $post, $parsely_options );
+		if ( is_array( $filtered ) ) {
+			return $filtered;
+		}
+
+		return array();
+	}
+
+	/**
+	 * Sanitize content
+	 *
+	 * @since 2.6.0
+	 * @since 3.3.0 Moved to class-metadata
+	 *
+	 * @param string|null $val The content you'd like sanitized.
+	 * @return string
+	 */
+	private function get_clean_parsely_page_value( ?string $val ): string {
+		if ( null === $val ) {
+			return '';
+		}
+
+		$val = str_replace( "\n", '', $val );
+		$val = str_replace( "\r", '', $val );
+		$val = wp_strip_all_tags( $val );
+		return trim( $val );
+	}
+
+	/**
+	 * Retrieve all the authors for a post as an array. Can include multiple
+	 * authors if coauthors plugin is in use.
+	 *
+	 * @since 3.3.0 Moved to class-metadata
+	 *
+	 * @param WP_Post $post The post object.
+	 * @return array<string>
+	 */
+	private function get_author_names( WP_Post $post ): array {
+		$authors = $this->get_coauthor_names( $post->ID );
+		if ( 0 === count( $authors ) ) {
+			$post_author = get_user_by( 'id', $post->post_author );
+			if ( false !== $post_author ) {
+				$authors = array( $post_author );
+			}
+		}
+
+		/**
+		 * Filters the list of author WP_User objects for a post.
+		 *
+		 * @since 1.14.0
+		 *
+		 * @param WP_User[] $authors One or more authors as WP_User objects.
+		 * @param WP_Post   $post    Post object.
+		 */
+		$authors = apply_filters( 'wp_parsely_pre_authors', $authors, $post );
+
+		// Getting the author name for each author.
+		$authors = array_map( array( $this, 'get_author_name' ), $authors );
+
+		/**
+		 * Filters the list of author names for a post.
+		 *
+		 * @since 1.14.0
+		 *
+		 * @param string[] $authors One or more author names.
+		 * @param WP_Post  $post    Post object.
+		 */
+		$authors = apply_filters( 'wp_parsely_post_authors', $authors, $post );
+
+		return array_map( array( $this, 'get_clean_parsely_page_value' ), $authors );
+	}
+
+	/**
+	 * Returns a properly cleaned category/taxonomy value and will optionally use the top-level category/taxonomy value
+	 * if so instructed via the `use_top_level_cats` option.
+	 *
+	 * @since 3.3.0 Moved to class-metadata
+	 *
+	 * @param WP_Post $post_obj The object for the post.
+	 * @param array   $parsely_options The parsely options.
+	 * @return string Cleaned category name for the post in question.
+	 */
+	private function get_category_name( WP_Post $post_obj, array $parsely_options ): string {
+		$taxonomy_dropdown_choice = get_the_terms( $post_obj->ID, $parsely_options['custom_taxonomy_section'] );
+		// Get top-level taxonomy name for chosen taxonomy and assign to $parent_name; it will be used
+		// as the category value if 'use_top_level_cats' option is checked.
+		// Assign as the default category name if no value is checked for the chosen taxonomy.
+		$category_name = get_cat_name( get_option( 'default_category' ) );
+		if ( ! empty( $taxonomy_dropdown_choice ) && ! is_wp_error( $taxonomy_dropdown_choice ) ) {
+			if ( $parsely_options['use_top_level_cats'] ) {
+				$first_term = array_shift( $taxonomy_dropdown_choice );
+				$term_name  = $this->get_top_level_term( $first_term->term_id, $first_term->taxonomy );
+			} else {
+				$term_name = $this->get_bottom_level_term( $post_obj->ID, $parsely_options['custom_taxonomy_section'] );
+			}
+
+			if ( is_string( $term_name ) && 0 < strlen( $term_name ) ) {
+				$category_name = $term_name;
+			}
+		}
+
+		/**
+		 * Filters the constructed category name that are used as metadata keywords.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string  $category        Category name.
+		 * @param WP_Post $post_obj        Post object.
+		 * @param array   $parsely_options The Parsely options.
+		 */
+		$category_name = apply_filters( 'wp_parsely_post_category', $category_name, $post_obj, $parsely_options );
+
+		return $this->get_clean_parsely_page_value( $category_name );
+	}
+
+	/**
+	 * Returns the tags associated with this page or post
+	 *
+	 * @since 3.3.0 Moved to class-metadata
+	 *
+	 * @param int $post_id The id of the post you're trying to get tags for.
+	 * @return array The tags of the post represented by the post id.
+	 */
+	private function get_tags( int $post_id ): array {
+		$tags      = array();
+		$post_tags = wp_get_post_tags( $post_id );
+		if ( ! is_wp_error( $post_tags ) ) {
+			foreach ( $post_tags as $wp_tag ) {
+				$tags[] = $wp_tag->name;
+			}
+		}
+		return $tags;
+	}
+
+	/**
+	 * Returns an array of all the child categories for the current post
+	 *
+	 * @since 3.3.0 Moved to class-metadata
+	 *
+	 * @param int    $post_id The id of the post you're trying to get categories for.
+	 * @param string $delimiter What character will delimit the categories.
+	 * @return array<string> All the child categories of the current post.
+	 */
+	private function get_categories( int $post_id, string $delimiter = '/' ): array {
+		$tags = array();
+		foreach ( get_the_category( $post_id ) as $category ) {
+			$hierarchy = get_category_parents( $category->term_id, false, $delimiter );
+			if ( ! is_wp_error( $hierarchy ) ) {
+				$tags[] = rtrim( $hierarchy, '/' );
+			}
+		}
+		// take last element in the hierarchy, a string representing the full parent->child tree,
+		// and split it into individual category names.
+		$last_tag = end( $tags );
+		if ( false !== $last_tag ) {
+			$tags = explode( '/', $last_tag );
+		}
+
+		// Remove default category name from tags if needed.
+		$default_category_name = get_cat_name( get_option( 'default_category' ) );
+		return array_diff( $tags, array( $default_category_name ) );
+	}
+
+	/**
+	 * Get all term values from custom taxonomies.
+	 *
+	 * @since 3.3.0 Moved to class-metadata
+	 *
+	 * @param WP_Post $post_obj The post object.
+	 * @return array<string>
+	 */
+	private function get_custom_taxonomy_values( WP_Post $post_obj ): array {
+		// filter out default WordPress taxonomies.
+		$all_taxonomies = array_diff( get_taxonomies(), array( 'post_tag', 'nav_menu', 'author', 'link_category', 'post_format' ) );
+		$all_values     = array();
+
+		foreach ( $all_taxonomies as $taxonomy ) {
+			$custom_taxonomy_objects = get_the_terms( $post_obj->ID, $taxonomy );
+			if ( is_array( $custom_taxonomy_objects ) ) {
+				foreach ( $custom_taxonomy_objects as $custom_taxonomy_object ) {
+					$all_values[] = $custom_taxonomy_object->name;
+				}
+			}
+		}
+
+		return $all_values;
+	}
+
+	/**
+	 * Get the URL of the current PHP script.
+	 * A fall-back implementation to determine permalink
+	 *
+	 * @since 3.0.0 $parsely_type Default parameter changed to `non-post`.
+	 * @since 3.3.0 Moved to class-metadata
+	 *
+	 * @param string $parsely_type Optional. Parse.ly post type you're interested in, either 'post' or 'non-post'. Default is 'non-post'.
+	 * @param int    $post_id      Optional. ID of the post you want to get the URL for. Default is 0, which means the global `$post` is used.
+	 * @return string
+	 */
+	private function get_current_url( string $parsely_type = 'non-post', int $post_id = 0 ): string {
+		if ( 'post' === $parsely_type ) {
+			$permalink = (string) get_permalink( $post_id );
+
+			/**
+			 * Filters the permalink for a post.
+			 *
+			 * @since 1.14.0
+			 * @since 2.5.0  Added $post_id.
+			 *
+			 * @param string $permalink         The permalink URL or false if post does not exist.
+			 * @param string $parsely_type      Parse.ly type ("post" or "non-post").
+			 * @param int    $post_id           ID of the post you want to get the URL for. May be 0, so $permalink will be
+			 *                                  for the global $post.
+			 */
+			$url = apply_filters( 'wp_parsely_permalink', $permalink, $parsely_type, $post_id );
+		} else {
+			$request_uri = isset( $_SERVER['REQUEST_URI'] )
+				? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) )
+				: '';
+
+			$url = home_url( $request_uri );
+		}
+
+		$options = $this->parsely->get_options();
+		return $options['force_https_canonicals']
+			? str_replace( 'http://', 'https://', $url )
+			: str_replace( 'https://', 'http://', $url );
+	}
+
+	/**
+	 * Sets all metadata values related to post time.
+	 *
+	 * @since 3.0.2
+	 * @since 3.3.0 Moved to class-metadata
+	 *
+	 * @param array   $metadata Array containing all metadata. It will be potentially mutated to add keys: dateCreated, dateModified, & datePublished.
+	 * @param WP_Post $post     Post object from which to extract time data.
+	 * @return void
+	 */
+	private function set_metadata_post_times( array &$metadata, WP_Post $post ): void {
+		$date_format      = 'Y-m-d\TH:i:s\Z';
+		$post_created_gmt = get_post_time( $date_format, true, $post );
+
+		if ( false === $post_created_gmt ) {
+			return;
+		}
+
+		$metadata['dateCreated']   = $post_created_gmt;
+		$metadata['datePublished'] = $post_created_gmt;
+		$metadata['dateModified']  = $post_created_gmt;
+
+		$post_modified_gmt = get_post_modified_time( $date_format, true, $post );
+
+		if ( false !== $post_modified_gmt && $post_modified_gmt > $post_created_gmt ) {
+			$metadata['dateModified'] = $post_modified_gmt;
+		}
+	}
+
+	/**
+	 * Returns a list of coauthors for a post assuming the Co-Authors Plus plugin is
+	 * installed. Borrowed from
+	 * https://github.com/Automattic/Co-Authors-Plus/blob/master/template-tags.php#L3-35
+	 *
+	 * @since 3.3.0 Moved to class-metadata
+	 *
+	 * @param int $post_id The id of the post.
+	 * @return array<WP_User>
+	 */
+	private function get_coauthor_names( int $post_id ): array {
+		$coauthors = array();
+		if ( class_exists( 'coauthors_plus' ) ) {
+			global $post, $post_ID, $coauthors_plus;
+
+			if ( ! $post_id && $post_ID ) {
+				$post_id = $post_ID;
+			}
+
+			if ( ! $post_id && $post ) {
+				$post_id = $post->ID;
+			}
+
+			if ( $post_id ) {
+				$coauthor_terms = get_the_terms( $post_id, $coauthors_plus->coauthor_taxonomy );
+
+				if ( is_array( $coauthor_terms ) && ! empty( $coauthor_terms ) ) {
+					foreach ( $coauthor_terms as $coauthor ) {
+						$coauthor_slug = preg_replace( '#^cap-#', '', $coauthor->slug );
+						$post_author   = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_slug );
+						// In case the user has been deleted while plugin was deactivated.
+						if ( ! empty( $post_author ) ) {
+							$coauthors[] = new WP_User( $post_author );
+						}
+					}
+				} elseif ( ! $coauthors_plus->force_guest_authors ) {
+					if ( $post && $post_id === $post->ID ) {
+						$post_author = get_userdata( $post->post_author );
+					}
+					if ( ! empty( $post_author ) ) {
+						$coauthors[] = $post_author;
+					}
+				} // the empty else case is because if we force guest authors, we don't ever care what value wp_posts.post_author has.
+			}
+		}
+		return $coauthors;
+	}
+
+	/**
+	 * Determine author name from display name, falling back to firstname
+	 * lastname, then nickname and finally the nicename.
+	 *
+	 * @since 3.3.0 Moved to class-metadata
+	 *
+	 * @param ?WP_User $author The author of the post.
+	 * @return string
+	 */
+	private function get_author_name( ?WP_User $author ): string {
+		// Gracefully handle situation where no author is available.
+		if ( null === $author ) {
+			return '';
+		}
+
+		if ( ! empty( $author->display_name ) ) {
+			return $author->display_name;
+		}
+
+		$author_name = $author->user_firstname . ' ' . $author->user_lastname;
+		if ( ' ' !== $author_name ) {
+			return $author_name;
+		}
+
+		if ( ! empty( $author->nickname ) ) {
+			return $author->nickname;
+		}
+
+		if ( ! empty( $author->user_nicename ) ) {
+			return $author->user_nicename;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Get the first image from a post
+	 * https://css-tricks.com/snippets/wordpress/get-the-first-image-from-a-post/
+	 *
+	 * @since 3.3.0 Moved to class-metadata
+	 *
+	 * @param WP_Post $post The post object you're interested in.
+	 * @return string
+	 */
+	private function get_first_image( WP_Post $post ): string {
+		ob_start();
+		ob_end_clean();
+		if ( preg_match_all( '/<img.+src=[\'"]( [^\'"]+ )[\'"].*>/i', $post->post_content, $matches ) ) {
+			return $matches[1][0];
+		}
+		return '';
+	}
+
+	/**
+	 * Return the top-most category/taxonomy value in a hierarcy given a taxonomy value's ID
+	 * ( WordPress calls taxonomy values 'terms' ).
+	 *
+	 * @since 3.3.0 Moved to class-metadata
+	 *
+	 * @param int    $term_id The id of the top level term.
+	 * @param string $taxonomy_name The name of the taxonomy.
+	 * @return string|false $parent The top level name of the category / taxonomy.
+	 */
+	private function get_top_level_term( int $term_id, string $taxonomy_name ) {
+		$parent = get_term_by( 'id', $term_id, $taxonomy_name );
+		while ( false !== $parent && 0 !== $parent->parent ) {
+			$parent = get_term_by( 'id', $parent->parent, $taxonomy_name );
+		}
+		return $parent ? $parent->name : false;
+	}
+
+	/**
+	 * Return the bottom-most category/taxonomy value in a hierarchy given a post ID
+	 * ( WordPress calls taxonomy values 'terms' ).
+	 *
+	 * @since 3.3.0 Moved to class-metadata
+	 *
+	 * @param int    $post_id The post id you're interested in.
+	 * @param string $taxonomy_name The name of the taxonomy.
+	 * @return string Name of the custom taxonomy.
+	 */
+	private function get_bottom_level_term( int $post_id, string $taxonomy_name ): string {
+		$terms = get_the_terms( $post_id, $taxonomy_name );
+
+		if ( ! is_array( $terms ) ) {
+			return '';
+		}
+
+		$term_ids = wp_list_pluck( $terms, 'term_id' );
+		$parents  = array_filter( wp_list_pluck( $terms, 'parent' ) );
+
+		// Get array of IDs of terms which are not parents.
+		$term_ids_not_parents = array_diff( $term_ids, $parents );
+		// Get corresponding term objects, which are mapped to array index keys.
+		$terms_not_parents = array_intersect_key( $terms, $term_ids_not_parents );
+		// remove array index keys.
+		$terms_not_parents_cleaned = array();
+		foreach ( $terms_not_parents as $index => $value ) {
+			$terms_not_parents_cleaned[] = $value;
+		}
+
+		if ( ! empty( $terms_not_parents_cleaned ) ) {
+			// if you assign multiple child terms in a custom taxonomy, will only return the first.
+			return $terms_not_parents_cleaned[0]->name ?? '';
+		}
+
+		return '';
+	}
+}

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -46,7 +46,7 @@ class Metadata {
 	 */
 	public function construct_metadata( array $parsely_options, WP_Post $post ): array {
 		$parsely_page      = array(
-			'@context' => 'http://schema.org',
+			'@context' => 'https://schema.org',
 			'@type'    => 'WebPage',
 		);
 		$current_url       = $this->get_current_url();

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -17,7 +17,7 @@ use WP_Post;
  * Generates and inserts metadata readable by the Parse.ly Crawler.
  *
  * @since 1.0.0
- * @since 3.3.0 Moved from class-parsely to separate file
+ * @since 3.3.0 Logic extracted from Parsely\Parsely class to separate file/class.
  */
 class Metadata {
 	/**

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace Parsely;
 
 use WP_Post;
-use WP_User;
 
 /**
  * Holds most of the logic for the plugin.
@@ -61,7 +60,7 @@ class Parsely {
 	 * @since 2.5.0
 	 * @var string[]
 	 */
-	private $supported_jsonld_post_types = array(
+	public const SUPPORTED_JSONLD_POST_TYPES = array(
 		'NewsArticle',
 		'Article',
 		'TechArticle',
@@ -80,7 +79,7 @@ class Parsely {
 	 * @since 2.5.0
 	 * @var string[]
 	 */
-	private $supported_jsonld_non_post_types = array(
+	public const SUPPORTED_JSONLD_NON_POST_TYPES = array(
 		'WebPage',
 		'Event',
 		'Hotel',
@@ -339,207 +338,8 @@ class Parsely {
 	 * @return array<string, mixed>
 	 */
 	public function construct_parsely_metadata( array $parsely_options, WP_Post $post ): array {
-		$parsely_page      = array(
-			'@context' => 'http://schema.org',
-			'@type'    => 'WebPage',
-		);
-		$current_url       = $this->get_current_url();
-		$queried_object_id = get_queried_object_id();
-
-		if ( is_front_page() && ! is_paged() ) {
-			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_bloginfo( 'name', 'raw' ) );
-			$parsely_page['url']      = home_url();
-		} elseif ( is_front_page() && is_paged() ) {
-			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_bloginfo( 'name', 'raw' ) );
-			$parsely_page['url']      = $current_url;
-		} elseif (
-			is_home() && (
-				! ( 'page' === get_option( 'show_on_front' ) && ! get_option( 'page_on_front' ) ) ||
-				$queried_object_id && (int) get_option( 'page_for_posts' ) === $queried_object_id
-			)
-		) {
-			$parsely_page['headline'] = get_the_title( get_option( 'page_for_posts', true ) );
-			$parsely_page['url']      = $current_url;
-		} elseif ( is_author() ) {
-			// TODO: why can't we have something like a WP_User object for all the other cases? Much nicer to deal with than functions.
-			$author                   = ( get_query_var( 'author_name' ) ) ? get_user_by( 'slug', get_query_var( 'author_name' ) ) : get_userdata( get_query_var( 'author' ) );
-			$parsely_page['headline'] = $this->get_clean_parsely_page_value( 'Author - ' . $author->data->display_name );
-			$parsely_page['url']      = $current_url;
-		} elseif ( is_category() || is_post_type_archive() || is_tax() ) {
-			$category                 = get_queried_object();
-			$parsely_page['headline'] = $this->get_clean_parsely_page_value( $category->name );
-			$parsely_page['url']      = $current_url;
-		} elseif ( is_date() ) {
-			if ( is_year() ) {
-				/* translators: %s: Archive year */
-				$parsely_page['headline'] = sprintf( __( 'Yearly Archive - %s', 'wp-parsely' ), get_the_time( 'Y' ) );
-			} elseif ( is_month() ) {
-				/* translators: %s: Archive month, formatted as F, Y */
-				$parsely_page['headline'] = sprintf( __( 'Monthly Archive - %s', 'wp-parsely' ), get_the_time( 'F, Y' ) );
-			} elseif ( is_day() ) {
-				/* translators: %s: Archive day, formatted as F jS, Y */
-				$parsely_page['headline'] = sprintf( __( 'Daily Archive - %s', 'wp-parsely' ), get_the_time( 'F jS, Y' ) );
-			} elseif ( is_time() ) {
-				/* translators: %s: Archive time, formatted as F jS g:i:s A */
-				$parsely_page['headline'] = sprintf( __( 'Hourly, Minutely, or Secondly Archive - %s', 'wp-parsely' ), get_the_time( 'F jS g:i:s A' ) );
-			}
-			$parsely_page['url'] = $current_url;
-		} elseif ( is_tag() ) {
-			$tag = single_tag_title( '', false );
-			if ( empty( $tag ) ) {
-				$tag = single_term_title( '', false );
-			}
-			/* translators: %s: Tag name */
-			$parsely_page['headline'] = $this->get_clean_parsely_page_value( sprintf( __( 'Tagged - %s', 'wp-parsely' ), $tag ) );
-			$parsely_page['url']      = $current_url;
-		} elseif ( in_array( get_post_type( $post ), $parsely_options['track_post_types'], true ) && self::post_has_trackable_status( $post ) ) {
-			$authors  = $this->get_author_names( $post );
-			$category = $this->get_category_name( $post, $parsely_options );
-
-			if ( has_post_thumbnail( $post ) ) {
-				$image_id  = get_post_thumbnail_id( $post );
-				$image_url = wp_get_attachment_image_src( $image_id );
-				$image_url = $image_url[0];
-			} else {
-				$image_url = $this->get_first_image( $post );
-			}
-
-			$tags = $this->get_tags( $post->ID );
-			if ( $parsely_options['cats_as_tags'] ) {
-				$tags = array_merge( $tags, $this->get_categories( $post->ID ) );
-				// add custom taxonomy values.
-				$tags = array_merge( $tags, $this->get_custom_taxonomy_values( $post ) );
-			}
-			// the function 'mb_strtolower' is not enabled by default in php, so this check
-			// falls back to the native php function 'strtolower' if necessary.
-			if ( function_exists( 'mb_strtolower' ) ) {
-				$lowercase_callback = 'mb_strtolower';
-			} else {
-				$lowercase_callback = 'strtolower';
-			}
-			if ( $parsely_options['lowercase_tags'] ) {
-				$tags = array_map( $lowercase_callback, $tags );
-			}
-
-			/**
-			 * Filters the post tags that are used as metadata keywords.
-			 *
-			 * @since 1.8.0
-			 *
-			 * @param string[] $tags Post tags.
-			 * @param int      $ID   Post ID.
-			 */
-			$tags = apply_filters( 'wp_parsely_post_tags', $tags, $post->ID );
-			$tags = array_map( array( $this, 'get_clean_parsely_page_value' ), $tags );
-			$tags = array_values( array_unique( $tags ) );
-
-			/**
-			 * Filters the JSON-LD @type.
-			 *
-			 * @since 2.5.0
-			 *
-			 * @param array  $jsonld_type JSON-LD @type value, default is NewsArticle.
-			 * @param int    $id          Post ID.
-			 * @param string $post_type   The Post type in WordPress.
-			 */
-			$type            = (string) apply_filters( 'wp_parsely_post_type', 'NewsArticle', $post->ID, $post->post_type );
-			$supported_types = array_merge( $this->supported_jsonld_post_types, $this->supported_jsonld_non_post_types );
-
-			// Validate type before passing it further as an invalid type will not be recognized by Parse.ly.
-			if ( ! in_array( $type, $supported_types, true ) ) {
-				$error = sprintf(
-					/* translators: 1: JSON @type like NewsArticle, 2: URL */
-					__( '@type %1$s is not supported by Parse.ly. Please use a type mentioned in %2$s', 'wp-parsely' ),
-					$type,
-					'https://www.parse.ly/help/integration/jsonld#distinguishing-between-posts-and-pages'
-				);
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-				trigger_error( esc_html( $error ), E_USER_WARNING );
-				$type = 'NewsArticle';
-			}
-
-			$parsely_page['@type']            = $type;
-			$parsely_page['mainEntityOfPage'] = array(
-				'@type' => 'WebPage',
-				'@id'   => $this->get_current_url( 'post' ),
-			);
-			$parsely_page['headline']         = $this->get_clean_parsely_page_value( get_the_title( $post ) );
-			$parsely_page['url']              = $this->get_current_url( 'post', $post->ID );
-			$parsely_page['thumbnailUrl']     = $image_url;
-			$parsely_page['image']            = array(
-				'@type' => 'ImageObject',
-				'url'   => $image_url,
-			);
-
-			$this->set_metadata_post_times( $parsely_page, $post );
-
-			$parsely_page['articleSection'] = $category;
-			$author_objects                 = array();
-			foreach ( $authors as $author ) {
-				$author_tag       = array(
-					'@type' => 'Person',
-					'name'  => $author,
-				);
-				$author_objects[] = $author_tag;
-			}
-			$parsely_page['author']    = $author_objects;
-			$parsely_page['creator']   = $authors;
-			$parsely_page['publisher'] = array(
-				'@type' => 'Organization',
-				'name'  => get_bloginfo( 'name' ),
-				'logo'  => $parsely_options['logo'],
-			);
-			$parsely_page['keywords']  = $tags;
-		} elseif ( in_array( get_post_type(), $parsely_options['track_page_types'], true ) && self::post_has_trackable_status( $post ) ) {
-			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_the_title( $post ) );
-			$parsely_page['url']      = $this->get_current_url( 'post' );
-		} elseif ( 'page' === get_option( 'show_on_front' ) && ! get_option( 'page_on_front' ) ) {
-			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_bloginfo( 'name', 'raw' ) );
-			$parsely_page['url']      = home_url();
-		}
-
-		/**
-		 * Filters the structured metadata.
-		 *
-		 * @since 2.5.0
-		 *
-		 * @param array   $parsely_page    Existing structured metadata for a page.
-		 * @param WP_Post $post            Post object.
-		 * @param array   $parsely_options The Parsely options.
-		 */
-		$filtered = apply_filters( 'wp_parsely_metadata', $parsely_page, $post, $parsely_options );
-		if ( is_array( $filtered ) ) {
-			return $filtered;
-		}
-		return array();
-	}
-
-	/**
-	 * Sets all metadata values related to post time.
-	 *
-	 * @since 3.0.2
-	 *
-	 * @param array   $metadata Array containing all metadata. It will be potentially mutated to add keys: dateCreated, dateModified, & datePublished.
-	 * @param WP_Post $post     Post object from which to extract time data.
-	 * @return void
-	 */
-	private function set_metadata_post_times( array &$metadata, WP_Post $post ): void {
-		$date_format      = 'Y-m-d\TH:i:s\Z';
-		$post_created_gmt = get_post_time( $date_format, true, $post );
-
-		if ( false === $post_created_gmt ) {
-			return;
-		}
-
-		$metadata['dateCreated']   = $post_created_gmt;
-		$metadata['datePublished'] = $post_created_gmt;
-		$metadata['dateModified']  = $post_created_gmt;
-
-		$post_modified_gmt = get_post_modified_time( $date_format, true, $post );
-
-		if ( false !== $post_modified_gmt && $post_modified_gmt > $post_created_gmt ) {
-			$metadata['dateModified'] = $post_modified_gmt;
-		}
+		$metadata = new Metadata( $this );
+		return $metadata->construct_metadata( $parsely_options, $post );
 	}
 
 	/**
@@ -673,55 +473,11 @@ class Parsely {
 	}
 
 	/**
-	 * Returns the tags associated with this page or post
-	 *
-	 * @param int $post_id The id of the post you're trying to get tags for.
-	 * @return array The tags of the post represented by the post id.
-	 */
-	private function get_tags( int $post_id ): array {
-		$tags      = array();
-		$post_tags = wp_get_post_tags( $post_id );
-		if ( ! is_wp_error( $post_tags ) ) {
-			foreach ( $post_tags as $wp_tag ) {
-				$tags[] = $wp_tag->name;
-			}
-		}
-		return $tags;
-	}
-
-	/**
-	 * Returns an array of all the child categories for the current post
-	 *
-	 * @param int    $post_id The id of the post you're trying to get categories for.
-	 * @param string $delimiter What character will delimit the categories.
-	 * @return array<string> All the child categories of the current post.
-	 */
-	private function get_categories( int $post_id, string $delimiter = '/' ): array {
-		$tags = array();
-		foreach ( get_the_category( $post_id ) as $category ) {
-			$hierarchy = get_category_parents( $category->term_id, false, $delimiter );
-			if ( ! is_wp_error( $hierarchy ) ) {
-				$tags[] = rtrim( $hierarchy, '/' );
-			}
-		}
-		// take last element in the hierarchy, a string representing the full parent->child tree,
-		// and split it into individual category names.
-		$last_tag = end( $tags );
-		if ( false !== $last_tag ) {
-			$tags = explode( '/', $last_tag );
-		}
-
-		// Remove default category name from tags if needed.
-		$default_category_name = get_cat_name( get_option( 'default_category' ) );
-		return array_diff( $tags, array( $default_category_name ) );
-	}
-
-	/**
 	 * Safely returns options for the plugin by assigning defaults contained in optionDefaults.  As soon as actual
 	 * options are saved, they override the defaults. This prevents us from having to do a lot of isset() checking
 	 * on variables.
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	public function get_options(): array {
 		$options = get_option( self::OPTIONS_KEY, $this->option_defaults );
@@ -734,326 +490,14 @@ class Parsely {
 	}
 
 	/**
-	 * Returns a properly cleaned category/taxonomy value and will optionally use the top-level category/taxonomy value
-	 * if so instructed via the `use_top_level_cats` option.
-	 *
-	 * @param WP_Post $post_obj The object for the post.
-	 * @param array   $parsely_options The parsely options.
-	 * @return string Cleaned category name for the post in question.
-	 */
-	private function get_category_name( WP_Post $post_obj, array $parsely_options ): string {
-		$taxonomy_dropdown_choice = get_the_terms( $post_obj->ID, $parsely_options['custom_taxonomy_section'] );
-		// Get top-level taxonomy name for chosen taxonomy and assign to $parent_name; it will be used
-		// as the category value if 'use_top_level_cats' option is checked.
-		// Assign as the default category name if no value is checked for the chosen taxonomy.
-		$category_name = get_cat_name( get_option( 'default_category' ) );
-		if ( ! empty( $taxonomy_dropdown_choice ) && ! is_wp_error( $taxonomy_dropdown_choice ) ) {
-			if ( $parsely_options['use_top_level_cats'] ) {
-				$first_term = array_shift( $taxonomy_dropdown_choice );
-				$term_name  = $this->get_top_level_term( $first_term->term_id, $first_term->taxonomy );
-			} else {
-				$term_name = $this->get_bottom_level_term( $post_obj->ID, $parsely_options['custom_taxonomy_section'] );
-			}
-
-			if ( is_string( $term_name ) && 0 < strlen( $term_name ) ) {
-				$category_name = $term_name;
-			}
-		}
-
-		/**
-		 * Filters the constructed category name that are used as metadata keywords.
-		 *
-		 * @since 1.8.0
-		 *
-		 * @param string  $category        Category name.
-		 * @param WP_Post $post_obj        Post object.
-		 * @param array   $parsely_options The Parsely options.
-		 */
-		$category_name = apply_filters( 'wp_parsely_post_category', $category_name, $post_obj, $parsely_options );
-
-		return $this->get_clean_parsely_page_value( $category_name );
-	}
-
-	/**
-	 * Return the top-most category/taxonomy value in a hierarcy given a taxonomy value's ID
-	 * ( WordPress calls taxonomy values 'terms' ).
-	 *
-	 * @param int    $term_id The id of the top level term.
-	 * @param string $taxonomy_name The name of the taxonomy.
-	 * @return string|false $parent The top level name of the category / taxonomy.
-	 */
-	private function get_top_level_term( int $term_id, string $taxonomy_name ) {
-		$parent = get_term_by( 'id', $term_id, $taxonomy_name );
-		while ( false !== $parent && 0 !== $parent->parent ) {
-			$parent = get_term_by( 'id', $parent->parent, $taxonomy_name );
-		}
-		return $parent ? $parent->name : false;
-	}
-
-	/**
-	 * Return the bottom-most category/taxonomy value in a hierarcy given a post ID
-	 * ( WordPress calls taxonomy values 'terms' ).
-	 *
-	 * @param int    $post_id The post id you're interested in.
-	 * @param string $taxonomy_name The name of the taxonomy.
-	 * @return string Name of the custom taxonomy.
-	 */
-	private function get_bottom_level_term( int $post_id, string $taxonomy_name ): string {
-		$terms = get_the_terms( $post_id, $taxonomy_name );
-
-		if ( ! is_array( $terms ) ) {
-			return '';
-		}
-
-		$term_ids = wp_list_pluck( $terms, 'term_id' );
-		$parents  = array_filter( wp_list_pluck( $terms, 'parent' ) );
-
-		// Get array of IDs of terms which are not parents.
-		$term_ids_not_parents = array_diff( $term_ids, $parents );
-		// Get corresponding term objects, which are mapped to array index keys.
-		$terms_not_parents = array_intersect_key( $terms, $term_ids_not_parents );
-		// remove array index keys.
-		$terms_not_parents_cleaned = array();
-		foreach ( $terms_not_parents as $index => $value ) {
-			$terms_not_parents_cleaned[] = $value;
-		}
-
-		if ( ! empty( $terms_not_parents_cleaned ) ) {
-			// if you assign multiple child terms in a custom taxonomy, will only return the first.
-			return $terms_not_parents_cleaned[0]->name ?? '';
-		}
-
-		return '';
-	}
-
-	/**
-	 * Get all term values from custom taxonomies.
-	 *
-	 * @param WP_Post $post_obj The post object.
-	 * @return array<string>
-	 */
-	private function get_custom_taxonomy_values( WP_Post $post_obj ): array {
-		// filter out default WordPress taxonomies.
-		$all_taxonomies = array_diff( get_taxonomies(), array( 'post_tag', 'nav_menu', 'author', 'link_category', 'post_format' ) );
-		$all_values     = array();
-
-		foreach ( $all_taxonomies as $taxonomy ) {
-			$custom_taxonomy_objects = get_the_terms( $post_obj->ID, $taxonomy );
-			if ( is_array( $custom_taxonomy_objects ) ) {
-				foreach ( $custom_taxonomy_objects as $custom_taxonomy_object ) {
-					$all_values[] = $custom_taxonomy_object->name;
-				}
-			}
-		}
-
-		return $all_values;
-	}
-
-	/**
-	 * Returns a list of coauthors for a post assuming the Co-Authors Plus plugin is
-	 * installed. Borrowed from
-	 * https://github.com/Automattic/Co-Authors-Plus/blob/master/template-tags.php#L3-35
-	 *
-	 * @param int $post_id The id of the post.
-	 * @return array<WP_User>
-	 */
-	private function get_coauthor_names( int $post_id ): array {
-		$coauthors = array();
-		if ( class_exists( 'coauthors_plus' ) ) {
-			global $post, $post_ID, $coauthors_plus;
-
-			if ( ! $post_id && $post_ID ) {
-				$post_id = $post_ID;
-			}
-
-			if ( ! $post_id && $post ) {
-				$post_id = $post->ID;
-			}
-
-			if ( $post_id ) {
-				$coauthor_terms = get_the_terms( $post_id, $coauthors_plus->coauthor_taxonomy );
-
-				if ( is_array( $coauthor_terms ) && ! empty( $coauthor_terms ) ) {
-					foreach ( $coauthor_terms as $coauthor ) {
-						$coauthor_slug = preg_replace( '#^cap-#', '', $coauthor->slug );
-						$post_author   = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_slug );
-						// In case the user has been deleted while plugin was deactivated.
-						if ( ! empty( $post_author ) ) {
-							$coauthors[] = new WP_User( $post_author );
-						}
-					}
-				} elseif ( ! $coauthors_plus->force_guest_authors ) {
-					if ( $post && $post_id === $post->ID ) {
-						$post_author = get_userdata( $post->post_author );
-					}
-					if ( ! empty( $post_author ) ) {
-						$coauthors[] = $post_author;
-					}
-				} // the empty else case is because if we force guest authors, we don't ever care what value wp_posts.post_author has.
-			}
-		}
-		return $coauthors;
-	}
-
-	/**
-	 * Determine author name from display name, falling back to firstname
-	 * lastname, then nickname and finally the nicename.
-	 *
-	 * @param ?WP_User $author The author of the post.
-	 * @return string
-	 */
-	private function get_author_name( ?WP_User $author ): string {
-		// Gracefully handle situation where no author is available.
-		if ( null === $author ) {
-			return '';
-		}
-
-		if ( ! empty( $author->display_name ) ) {
-			return $author->display_name;
-		}
-
-		$author_name = $author->user_firstname . ' ' . $author->user_lastname;
-		if ( ' ' !== $author_name ) {
-			return $author_name;
-		}
-
-		if ( ! empty( $author->nickname ) ) {
-			return $author->nickname;
-		}
-
-		if ( ! empty( $author->user_nicename ) ) {
-			return $author->user_nicename;
-		}
-
-		return '';
-	}
-
-	/**
-	 * Retrieve all the authors for a post as an array. Can include multiple
-	 * authors if coauthors plugin is in use.
-	 *
-	 * @param WP_Post $post The post object.
-	 * @return array<string>
-	 */
-	private function get_author_names( WP_Post $post ): array {
-		$authors = $this->get_coauthor_names( $post->ID );
-		if ( 0 === count( $authors ) ) {
-			$post_author = get_user_by( 'id', $post->post_author );
-			if ( false !== $post_author ) {
-				$authors = array( $post_author );
-			}
-		}
-
-		/**
-		 * Filters the list of author WP_User objects for a post.
-		 *
-		 * @since 1.14.0
-		 *
-		 * @param WP_User[] $authors One or more authors as WP_User objects.
-		 * @param WP_Post   $post    Post object.
-		 */
-		$authors = apply_filters( 'wp_parsely_pre_authors', $authors, $post );
-
-		// Getting the author name for each author.
-		$authors = array_map( array( $this, 'get_author_name' ), $authors );
-
-		/**
-		 * Filters the list of author names for a post.
-		 *
-		 * @since 1.14.0
-		 *
-		 * @param string[] $authors One or more author names.
-		 * @param WP_Post  $post    Post object.
-		 */
-		$authors = apply_filters( 'wp_parsely_post_authors', $authors, $post );
-
-		return array_map( array( $this, 'get_clean_parsely_page_value' ), $authors );
-	}
-
-	/**
-	 * Sanitize content
-	 *
-	 * @since 2.6.0
-	 *
-	 * @param string|null $val The content you'd like sanitized.
-	 * @return string
-	 */
-	public function get_clean_parsely_page_value( ?string $val ): string {
-		if ( null === $val ) {
-			return '';
-		}
-
-		$val = str_replace( "\n", '', $val );
-		$val = str_replace( "\r", '', $val );
-		$val = wp_strip_all_tags( $val );
-		return trim( $val );
-	}
-
-	/**
 	 * Get the URL of the plugin settings page.
 	 *
-	 * @param int $_blog_id The Blog ID for the multisite subsite to use for context (Default null for current).
+	 * @param int|null $_blog_id The Blog ID for the multisite subsite to use for context (Default null for current).
 	 *
 	 * @return string
 	 */
 	public static function get_settings_url( int $_blog_id = null ): string {
 		return get_admin_url( $_blog_id, 'options-general.php?page=' . self::MENU_SLUG );
-	}
-
-	/**
-	 * Get the URL of the current PHP script.
-	 * A fall-back implementation to determine permalink
-	 *
-	 * @since 3.0.0 $parsely_type Default parameter changed to `non-post`.
-	 *
-	 * @param string $parsely_type Optional. Parse.ly post type you're interested in, either 'post' or 'non-post'. Default is 'non-post'.
-	 * @param int    $post_id      Optional. ID of the post you want to get the URL for. Default is 0, which means the global `$post` is used.
-	 * @return string
-	 */
-	public function get_current_url( string $parsely_type = 'non-post', int $post_id = 0 ): string {
-		if ( 'post' === $parsely_type ) {
-			$permalink = (string) get_permalink( $post_id );
-
-			/**
-			 * Filters the permalink for a post.
-			 *
-			 * @since 1.14.0
-			 * @since 2.5.0  Added $post_id.
-			 *
-			 * @param string $permalink         The permalink URL or false if post does not exist.
-			 * @param string $parsely_type      Parse.ly type ("post" or "non-post").
-			 * @param int    $post_id           ID of the post you want to get the URL for. May be 0, so $permalink will be
-			 *                                  for the global $post.
-			 */
-			$url = apply_filters( 'wp_parsely_permalink', $permalink, $parsely_type, $post_id );
-		} else {
-			$request_uri = isset( $_SERVER['REQUEST_URI'] )
-					? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) )
-					: '';
-
-			$url = home_url( $request_uri );
-		}
-
-		$options = $this->get_options();
-		return $options['force_https_canonicals']
-				? str_replace( 'http://', 'https://', $url )
-				: str_replace( 'https://', 'http://', $url );
-	}
-
-	/**
-	 * Get the first image from a post
-	 * https://css-tricks.com/snippets/wordpress/get-the-first-image-from-a-post/
-	 *
-	 * @param WP_Post $post The post object you're interested in.
-	 * @return string
-	 */
-	public function get_first_image( WP_Post $post ): string {
-		ob_start();
-		ob_end_clean();
-		if ( preg_match_all( '/<img.+src=[\'"]( [^\'"]+ )[\'"].*>/i', $post->post_content, $matches ) ) {
-			return $matches[1][0];
-		}
-		return '';
 	}
 
 	/**
@@ -1083,7 +527,7 @@ class Parsely {
 	 * @return string "post" or "index".
 	 */
 	private function convert_jsonld_to_parsely_type( string $type ): string {
-		return in_array( $type, $this->supported_jsonld_post_types, true ) ? 'post' : 'index';
+		return in_array( $type, self::SUPPORTED_JSONLD_POST_TYPES, true ) ? 'post' : 'index';
 	}
 
 	/**

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -331,13 +331,19 @@ class Parsely {
 	}
 
 	/**
+	 * Deprecated. Please use the `Metadata` class instead.
+	 *
 	 * Creates parsely metadata object from post metadata.
+	 *
+	 * @deprecated 3.3.0
+	 * @see \Parsely\Metadata::construct_metadata
 	 *
 	 * @param array<string, mixed> $parsely_options parsely_options array.
 	 * @param WP_Post              $post object.
 	 * @return array<string, mixed>
 	 */
 	public function construct_parsely_metadata( array $parsely_options, WP_Post $post ): array {
+		_deprecated_function( 'Parsely::construct_parsely_metadata', '3.3.0' );
 		$metadata = new Metadata( $this );
 		return $metadata->construct_metadata( $parsely_options, $post );
 	}

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -343,7 +343,6 @@ class Parsely {
 	 * @return array<string, mixed>
 	 */
 	public function construct_parsely_metadata( array $parsely_options, WP_Post $post ): array {
-		_deprecated_function( 'Parsely::construct_parsely_metadata', '3.3.0' );
 		$metadata = new Metadata( $this );
 		return $metadata->construct_metadata( $parsely_options, $post );
 	}

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -232,7 +232,7 @@ final class RestMetadataTest extends TestCase {
 
 		$meta_string = self::$rest->get_rendered_meta( 'json_ld' );
 		$expected    = '<script type="application/ld+json">
-{"@context":"http:\/\/schema.org","@type":"NewsArticle","mainEntityOfPage":{"@type":"WebPage","@id":"http:\/\/example.org\/?p=' . $post_id . '"},"headline":"My test_get_rendered_meta_json_ld title","url":"http:\/\/example.org\/?p=' . $post_id . '","thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"dateCreated":"' . $date . '","datePublished":"' . $date . '","dateModified":"' . $date . '","articleSection":"Uncategorized","author":[],"creator":[],"publisher":{"@type":"Organization","name":"Test Blog","logo":""},"keywords":[]}
+{"@context":"https:\/\/schema.org","@type":"NewsArticle","mainEntityOfPage":{"@type":"WebPage","@id":"http:\/\/example.org\/?p=' . $post_id . '"},"headline":"My test_get_rendered_meta_json_ld title","url":"http:\/\/example.org\/?p=' . $post_id . '","thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"dateCreated":"' . $date . '","datePublished":"' . $date . '","dateModified":"' . $date . '","articleSection":"Uncategorized","author":[],"creator":[],"publisher":{"@type":"Organization","name":"Test Blog","logo":""},"keywords":[]}
 </script>';
 		self::assertEquals( $expected, $meta_string );
 	}

--- a/tests/Integration/GetCurrentUrlTest.php
+++ b/tests/Integration/GetCurrentUrlTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Parsely\Tests\Integration;
 
 use Parsely\Parsely;
+use Parsely\Metadata;
 
 /**
  * \Parsely\Parsely::get_current_url() tests.
@@ -127,8 +128,9 @@ final class GetCurrentUrlTest extends TestCase {
 	private function assertCurrentUrlForHomepage( string $expected ): void {
 		$this->go_to( '/' );
 
-		$parsely = new Parsely();
-		$res     = $parsely->get_current_url();
+		$metadata        = new Metadata( new Parsely() );
+		$get_current_url = self::getMethod( 'get_current_url', Metadata::class );
+		$res             = $get_current_url->invoke( $metadata );
 
 		self::assertEquals( $expected . '/', $res, 'Homepage page does not match.' );
 	}
@@ -141,8 +143,9 @@ final class GetCurrentUrlTest extends TestCase {
 	private function assertCurrentUrlForSpecificPostWithId( string $expected ): void {
 		$post_id = $this->go_to_new_post();
 
-		$parsely = new Parsely();
-		$res     = $parsely->get_current_url( 'post', $post_id );
+		$metadata        = new Metadata( new Parsely() );
+		$get_current_url = self::getMethod( 'get_current_url', Metadata::class );
+		$res             = $get_current_url->invoke( $metadata, 'post', $post_id );
 
 		self::assertEquals( $expected . '/?p=' . $post_id, $res, 'Specific post by ID does not match.' );
 	}
@@ -153,9 +156,11 @@ final class GetCurrentUrlTest extends TestCase {
 	 * @param string $expected Expected start of the URL.
 	 */
 	private function assertCurrentUrlForRandomUrl( string $expected ): void {
-		$parsely = new Parsely();
 		$this->go_to( '/random/url/' );
-		$res = $parsely->get_current_url();
+
+		$metadata        = new Metadata( new Parsely() );
+		$get_current_url = self::getMethod( 'get_current_url', Metadata::class );
+		$res             = $get_current_url->invoke( $metadata );
 
 		$constructed_expected = $expected . '/random/url/';
 		self::assertEquals( $constructed_expected, $res, 'Random URL does not match.' );

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -53,6 +53,7 @@ const PARSELY_FILE    = __FILE__;
 
 require __DIR__ . '/src/class-parsely.php';
 require __DIR__ . '/src/class-scripts.php';
+require __DIR__ . '/src/class-metadata.php';
 require __DIR__ . '/src/class-dashboard-link.php';
 require __DIR__ . '/src/UI/class-admin-bar.php';
 require __DIR__ . '/src/Endpoints/class-metadata-endpoint.php';


### PR DESCRIPTION
## Description

We are working towards a better way of generating metadata in the plugin. All that logic lies currently on the `Parsely` class, which is a bit problematic. In this initial PR, we are simply moving the metadata-related methods from that class into their own `Metadata` class. 

The method's contents is fairly untouched (minus some minor adjustments due to moving), and we've added a proxy method on `Parsely` for backwards compatibility reasons.

## Motivation and Context

See https://github.com/Parsely/wp-parsely/issues/682

## How Has This Been Tested?

All tests pass and metadata is generated as usual.