### PR TITLE
Set image URL instead of thumbnail URL in update_metadata_endpoint()

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -263,7 +263,7 @@ class Parsely {
 			'canonical_url' => $metadata['url'],
 			'page_type'     => $this->convert_jsonld_to_parsely_type( $metadata['@type'] ),
 			'title'         => $metadata['headline'],
-			'image_url'     => $metadata['thumbnailUrl'],
+			'image_url'     => $metadata['image']['url'],
 			'pub_date_tmsp' => $metadata['datePublished'],
 			'section'       => $metadata['articleSection'],
 			'authors'       => $metadata['creator'],


### PR DESCRIPTION
## Description
In our `update_metadata_endpoint()` function, we were setting the `image_url` field to a a thumbnail URL instead of the full featured image URL. This PR fixes this.

## Motivation and Context
When a post gets updated, the `update_metadata_endpoint()` function runs to send the updated metadata to Parse.ly. One of the fields is `image_url`, which denotes the post's featured image URL. The problem with sending a thumbnail URL is that Parse.ly will:
- Generate a thumbnail from the already small/compressed thumbnail path in the URL.
- Store the image URL as metadata in the Parse.ly system and use it, including serving it through the `related` API.

Besides any other effects, this also impacts the Recommendations Block image size and quality, because the block draws its data from the `related` API. In essence, we fixed this in https://github.com/Parsely/wp-parsely/pull/758 (see https://github.com/Parsely/wp-parsely/pull/758/commits/3c364ee5ddf581d9b7207232963c969c50625352), but only partially as `update_metadata_endpoint()` would then recreate the issue when/if posts got updated.

## How Has This Been Tested?
Verified that data value is correct by step debugging.