### PR TITLE
Adding tracker URL to REST API

### DIFF
--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -19,7 +19,7 @@ use WP_Post;
  * @since 3.2.0 Renamed FQCN from `Parsely\Rest` to `Parsely\Endpoints\Rest_Metadata`.
  */
 class Rest_Metadata extends Metadata_Endpoint {
-	private const REST_VERSION = '1.0.0';
+	private const REST_VERSION = '1.1.0';
 
 	/**
 	 * Register fields in WordPress REST API
@@ -95,9 +95,22 @@ class Rest_Metadata extends Metadata_Endpoint {
 		 * @since 3.1.0
 		 *
 		 * @param bool $enabled True if enabled, false if not.
+		 * @param WP_Post|false $post Current post object.
 		 */
 		if ( apply_filters( 'wp_parsely_enable_rest_rendered_support', true, $post ) ) {
 			$response['rendered'] = $this->get_rendered_meta( $options['meta_type'] );
+		}
+
+		/**
+		 * Filter whether REST API support in rendered string format is enabled or not.
+		 *
+		 * @since 3.3.0
+		 *
+		 * @param bool $enabled True if enabled, false if not.
+		 * @param WP_Post|false $post Current post object.
+		 */
+		if ( apply_filters( 'wp_parsely_enable_tracker_url', true, $post ) ) {
+			$response['tracker_url'] = $this->parsely->get_tracker_url();
 		}
 
 		return $response;

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -102,7 +102,7 @@ class Rest_Metadata extends Metadata_Endpoint {
 		}
 
 		/**
-		 * Filter whether REST API support in rendered string format is enabled or not.
+		 * Filter whether the REST API returns the tracker URL.
 		 *
 		 * @since 3.3.0
 		 *

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -144,15 +144,14 @@ final class RestMetadataTest extends TestCase {
 
 		$meta_object = self::$rest->get_callback( get_post( $post_id, 'ARRAY_A' ) );
 		$expected    = array(
-			'version'  => '1.0.0',
-			'meta'     => self::$parsely->construct_parsely_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
-			'rendered' => self::$rest->get_rendered_meta( 'json_ld' ),
+			'version'     => '1.1.0',
+			'meta'        => self::$parsely->construct_parsely_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
+			'rendered'    => self::$rest->get_rendered_meta( 'json_ld' ),
+			'tracker_url' => 'https://cdn.parsely.com/keys/testkey/p.js',
 		);
 
 		self::assertEquals( $expected, $meta_object );
 	}
-
-
 
 	/**
 	 * Test that the get_rest_callback method is able to generate the `parsely` object for the REST API.
@@ -166,8 +165,29 @@ final class RestMetadataTest extends TestCase {
 
 		$meta_object = self::$rest->get_callback( get_post( $post_id, 'ARRAY_A' ) );
 		$expected    = array(
-			'version' => '1.0.0',
-			'meta'    => self::$parsely->construct_parsely_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
+			'version'     => '1.1.0',
+			'meta'        => self::$parsely->construct_parsely_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
+			'tracker_url' => 'https://cdn.parsely.com/keys/testkey/p.js',
+		);
+
+		self::assertEquals( $expected, $meta_object );
+	}
+
+	/**
+	 * Test that the get_rest_callback method is able to generate the `parsely` object for the REST API.
+	 *
+	 * @covers \Parsely\Endpoints\Rest_Metadata::get_callback
+	 */
+	public function test_get_callback_with_url_filter(): void {
+		add_filter( 'wp_parsely_enable_tracker_url', '__return_false' );
+		self::set_options( array( 'apikey' => 'testkey' ) );
+		$post_id = self::factory()->post->create();
+
+		$meta_object = self::$rest->get_callback( get_post( $post_id, 'ARRAY_A' ) );
+		$expected    = array(
+			'version'  => '1.1.0',
+			'meta'     => self::$parsely->construct_parsely_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
+			'rendered' => self::$rest->get_rendered_meta( 'json_ld' ),
 		);
 
 		self::assertEquals( $expected, $meta_object );
@@ -181,9 +201,10 @@ final class RestMetadataTest extends TestCase {
 	public function test_get_callback_with_non_existent_post(): void {
 		$meta_object = self::$rest->get_callback( array() );
 		$expected    = array(
-			'version'  => '1.0.0',
-			'meta'     => '',
-			'rendered' => '',
+			'version'     => '1.1.0',
+			'meta'        => '',
+			'rendered'    => '',
+			'tracker_url' => '',
 		);
 
 		self::assertEquals( $expected, $meta_object );


### PR DESCRIPTION
## Description

This PR brings feature parity back between the REST API and the GraphQL API. With this update, we're providing the tracking script URL generated according to the API key. This way, consumer sites will be able to fetch it directly from where the API is pointing them.

The feature can be disabled by a filter. This PR also includes additional tests to check the functionality.

## Motivation and Context

Closes https://github.com/Parsely/wp-parsely/issues/732.

## How Has This Been Tested?

We're leveraging the same functionality that GraphQL uses. To test, go to a REST API post or page and check in the `parsely` object. It should contain the `tracker_url` field.

## Screenshots (if appropriate)

<img width="586" alt="Screen Shot 2022-03-29 at 11 59 40 AM" src="https://user-images.githubusercontent.com/7188409/160586450-77491b15-a2cf-49fe-8825-31994cfdcac5.png">