### PR TITLE
Removing Dynamic Tracking references

### DIFF
--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -229,6 +229,10 @@ final class Settings_Page {
 	 */
 	public function add_help_text(): void {
 		$screen = get_current_screen();
+		if ( null === $screen ) {
+			return;
+		}
+
 		$screen->add_help_tab(
 			array(
 				'id'      => 'overview',
@@ -634,8 +638,9 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 * @since 3.1.0
 	 *
 	 * @param array $args The arguments for the form field. May contain 'help_text'.
+	 * @return void
 	 */
-	public function print_description_text( $args ) {
+	public function print_description_text( $args ): void {
 		echo isset( $args['help_text'] ) ? '<p class="description" id="' . esc_attr( $args['option_key'] ) . '-description">' . wp_kses_post( $args['help_text'] ) . '</p>' : '';
 	}
 
@@ -753,43 +758,13 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Prints out multiple selection in the form of checkboxes
-	 *
-	 * @param array $args The arguments for the checkboxes.
-	 * @return void
-	 */
-	public function print_multiple_checkboxes( array $args ): void {
-		$options        = $this->parsely->get_options();
-		$select_options = $args['select_options'];
-		$id             = esc_attr( $args['option_key'] );
-		$name           = Parsely::OPTIONS_KEY . "[$id]";
-
-		?>
-		<fieldset>
-			<legend class="screen-reader-text"><span><?php echo esc_html( $args['title'] ); ?></span></legend>
-		<?php
-		foreach ( $select_options as $key => $val ) {
-			$selected = in_array( $val, $options[ $args['option_key'] ], true );
-			printf(
-				'<label for="%1$s-%2$s"><input type="checkbox" name="%1$s[]" id="%1$s-%2$s" value="%2$s" ',
-				esc_attr( $name ),
-				esc_attr( $key )
-			);
-			echo checked( $selected, true, false );
-			echo sprintf( ' /> %s</label><br />', esc_attr( $val ) );
-		}
-
-		$this->print_description_text( $args );
-	}
-
-	/**
 	 * Print out a "single-image browse control" which includes a text
 	 * input to store image path and a button to browse for images.
 	 *
 	 * @param array $args The arguments for the control.
 	 * @return void
 	 */
-	public function print_media_single_image( array $args ) {
+	public function print_media_single_image( array $args ): void {
 		$key         = $args['option_key'];
 		$input_value = $this->parsely->get_options()[ $key ];
 		$input_name  = Parsely::OPTIONS_KEY . "[$key]";

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -234,8 +234,7 @@ final class Settings_Page {
 				'id'      => 'overview',
 				'title'   => __( 'Overview', 'wp-parsely' ),
 				'content' => '<p>' . __( 'The only required setting on this page is the Site ID. All of the other settings are optional.', 'wp-parsely' ) . '</p>' .
-					'<p>' . __( 'You must click the Save Changes button at the bottom of the screen for new settings to take effect.', 'wp-parsely' ) . '</p>' .
-					'<p>' . __( 'This plugin does not currently support dynamic tracking (the tracking of multiple pageviews on a single page). Some common use-cases for dynamic tracking are slideshows or articles loaded via AJAX calls in single-page applications — situations in which new content is loaded without a full page refresh. Tracking these events requires manually implementing additional JavaScript above <a href="https://www.parsely.com/help/integration/basic/">the standard Parse.ly include</a> that the plugin injects into your page source. Please consult <a href="https://www.parsely.com/help/integration/dynamic/">the Parse.ly documentation on dynamic tracking</a> for instructions on implementing dynamic tracking, or contact Parse.ly support (<a href="mailto:support@parsely.com">support@parsely.com</a>) for additional assistance.', 'wp-parsely' ) . '</p>',
+					'<p>' . __( 'You must click the Save Changes button at the bottom of the screen for new settings to take effect.', 'wp-parsely' ) . '</p>',
 			)
 		);
 		$screen->add_help_tab(
@@ -1168,21 +1167,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 		if ( isset( $input[ $track_as ] ) ) {
 			unset( $input[ $track_as ] );
 		}
-	}
-
-	/**
-	 * Show our note about dynamic tracking.
-	 *
-	 * @return void
-	 */
-	public function print_dynamic_tracking_note(): void {
-		printf(
-		/* translators: 1: Documentation URL 2: Documentation URL */
-			wp_kses_post( __( 'This plugin does not currently support dynamic tracking ( the tracking of multiple pageviews on a single page). Some common use-cases for dynamic tracking are slideshows or articles loaded via AJAX calls in single-page applications -- situations in which new content is loaded without a full page refresh. Tracking these events requires manually implementing additional JavaScript above <a href="%1$s">the standard Parse.ly include</a> that the plugin injects into your page source. Please consult <a href="%2$s">the Parse.ly documentation on dynamic tracking</a> for instructions on implementing dynamic tracking, or contact Parse.ly support (<a href="%3$s">support@parsely.com</a> ) for additional assistance.', 'wp-parsely' ) ),
-			esc_url( 'http://www.parsely.com/help/integration/basic/' ),
-			esc_url( 'https://www.parsely.com/help/integration/dynamic/' ),
-			esc_url( 'mailto:support@parsely.com' )
-		);
 	}
 
 	/**


### PR DESCRIPTION
## Description

In preparation for the upcoming work on Dynamic Tracking, we are removing the references in the settings page to the plugin not supporting it. At this stage, this comment was already misleading. 

We are also removing a chunk of dead code -- the `print_dynamic_tracking_note` and `print_multiple_checkboxes` functions.

## Motivation and Context

See #35 

## How Has This Been Tested?

See screenshots below.

## Screenshots (if appropriate)

*Before*

<img width="871" alt="Screen Shot 2022-04-19 at 9 10 19 AM" src="https://user-images.githubusercontent.com/7188409/163946129-d16d675f-70b4-4381-bde8-b12cb58d9a2c.png">

*After*

<img width="876" alt="Screen Shot 2022-04-19 at 9 10 02 AM" src="https://user-images.githubusercontent.com/7188409/163946197-c2c1c04b-9e6f-497a-ae7e-b6bfaf481854.png">
