### PR TITLE
Adding e2e tests for metadata

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -144,7 +144,7 @@ class Parsely {
 	}
 
 	/**
-	 * Deprecated
+	 * Deprecated.
 	 * Insert the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
 	 *
 	 * @since 3.2.0

--- a/tests/e2e/specs/front-end-metadata.spec.js
+++ b/tests/e2e/specs/front-end-metadata.spec.js
@@ -37,6 +37,8 @@ describe( 'Front end metadata insertion', () => {
 		expect( content ).toContain( '<script type="application/ld+json">\n' +
 			'{"@context":"https:\\/\\/schema.org","@type":"WebPage","headline":"wp-parsely","url":"http:\\/\\/localhost:8889"}\n' +
 		'</script>' );
+
+		expect( content ).not.toContain( '<meta name="parsely-title" ' );
 	} );
 
 	it( 'Should insert JSON LD on post page', async () => {
@@ -48,6 +50,8 @@ describe( 'Front end metadata insertion', () => {
 
 		expect( content ).toContain( '<script type="application/ld+json">' );
 		expect( content ).toContain( '{"@context":"https:\\/\\/schema.org","@type":"NewsArticle","mainEntityOfPage":{"@type":"WebPage","@id":"http:\\/\\/localhost:8889\\/?p=1"},"headline":"Hello world!","url":"http:\\/\\/localhost:8889\\/?p=1","thumbnailUrl":"","image":{"@type":"ImageObject","url":""},' );
+
+		expect( content ).not.toContain( '<meta name="parsely-title" ' );
 	} );
 
 	it( 'Should insert repeated metas on homepage', async () => {
@@ -60,6 +64,8 @@ describe( 'Front end metadata insertion', () => {
 		expect( content ).toContain( '<meta name="parsely-title" content="wp-parsely">' );
 		expect( content ).toContain( '<meta name="parsely-link" content="http://localhost:8889">' );
 		expect( content ).toContain( '<meta name="parsely-type" content="index">' );
+
+		expect( content ).not.toContain( '<script type="application/ld+json">' );
 	} );
 
 	it( 'Should insert repeated metas on post page', async () => {
@@ -75,5 +81,7 @@ describe( 'Front end metadata insertion', () => {
 		expect( content ).toMatch( /<meta name="parsely-pub-date" content=".*Z">/ );
 		expect( content ).toContain( '<meta name="parsely-section" content="Uncategorized">' );
 		expect( content ).toContain( '<meta name="parsely-author" content="admin">' );
+
+		expect( content ).not.toContain( '<script type="application/ld+json">' );
 	} );
 } );

--- a/tests/e2e/specs/front-end-metadata.spec.js
+++ b/tests/e2e/specs/front-end-metadata.spec.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { createURL } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { changeKeysState, startUpTest } from '../utils';
+
+describe( 'Front end metadata insertion', () => {
+	beforeAll( startUpTest );
+
+	it( 'Should insert repeated metas on homepage', async () => {
+		await changeKeysState( true, false );
+
+		await page.goto( createURL( '/' ) );
+
+		const content = await page.content();
+
+		expect( content ).toContain( '<meta name="parsely-title" content="wp-parsely">' );
+		expect( content ).toContain( '<meta name="parsely-link" content="http://localhost:8889">' );
+		expect( content ).toContain( '<meta name="parsely-type" content="index">' );
+	} );
+
+	it( 'Should insert repeated metas on post page', async () => {
+		await changeKeysState( true, false );
+
+		await page.goto( createURL( '/', '?p=1' ) );
+
+		const content = await page.content();
+
+		expect( content ).toContain( '<meta name="parsely-title" content="Hello world!">' );
+		expect( content ).toContain( '<meta name="parsely-link" content="http://localhost:8889/?p=1">' );
+		expect( content ).toContain( '<meta name="parsely-type" content="post">' );
+		expect( content ).toContain( '<meta name="parsely-pub-date" content="' );
+		expect( content ).toContain( '<meta name="parsely-section" content="Uncategorized">' );
+		expect( content ).toContain( '<meta name="parsely-author" content="admin">' );
+	} );
+} );

--- a/tests/e2e/specs/front-end-metadata.spec.js
+++ b/tests/e2e/specs/front-end-metadata.spec.js
@@ -1,18 +1,38 @@
 /**
  * External dependencies
  */
