### PR TITLE
README.md: Update "Tested up to" to 5.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Stable tag: 3.3.0-alpha  
 Requires at least: 5.0  
-Tested up to: 5.9.2  
+Tested up to: 5.9.3  
 Requires PHP: 7.1  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  


### PR DESCRIPTION
## Description
This PR bumps the "Tested up to" section of the README to 5.9.3.

## Motivation and Context
- Make information current in the README.

## How Has This Been Tested?
- Running the plugin successfully on WordPress 5.9.3.
- Automated tests pass.