### PR TITLE
Improve image URLs in generated metadata

### DIFF
--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -558,18 +558,17 @@ class Metadata {
 	}
 
 	/**
-	 * Get the first image from a post
-	 * https://css-tricks.com/snippets/wordpress/get-the-first-image-from-a-post/
+	 * Gets the first image from a post.
 	 *
 	 * @since 3.3.0 Moved to class-metadata
 	 *
-	 * @param WP_Post $post The post object you're interested in.
+	 * @param WP_Post $post The post object.
 	 * @return string
 	 */
 	private function get_first_image( WP_Post $post ): string {
 		ob_start();
 		ob_end_clean();
-		if ( preg_match_all( '/<img.+src=[\'"]( [^\'"]+ )[\'"].*>/i', $post->post_content, $matches ) ) {
+		if ( preg_match_all( '/\<img.+src\=(?:\"|\')(.+?)(?:\"|\')(?:.+?)\>/i', $post->post_content, $matches ) ) {
 			return $matches[1][0];
 		}
 		return '';

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -104,11 +104,12 @@ class Metadata {
 
 			// Get featured image and thumbnail. On failure, fall back to the post's first image.
 			$image_url = get_the_post_thumbnail_url( $post, 'full' );
-			if ( false !== $image_url ) {
-				$thumb_url = get_the_post_thumbnail_url( $post, 'thumbnail' );
-			} else {
-				$image_url = $this->get_first_image( $post );
-				$thumb_url = $image_url;
+			if ( false === $image_url ) {
+				$image_url = '';
+			}
+			$thumb_url = get_the_post_thumbnail_url( $post, 'thumbnail' );
+			if ( false === $thumb_url ) {
+				$thumb_url = '';
 			}
 
 			$tags = $this->get_tags( $post->ID );
@@ -554,23 +555,6 @@ class Metadata {
 			return $author->user_nicename;
 		}
 
-		return '';
-	}
-
-	/**
-	 * Gets the first image from a post.
-	 *
-	 * @since 3.3.0 Moved to class-metadata
-	 *
-	 * @param WP_Post $post The post object.
-	 * @return string
-	 */
-	private function get_first_image( WP_Post $post ): string {
-		ob_start();
-		ob_end_clean();
-		if ( preg_match_all( '/\<img.+src\=(?:\"|\')(.+?)(?:\"|\')(?:.+?)\>/i', $post->post_content, $matches ) ) {
-			return $matches[1][0];
-		}
 		return '';
 	}
 

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -102,7 +102,7 @@ class Metadata {
 			$authors  = $this->get_author_names( $post );
 			$category = $this->get_category_name( $post, $parsely_options );
 
-			// Get featured image and thumbnail. On failure, fall back to the post's first image.
+			// Get featured image and thumbnail.
 			$image_url = get_the_post_thumbnail_url( $post, 'full' );
 			if ( false === $image_url ) {
 				$image_url = '';

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -102,12 +102,13 @@ class Metadata {
 			$authors  = $this->get_author_names( $post );
 			$category = $this->get_category_name( $post, $parsely_options );
 
-			if ( has_post_thumbnail( $post ) ) {
-				$image_id  = get_post_thumbnail_id( $post );
-				$image_url = wp_get_attachment_image_src( $image_id );
-				$image_url = $image_url[0];
+			// Get featured image and thumbnail. On failure, fall back to the post's first image.
+			$image_url = get_the_post_thumbnail_url( $post, 'full' );
+			if ( false !== $image_url ) {
+				$thumb_url = get_the_post_thumbnail_url( $post, 'thumbnail' );
 			} else {
 				$image_url = $this->get_first_image( $post );
+				$thumb_url = $image_url;
 			}
 
 			$tags = $this->get_tags( $post->ID );
@@ -173,7 +174,7 @@ class Metadata {
 			);
 			$parsely_page['headline']         = $this->get_clean_parsely_page_value( get_the_title( $post ) );
 			$parsely_page['url']              = $this->get_current_url( 'post', $post->ID );
-			$parsely_page['thumbnailUrl']     = $image_url;
+			$parsely_page['thumbnailUrl']     = $thumb_url;
 			$parsely_page['image']            = array(
 				'@type' => 'ImageObject',
 				'url'   => $image_url,

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -104,11 +104,11 @@ class Metadata {
 
 			// Get featured image and thumbnail.
 			$image_url = get_the_post_thumbnail_url( $post, 'full' );
-			if ( false === $image_url ) {
+			if ( ! is_string( $image_url ) ) {
 				$image_url = '';
 			}
 			$thumb_url = get_the_post_thumbnail_url( $post, 'thumbnail' );
-			if ( false === $thumb_url ) {
+			if ( ! is_string( $thumb_url ) ) {
 				$thumb_url = '';
 			}
 

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -77,7 +77,6 @@ final class OtherTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
@@ -126,7 +125,6 @@ final class OtherTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint

--- a/tests/Integration/StructuredData/AuthorArchiveTest.php
+++ b/tests/Integration/StructuredData/AuthorArchiveTest.php
@@ -29,7 +29,6 @@ final class AuthorArchiveTest extends NonPostTestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status

--- a/tests/Integration/StructuredData/BlogArchiveTest.php
+++ b/tests/Integration/StructuredData/BlogArchiveTest.php
@@ -29,7 +29,6 @@ final class BlogArchiveTest extends NonPostTestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status

--- a/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
@@ -30,7 +30,6 @@ final class CustomPostTypeArchiveTest extends NonPostTestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status

--- a/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
@@ -30,7 +30,6 @@ class CustomTaxonomyTermArchiveTest extends NonPostTestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status

--- a/tests/Integration/StructuredData/HomePageTest.php
+++ b/tests/Integration/StructuredData/HomePageTest.php
@@ -40,7 +40,6 @@ final class HomePageTest extends NonPostTestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
@@ -86,7 +85,6 @@ final class HomePageTest extends NonPostTestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
@@ -137,7 +135,6 @@ final class HomePageTest extends NonPostTestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
@@ -189,7 +186,6 @@ final class HomePageTest extends NonPostTestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status

--- a/tests/Integration/StructuredData/SinglePageTest.php
+++ b/tests/Integration/StructuredData/SinglePageTest.php
@@ -30,7 +30,6 @@ final class SinglePageTest extends NonPostTestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status

--- a/tests/Integration/StructuredData/SinglePostTest.php
+++ b/tests/Integration/StructuredData/SinglePostTest.php
@@ -40,7 +40,6 @@ final class SinglePostTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
@@ -79,7 +78,6 @@ final class SinglePostTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
@@ -114,7 +112,6 @@ final class SinglePostTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
@@ -161,7 +158,6 @@ final class SinglePostTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
 	 * @uses \Parsely\Parsely::get_custom_taxonomy_values
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
@@ -208,7 +204,6 @@ final class SinglePostTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
 	 * @uses \Parsely\Parsely::get_custom_taxonomy_values
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
@@ -265,7 +260,6 @@ final class SinglePostTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::get_top_level_term
@@ -322,7 +316,6 @@ final class SinglePostTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::get_top_level_term
@@ -390,7 +383,6 @@ final class SinglePostTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
@@ -441,7 +433,6 @@ final class SinglePostTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status

--- a/tests/Integration/StructuredData/TermArchiveTest.php
+++ b/tests/Integration/StructuredData/TermArchiveTest.php
@@ -29,7 +29,6 @@ final class TermArchiveTest extends NonPostTestCase {
 	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
 	 * @uses \Parsely\Parsely::get_coauthor_names
 	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status


### PR DESCRIPTION
## Description
This PR:
- Fixes our metadata generation function that would erroneously limit all featured image URLs to thumbnail size.
- Removes the `get_first_image()` fallback function (which was not working), in favor of letting the Parse.ly crawler select the image URL by itself (should usually be the first image in the page).

## Motivation and Context

Fix #703

See #682 

## How Has This Been Tested?
- Manual testing on local devenv.
- Automated tests pass.