### PR TITLE
Update @uses and @covers comments taking into account Metadata class

### DIFF
--- a/tests/Integration/GetCurrentUrlTest.php
+++ b/tests/Integration/GetCurrentUrlTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * \Parsely\Parsely::get_current_url() tests.
+ * \Parsely\Metadata::get_current_url() tests.
  *
  * @package Parsely\Tests
  */
@@ -13,7 +13,7 @@ use Parsely\Parsely;
 use Parsely\Metadata;
 
 /**
- * \Parsely\Parsely::get_current_url() tests.
+ * \Parsely\Metadata::get_current_url() tests.
  */
 final class GetCurrentUrlTest extends TestCase {
 	/**
@@ -103,7 +103,7 @@ final class GetCurrentUrlTest extends TestCase {
 	 *
 	 * @testdox Given Force HTTPS is $force_https, when home is $home, then expect URLs starting with $expected.
 	 * @dataProvider data_for_test_get_current_url
-	 * @covers \Parsely\Parsely::get_current_url
+	 * @covers \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 *

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -70,16 +70,16 @@ final class OtherTest extends TestCase {
 	 * Check out page filtering.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -119,15 +119,15 @@ final class OtherTest extends TestCase {
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 */

--- a/tests/Integration/StructuredData/AuthorArchiveTest.php
+++ b/tests/Integration/StructuredData/AuthorArchiveTest.php
@@ -22,16 +22,16 @@ final class AuthorArchiveTest extends NonPostTestCase {
 	 * Check metadata for author archive.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/StructuredData/BlogArchiveTest.php
+++ b/tests/Integration/StructuredData/BlogArchiveTest.php
@@ -22,16 +22,16 @@ final class BlogArchiveTest extends NonPostTestCase {
 	 * Create a single page, set as the posts page (blog archive) but not the home page, go to Page 2, and test the structured data.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
@@ -23,16 +23,16 @@ final class CustomPostTypeArchiveTest extends NonPostTestCase {
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
 	 * @uses \Parsely\Parsely::__construct
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
@@ -23,16 +23,16 @@ class CustomTaxonomyTermArchiveTest extends NonPostTestCase {
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
 	 * @uses \Parsely\Parsely::__construct
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/StructuredData/HomePageTest.php
+++ b/tests/Integration/StructuredData/HomePageTest.php
@@ -33,16 +33,16 @@ final class HomePageTest extends NonPostTestCase {
 	 * Create a single page, set as homepage (blog archive), and test the structured data.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -79,16 +79,16 @@ final class HomePageTest extends NonPostTestCase {
 	 * Create 2 posts, set posts per page to 1, navigate to page 2 and test the structured data.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -130,16 +130,16 @@ final class HomePageTest extends NonPostTestCase {
 	 * Create a single page, set as homepage (page on front), and test the structured data.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -182,16 +182,16 @@ final class HomePageTest extends NonPostTestCase {
 	 * Check for the case when the show_on_front setting is Page, but no Page has been selected.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/StructuredData/SinglePageTest.php
+++ b/tests/Integration/StructuredData/SinglePageTest.php
@@ -23,16 +23,16 @@ final class SinglePageTest extends NonPostTestCase {
 	 * Create a single page, and test the structured data.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/StructuredData/SinglePostTest.php
+++ b/tests/Integration/StructuredData/SinglePostTest.php
@@ -33,16 +33,16 @@ final class SinglePostTest extends TestCase {
 	 * Create a single post, and test the structured data.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -72,16 +72,16 @@ final class SinglePostTest extends TestCase {
 	 * Check the category.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -107,16 +107,16 @@ final class SinglePostTest extends TestCase {
 	 * Check that the tags assigned to a post are lowercase.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -152,18 +152,18 @@ final class SinglePostTest extends TestCase {
 	 * Check the categories as tags.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_categories
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_custom_taxonomy_values
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_categories
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
+	 * @uses \Parsely\Metadata::get_custom_taxonomy_values
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -199,18 +199,18 @@ final class SinglePostTest extends TestCase {
 	 * Test custom taxonomy terms, categories, and tags in the metadata.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_categories
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
-	 * @uses \Parsely\Parsely::get_custom_taxonomy_values
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_categories
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
+	 * @uses \Parsely\Metadata::get_custom_taxonomy_values
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -258,17 +258,17 @@ final class SinglePostTest extends TestCase {
 	 * Are the top level categories what we expect?
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
-	 * @uses \Parsely\Parsely::get_top_level_term
+	 * @uses \Parsely\Metadata::get_tags
+	 * @uses \Parsely\Metadata::get_top_level_term
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -315,17 +315,17 @@ final class SinglePostTest extends TestCase {
 	 * Check out the custom taxonomy as section.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
-	 * @uses \Parsely\Parsely::get_top_level_term
+	 * @uses \Parsely\Metadata::get_tags
+	 * @uses \Parsely\Metadata::get_top_level_term
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -383,16 +383,16 @@ final class SinglePostTest extends TestCase {
 	 * Check the canonicals.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -434,16 +434,16 @@ final class SinglePostTest extends TestCase {
 	 * Check post modified date in Parsely metadata.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -486,7 +486,7 @@ final class SinglePostTest extends TestCase {
 	 * Check that post objects with valid creation date work with construct_parsely_metadata.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @covers \Parsely\Parsely::set_metadata_post_times
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @group metadata
 	 */
 	public function test_empty_post_date_has_dates_omitted_from_metadata(): void {
@@ -514,7 +514,7 @@ final class SinglePostTest extends TestCase {
 	 * Check that post objects with identical creation & modified dates produce expected metadata.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @covers \Parsely\Parsely::set_metadata_post_times
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @group metadata
 	 */
 	public function test_post_date_with_same_create_modified_dates_included_in_metadata(): void {
@@ -548,7 +548,7 @@ final class SinglePostTest extends TestCase {
 	 * Check that posts with modified before creation date "promotes" modified in metadata.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @covers \Parsely\Parsely::set_metadata_post_times
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @group metadata
 	 */
 	public function test_post_date_with_modified_before_created_date_in_metadata(): void {
@@ -583,7 +583,7 @@ final class SinglePostTest extends TestCase {
 	 * Check that posts with modified after creation date has both in metadata.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @covers \Parsely\Parsely::set_metadata_post_times
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @group metadata
 	 */
 	public function test_post_date_with_modified_after_created_date_in_metadata(): void {
@@ -637,7 +637,7 @@ final class SinglePostTest extends TestCase {
 	 * @since 3.0.3
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_categories
+	 * @uses \Parsely\Metadata::get_categories
 	 */
 	public function test_post_with_categories_as_tags_without_categories(): void {
 		// Setup Parsely object.

--- a/tests/Integration/StructuredData/TermArchiveTest.php
+++ b/tests/Integration/StructuredData/TermArchiveTest.php
@@ -22,16 +22,16 @@ final class TermArchiveTest extends NonPostTestCase {
 	 * Check metadata for term archive.
 	 *
 	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::get_author_name
-	 * @uses \Parsely\Parsely::get_author_names
-	 * @uses \Parsely\Parsely::get_bottom_level_term
-	 * @uses \Parsely\Parsely::get_category_name
-	 * @uses \Parsely\Parsely::get_clean_parsely_page_value
-	 * @uses \Parsely\Parsely::get_coauthor_names
-	 * @uses \Parsely\Parsely::get_current_url
+	 * @uses \Parsely\Metadata::get_author_name
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
 	 * @uses \Parsely\Parsely::get_first_image
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_tags
+	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata


### PR DESCRIPTION
## Description
We recently moved some functions to the `Metadata` class, but test comments (`@uses` and `@covers`) did not take this into account, showing broken paths. This PR updates function paths wherever needed.

Note: paths to the `get_first_image()` function were not updated due to its removal in comments within #758.

## Motivation and Context
Have correct function paths into our tests.

## How Has This Been Tested?
- Comment changes only, should not impact any code
- Automated tests pass