### PR TITLE
Getting rid of construct metadata usages

### DIFF
--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -64,10 +64,10 @@ abstract class Metadata_Endpoint {
 	 * @return string The metadata as HTML code.
 	 */
 	public function get_rendered_meta( string $meta_type ): string {
-		$metadata = new Metadata_Renderer( $this->parsely );
+		$metadata_renderer = new Metadata_Renderer( $this->parsely );
 
 		ob_start();
-		$metadata->render_metadata( $meta_type );
+		$metadata_renderer->render_metadata( $meta_type );
 		$out = ob_get_clean();
 
 		if ( false === $out ) {

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -80,15 +80,14 @@ class Rest_Metadata extends Metadata_Endpoint {
 		$options = $this->parsely->get_options();
 
 		if ( false === $post ) {
-			$meta = '';
+			$metadata = '';
 		} else {
-			$metadata = new Metadata( $this->parsely );
-			$meta     = $metadata->construct_metadata( $options, $post );
+			$metadata = ( new Metadata( $this->parsely ) )->construct_metadata( $options, $post );
 		}
 
 		$response = array(
 			'version' => self::REST_VERSION,
-			'meta'    => $meta,
+			'meta'    => $metadata,
 		);
 
 		/**

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Parsely\Endpoints;
 
+use Parsely\Metadata;
 use WP_Post;
 
 /**
@@ -81,7 +82,8 @@ class Rest_Metadata extends Metadata_Endpoint {
 		if ( false === $post ) {
 			$meta = '';
 		} else {
-			$meta = $this->parsely->construct_parsely_metadata( $options, $post );
+			$metadata = new Metadata( $this->parsely );
+			$meta     = $metadata->construct_metadata( $options, $post );
 		}
 
 		$response = array(

--- a/src/UI/class-metadata-renderer.php
+++ b/src/UI/class-metadata-renderer.php
@@ -56,8 +56,20 @@ final class Metadata_Renderer {
 		 * @param bool $insert_metadata True to insert the metadata, false otherwise.
 		 */
 		if ( apply_filters( 'wp_parsely_should_insert_metadata', true ) ) {
-			add_action( 'wp_head', array( $this, 'render_metadata' ) );
+			add_action( 'wp_head', array( $this, 'render_metadata_on_head' ) );
 		}
+	}
+
+	/**
+	 * Renders metadata on site's head using the format from the site's options.
+	 *
+	 * @since 3.3.0
+	 *
+	 * @return void
+	 */
+	public function render_metadata_on_head(): void {
+		$parsely_options = $this->parsely->get_options();
+		$this->render_metadata( $parsely_options['meta_type'] );
 	}
 
 	/**

--- a/src/UI/class-metadata-renderer.php
+++ b/src/UI/class-metadata-renderer.php
@@ -97,11 +97,10 @@ final class Metadata_Renderer {
 
 		// Assign default values for LD+JSON
 		// TODO: Mapping of an install's post types to Parse.ly post types (namely page/post).
-		$metadata     = new Metadata( $this->parsely );
-		$parsely_page = $metadata->construct_metadata( $parsely_options, $parsed_post );
+		$metadata = ( new Metadata( $this->parsely ) )->construct_metadata( $parsely_options, $post );
 
 		// Something went wrong - abort.
-		if ( 0 === count( $parsely_page ) || ! isset( $parsely_page['headline'] ) ) {
+		if ( 0 === count( $metadata ) || ! isset( $metadata['headline'] ) ) {
 			return;
 		}
 
@@ -110,25 +109,25 @@ final class Metadata_Renderer {
 			include plugin_dir_path( PARSELY_FILE ) . 'views/json-ld.php';
 		} else {
 			// Assume `meta_type` is `repeated_metas`.
-			$parsely_post_type = $this->parsely->convert_jsonld_to_parsely_type( $parsely_page['@type'] );
-			if ( isset( $parsely_page['keywords'] ) && is_array( $parsely_page['keywords'] ) ) {
-				$parsely_page['keywords'] = implode( ',', $parsely_page['keywords'] );
+			$parsely_post_type = $this->parsely->convert_jsonld_to_parsely_type( $metadata['@type'] );
+			if ( isset( $metadata['keywords'] ) && is_array( $metadata['keywords'] ) ) {
+				$metadata['keywords'] = implode( ',', $metadata['keywords'] );
 			}
 
 			$parsely_metas = array(
-				'title'     => $parsely_page['headline'] ?? null,
-				'link'      => $parsely_page['url'] ?? null,
+				'title'     => $metadata['headline'] ?? null,
+				'link'      => $metadata['url'] ?? null,
 				'type'      => $parsely_post_type,
-				'image-url' => $parsely_page['thumbnailUrl'] ?? null,
-				'pub-date'  => $parsely_page['datePublished'] ?? null,
-				'section'   => $parsely_page['articleSection'] ?? null,
-				'tags'      => $parsely_page['keywords'] ?? null,
-				'author'    => isset( $parsely_page['author'] ),
+				'image-url' => $metadata['thumbnailUrl'] ?? null,
+				'pub-date'  => $metadata['datePublished'] ?? null,
+				'section'   => $metadata['articleSection'] ?? null,
+				'tags'      => $metadata['keywords'] ?? null,
+				'author'    => isset( $metadata['author'] ),
 			);
 			$parsely_metas = array_filter( $parsely_metas, array( $this, 'filter_empty_and_not_string_from_array' ) );
 
-			if ( isset( $parsely_page['author'] ) ) {
-				$parsely_page_authors = wp_list_pluck( $parsely_page['author'], 'name' );
+			if ( isset( $metadata['author'] ) ) {
+				$parsely_page_authors = wp_list_pluck( $metadata['author'], 'name' );
 				$parsely_page_authors = array_filter( $parsely_page_authors, array( $this, 'filter_empty_and_not_string_from_array' ) );
 			}
 
@@ -136,7 +135,7 @@ final class Metadata_Renderer {
 		}
 
 		// Add any custom metadata.
-		if ( isset( $parsely_page['custom_metadata'] ) ) {
+		if ( isset( $metadata['custom_metadata'] ) ) {
 			include plugin_dir_path( PARSELY_FILE ) . 'views/custom-metadata.php';
 		}
 	}

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -257,8 +257,7 @@ class Parsely {
 			return;
 		}
 
-		$metadata_obj = new Metadata( $this );
-		$metadata     = $metadata_obj->construct_metadata( $parsely_options, $post );
+		$metadata = ( new Metadata( $this ) )->construct_metadata( $parsely_options, $post );
 
 		$endpoint_metadata = array(
 			'canonical_url' => $metadata['url'],
@@ -327,7 +326,7 @@ class Parsely {
 				ARRAY_N
 			);
 			foreach ( $results as $result ) {
-				array_push( $ids, $result[0] );
+				$ids[] = $result[0];
 			}
 			wp_cache_set( 'parsely_post_ids_need_meta_updating', $ids, '', 86400 );
 		}

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -156,8 +156,8 @@ class Parsely {
 	 */
 	public function render_metadata( string $meta_type ): void {
 		_deprecated_function( __FUNCTION__, '3.3', 'Metadata_Renderer::render_metadata()' );
-		$metadata = new Metadata_Renderer( $this );
-		$metadata->render_metadata( $meta_type );
+		$metadata_renderer = new Metadata_Renderer( $this );
+		$metadata_renderer->render_metadata( $meta_type );
 	}
 
 	/**
@@ -172,9 +172,9 @@ class Parsely {
 	 */
 	public function insert_page_header_metadata(): void {
 		_deprecated_function( __FUNCTION__, '3.3', 'Metadata_Renderer::render_metadata()' );
-		$parsely_options = $this->get_options();
-		$metadata        = new Metadata_Renderer( $this );
-		$metadata->render_metadata( $parsely_options['meta_type'] );
+		$parsely_options   = $this->get_options();
+		$metadata_renderer = new Metadata_Renderer( $this );
+		$metadata_renderer->render_metadata( $parsely_options['meta_type'] );
 	}
 
 	/**

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -248,13 +248,17 @@ class Parsely {
 	 */
 	public function update_metadata_endpoint( int $post_id ): void {
 		$parsely_options = $this->get_options();
-
 		if ( $this->api_key_is_missing() || empty( $parsely_options['metadata_secret'] ) ) {
 			return;
 		}
 
-		$post     = get_post( $post_id );
-		$metadata = $this->construct_parsely_metadata( $parsely_options, $post );
+		$post = get_post( $post_id );
+		if ( null === $post ) {
+			return;
+		}
+
+		$metadata_obj = new Metadata( $this );
+		$metadata     = $metadata_obj->construct_metadata( $parsely_options, $post );
 
 		$endpoint_metadata = array(
 			'canonical_url' => $metadata['url'],

--- a/views/custom-metadata.php
+++ b/views/custom-metadata.php
@@ -13,4 +13,4 @@ declare(strict_types=1);
 namespace Parsely;
 
 ?>
-<meta name="parsely-metadata" content="<?php echo esc_attr( $parsely_page['custom_metadata'] ); ?>" />
+<meta name="parsely-metadata" content="<?php echo esc_attr( $metadata['custom_metadata'] ); ?>" />

--- a/views/json-ld.php
+++ b/views/json-ld.php
@@ -14,5 +14,5 @@ namespace Parsely;
 
 ?>
 <script type="application/ld+json">
-<?php echo wp_json_encode( $parsely_page ) . "\n"; ?>
+<?php echo wp_json_encode( $metadata ) . "\n"; ?>
 </script>

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -82,8 +82,8 @@ function parsely_initialize_plugin(): void {
 	$admin_bar = new Admin_Bar( $GLOBALS['parsely'] );
 	$admin_bar->run();
 
-	$metadata = new Metadata_Renderer( $GLOBALS['parsely'] );
-	$metadata->run();
+	$metadata_renderer = new Metadata_Renderer( $GLOBALS['parsely'] );
+	$metadata_renderer->run();
 }
 
 require __DIR__ . '/src/UI/class-admin-warning.php';


### PR DESCRIPTION
## Description

This PR continues on the metadata refactor by replacing the usages of the deprecated metadata generation methods by the new ones on `class-parsely.php`. We are also introducing changes to make calling to metadata classes more consistent.

## Motivation and Context

See #682 

## How Has This Been Tested?

The output of the metadata fields is consistent.