### PR TITLE
Make WordPress_Cache use built-in caching functions

### DIFF
--- a/src/RemoteAPI/class-cached-proxy.php
+++ b/src/RemoteAPI/class-cached-proxy.php
@@ -10,8 +10,6 @@ declare(strict_types=1);
 
 namespace Parsely\RemoteAPI;
 
-use WP_Error;
-
 /**
  * Caching Decorator for the remote /related endpoint.
  */

--- a/src/RemoteAPI/class-wordpress-cache.php
+++ b/src/RemoteAPI/class-wordpress-cache.php
@@ -10,27 +10,10 @@ declare(strict_types=1);
 
 namespace Parsely\RemoteAPI;
 
-use WP_Object_Cache;
-
 /**
  * Remote API Adapter for the WordPress Object Cache.
  */
 class WordPress_Cache implements Cache {
-	/**
-	 * The WordPress Object Cache.
-	 *
-	 * @var WP_Object_Cache
-	 */
-	private $cache;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param WP_Object_Cache $cache A class that's compatible with the Cache Interface.
-	 */
-	public function __construct( WP_Object_Cache $cache ) {
-		$this->cache = $cache;
-	}
 
 	/**
 	 * Retrieves the cache contents from the cache by key and group.
@@ -46,7 +29,7 @@ class WordPress_Cache implements Cache {
 	 * @return mixed|false The cache contents on success, false on failure to retrieve contents.
 	 */
 	public function get( $key, string $group = '', bool $force = false, bool $found = null ) {
-		return $this->cache->get( $key, $group, $force, $found );
+		return wp_cache_get( $key, $group, $force, $found );
 	}
 
 	/**
@@ -62,7 +45,7 @@ class WordPress_Cache implements Cache {
 	 *                           Default 0 (no expiration).
 	 * @return bool True on success, false on failure.
 	 */
-	public function set( $key, $data, string $group = '', int $expire = 0 ): bool {
-		return $this->cache->set( $key, $data, $group, $expire );
+	public function set( $key, $data, string $group = '', $expire = 0 ): bool {
+		return wp_cache_set( $key, $data, $group, $expire ); // phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
 	}
 }

--- a/src/RemoteAPI/class-wordpress-cache.php
+++ b/src/RemoteAPI/class-wordpress-cache.php
@@ -46,6 +46,7 @@ class WordPress_Cache implements Cache {
 	 * @return bool True on success, false on failure.
 	 */
 	public function set( $key, $data, string $group = '', $expire = 0 ): bool {
-		return wp_cache_set( $key, $data, $group, $expire ); // phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
+		// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
+		return wp_cache_set( $key, $data, $group, $expire );
 	}
 }

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -141,7 +141,7 @@ function parsely_rest_api_init(): void {
 	$rest->run();
 
 	$proxy        = new Related_Proxy( $GLOBALS['parsely'] );
-	$cached_proxy = new Cached_Proxy( $proxy, new WordPress_Cache( $GLOBALS['wp_object_cache'] ) );
+	$cached_proxy = new Cached_Proxy( $proxy, new WordPress_Cache() );
 	$endpoint     = new Related_API_Proxy( $GLOBALS['parsely'], $cached_proxy );
 	$endpoint->run();
 }


### PR DESCRIPTION
## Description
In the initial implementation of `WordPress_Cache`, we were expecting an object of type `WP_Object_Cache` in the constructor, which was not always the case and could result in fatal errors. This new implementation tries to be more agnostic and work correctly in most scenarios.

## Motivation and Context
Fixes #749 

## How Has This Been Tested?
Manual local testing with a few well-known caching plugins. In one case, this patch actually had a beneficial result for object caching (didn't work in 3.2.0 release, but did work with this patch). However, this testing was done on a best-effort basis and some caching plugins didn't completely work due to the nature of the local devenv. If possible, we should test those changes in the environment that surfaced this issue. But this PR seems to be beneficial and had an effect in one case. No fatal errors were encountered during testing with this patch or the original 3.2.0 release.