### PR TITLE
Recommendations Block: Fix thumbnail images not showing

### DIFF
--- a/src/Endpoints/class-related-api-proxy.php
+++ b/src/Endpoints/class-related-api-proxy.php
@@ -117,9 +117,10 @@ final class Related_API_Proxy {
 		$data = array_map(
 			static function( stdClass $link ) {
 				return (object) array(
-					'image_url' => $link->image_url,
-					'title'     => $link->title,
-					'url'       => $link->url,
+					'image_url'        => $link->image_url,
+					'thumb_url_medium' => $link->thumb_url_medium,
+					'title'            => $link->title,
+					'url'              => $link->url,
 				);
 			},
 			$links

--- a/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
@@ -113,7 +113,7 @@ final class RelatedProxyEndpointTest extends TestCase {
 			function () use ( &$dispatched ) {
 				$dispatched++;
 				return array(
-					'body' => '{"data":[{"image_url":"https:\/\/example.com\/img.png","title":"something","url":"https:\/\/example.com"},{"image_url":"https:\/\/example.com\/img2.png","title":"something2","url":"https:\/\/example.com\/2"}]}',
+					'body' => '{"data":[{"image_url":"https:\/\/example.com\/img.png","thumb_url_medium":"https:\/\/example.com\/thumb.png","title":"something","url":"https:\/\/example.com"},{"image_url":"https:\/\/example.com\/img2.png","thumb_url_medium":"https:\/\/example.com\/thumb2.png","title":"something2","url":"https:\/\/example.com\/2"}]}',
 				);
 			}
 		);
@@ -126,14 +126,16 @@ final class RelatedProxyEndpointTest extends TestCase {
 			(object) array(
 				'data' => array(
 					(object) array(
-						'image_url' => 'https://example.com/img.png',
-						'title'     => 'something',
-						'url'       => 'https://example.com',
+						'image_url'        => 'https://example.com/img.png',
+						'thumb_url_medium' => 'https://example.com/thumb.png',
+						'title'            => 'something',
+						'url'              => 'https://example.com',
 					),
 					(object) array(
-						'image_url' => 'https://example.com/img2.png',
-						'title'     => 'something2',
-						'url'       => 'https://example.com/2',
+						'image_url'        => 'https://example.com/img2.png',
+						'thumb_url_medium' => 'https://example.com/thumb2.png',
+						'title'            => 'something2',
+						'url'              => 'https://example.com/2',
 					),
 				),
 			),


### PR DESCRIPTION
## Description
The Related API Proxy did not pass thumbnail image paths to the Recommendations Block, which resulted in thumbnails never being shown within the Block. This PR fixes the issue.

## Motivation and Context
User should be able to select thumbnail as an option in the Block.

## How Has This Been Tested?
- Manual testing (data inspection and verifying that thumbnails appear in the block).
- Updated integration test to pass the additional data.