-import { createURL } from '@wordpress/e2e-test-utils';
+import { createURL, visitAdminPage } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
  */
-import { changeKeysState, startUpTest } from '../utils';
+import { changeKeysState, selectScreenOptions, startUpTest } from '../utils';
+
+const setMetadataFormat = async ( format ) => {
+	await visitAdminPage( '/options-general.php', '?page=parsely' );
+	await selectScreenOptions( { recrawl: true, advanced: false } );
+
+	await page.select( '#parsely[meta_type]', format );
+
+	const [ input ] = await page.$x( '//p[contains(@class, \'submit\')]//input[contains(@name, \'submit\')]' );
+	await input.click();
+};
 
 describe( 'Front end metadata insertion', () => {
 	beforeAll( startUpTest );
 
-	it( 'Should insert repeated metas on homepage', async () => {
+	beforeEach( async () => {
 		await changeKeysState( true, false );
+	} );
+
+	it( 'Should insert JSON LD on homepage', async () => {
+		await setMetadataFormat( 'json_ld' );
+
+		await page.goto( createURL( '/' ) );
+	} );
+
+	it( 'Should insert repeated metas on homepage', async () => {
+		await setMetadataFormat( 'repeated_metas' );
 
 		await page.goto( createURL( '/' ) );
 
@@ -24,7 +44,7 @@ describe( 'Front end metadata insertion', () => {
 	} );
 
 	it( 'Should insert repeated metas on post page', async () => {
-		await changeKeysState( true, false );
+		await setMetadataFormat( 'repeated_metas' );
 
 		await page.goto( createURL( '/', '?p=1' ) );
 

--- a/tests/e2e/specs/front-end-metadata.spec.js
+++ b/tests/e2e/specs/front-end-metadata.spec.js
@@ -39,6 +39,17 @@ describe( 'Front end metadata insertion', () => {
 		'</script>' );
 	} );
 
+	it( 'Should insert JSON LD on post page', async () => {
+		await setMetadataFormat( 'json_ld' );
+
+		await page.goto( createURL( '/', '?p=1' ) );
+
+		const content = await page.content();
+
+		expect( content ).toContain( '<script type="application/ld+json">' );
+		expect( content ).toContain( '{"@context":"https:\\/\\/schema.org","@type":"NewsArticle","mainEntityOfPage":{"@type":"WebPage","@id":"http:\\/\\/localhost:8889\\/?p=1"},"headline":"Hello world!","url":"http:\\/\\/localhost:8889\\/?p=1","thumbnailUrl":"","image":{"@type":"ImageObject","url":""},' );
+	} );
+
 	it( 'Should insert repeated metas on homepage', async () => {
 		await setMetadataFormat( 'repeated_metas' );
 
@@ -61,7 +72,7 @@ describe( 'Front end metadata insertion', () => {
 		expect( content ).toContain( '<meta name="parsely-title" content="Hello world!">' );
 		expect( content ).toContain( '<meta name="parsely-link" content="http://localhost:8889/?p=1">' );
 		expect( content ).toContain( '<meta name="parsely-type" content="post">' );
-		expect( content ).toContain( '<meta name="parsely-pub-date" content="' );
+		expect( content ).toMatch( /<meta name="parsely-pub-date" content=".*Z">/ );
 		expect( content ).toContain( '<meta name="parsely-section" content="Uncategorized">' );
 		expect( content ).toContain( '<meta name="parsely-author" content="admin">' );
 	} );

--- a/tests/e2e/specs/front-end-tracker.spec.js
+++ b/tests/e2e/specs/front-end-tracker.spec.js
@@ -17,7 +17,7 @@ const getAssetVersion = () => {
 	return r[ 1 ];
 };
 
-describe( 'Front end code insertion', () => {
+describe( 'Front end tracking code insertion', () => {
 	beforeAll( startUpTest );
 
 	it( 'Should inject loading script homepage', async () => {


### PR DESCRIPTION
## Description

In this pull request we are adding end-to-end tests that check for the correct metadata insertion in the WordPress front-end.

## Motivation and Context

See #682 

## How Has This Been Tested?

Tests run consistently on CI and locally. No changes to the source code have been introduced.