### PR TITLE
Release 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -611,7 +611,7 @@ If you are using the plugin without any code-level customizations (for instance,
 - Initial version.
 - Add support for parsely-page and JavaScript on home page and published pages and posts as well as archive pages (date/author/category/tag).
 
-[3.2.0]: https://github.com/Parsely/wp-parsely/compare/3.2.0...3.2.1
+[3.2.1]: https://github.com/Parsely/wp-parsely/compare/3.2.0...3.2.1
 [3.2.0]: https://github.com/Parsely/wp-parsely/compare/3.1.3...3.2.0
 [3.1.3]: https://github.com/Parsely/wp-parsely/compare/3.1.2...3.1.3
 [3.1.2]: https://github.com/Parsely/wp-parsely/compare/3.1.1...3.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - 2022-04-01
+
+### Fixed
+
+- The Recommended Widget Proxy would fail to work with certain third-party cache plugins. [#750](https://github.com/Parsely/wp-parsely/pull/750)
+
 ## [3.2.0] - 2022-03-29
 
 The 3.2.0 release introduces many new features, including:
@@ -605,6 +611,7 @@ If you are using the plugin without any code-level customizations (for instance,
 - Initial version.
 - Add support for parsely-page and JavaScript on home page and published pages and posts as well as archive pages (date/author/category/tag).
 
+[3.2.0]: https://github.com/Parsely/wp-parsely/compare/3.2.0...3.2.1
 [3.2.0]: https://github.com/Parsely/wp-parsely/compare/3.1.3...3.2.0
 [3.1.3]: https://github.com/Parsely/wp-parsely/compare/3.1.2...3.1.3
 [3.1.2]: https://github.com/Parsely/wp-parsely/compare/3.1.1...3.1.2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.2.0  
+Stable tag: 3.2.1  
 Requires at least: 5.0  
 Tested up to: 5.9.2  
 Requires PHP: 7.1  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.2.0",
+	"version": "3.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.2.0",
+			"version": "3.2.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/dom-ready": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.2.0",
+	"version": "3.2.1",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, pauarge",

--- a/src/RemoteAPI/class-cached-proxy.php
+++ b/src/RemoteAPI/class-cached-proxy.php
@@ -10,8 +10,6 @@ declare(strict_types=1);
 
 namespace Parsely\RemoteAPI;
 
-use WP_Error;
-
 /**
  * Caching Decorator for the remote /related endpoint.
  */

--- a/src/RemoteAPI/class-wordpress-cache.php
+++ b/src/RemoteAPI/class-wordpress-cache.php
@@ -10,27 +10,10 @@ declare(strict_types=1);
 
 namespace Parsely\RemoteAPI;
 
-use WP_Object_Cache;
-
 /**
  * Remote API Adapter for the WordPress Object Cache.
  */
 class WordPress_Cache implements Cache {
-	/**
-	 * The WordPress Object Cache.
-	 *
-	 * @var WP_Object_Cache
-	 */
-	private $cache;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param WP_Object_Cache $cache A class that's compatible with the Cache Interface.
-	 */
-	public function __construct( WP_Object_Cache $cache ) {
-		$this->cache = $cache;
-	}
 
 	/**
 	 * Retrieves the cache contents from the cache by key and group.
@@ -46,7 +29,7 @@ class WordPress_Cache implements Cache {
 	 * @return mixed|false The cache contents on success, false on failure to retrieve contents.
 	 */
 	public function get( $key, string $group = '', bool $force = false, bool $found = null ) {
-		return $this->cache->get( $key, $group, $force, $found );
+		return wp_cache_get( $key, $group, $force, $found );
 	}
 
 	/**
@@ -62,7 +45,8 @@ class WordPress_Cache implements Cache {
 	 *                           Default 0 (no expiration).
 	 * @return bool True on success, false on failure.
 	 */
-	public function set( $key, $data, string $group = '', int $expire = 0 ): bool {
-		return $this->cache->set( $key, $data, $group, $expire );
+	public function set( $key, $data, string $group = '', $expire = 0 ): bool {
+		// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
+		return wp_cache_set( $key, $data, $group, $expire );
 	}
 }

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -1,6 +1,6 @@
 import { activatePlugin, loginUser, visitAdminPage } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.2.0';
+export const PLUGIN_VERSION = '3.2.1';
 
 export const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://www.parse.ly/help/integration/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.2.0
+ * Version:           3.2.1
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -48,7 +48,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.2.0';
+const PARSELY_VERSION = '3.2.1';
 const PARSELY_FILE    = __FILE__;
 
 require __DIR__ . '/src/class-parsely.php';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -141,7 +141,7 @@ function parsely_rest_api_init(): void {
 	$rest->run();
 
 	$proxy        = new Related_Proxy( $GLOBALS['parsely'] );
-	$cached_proxy = new Cached_Proxy( $proxy, new WordPress_Cache( $GLOBALS['wp_object_cache'] ) );
+	$cached_proxy = new Cached_Proxy( $proxy, new WordPress_Cache() );
 	$endpoint     = new Related_API_Proxy( $GLOBALS['parsely'], $cached_proxy );
 	$endpoint->run();
 }


### PR DESCRIPTION
Releasing 3.2.1, which fixes some rare issues that were reported by plugin users.

This branch cherry-picks some changes from develop (see commit history) and puts them into trunk. We are including the CHANGELOG and version bumps alongside.