### PR TITLE
Updating testing dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
 				"js-cookie": "^3.0.1"
 			},
 			"devDependencies": {
-				"@testing-library/jest-dom": "^5.16.2",
-				"@testing-library/react": "^12.1.4",
+				"@testing-library/jest-dom": "^5.16.4",
+				"@testing-library/react": "^12.1.5",
 				"@wordpress/api-fetch": "^6.3.0",
 				"@wordpress/babel-preset-default": "^6.8.0",
 				"@wordpress/block-editor": "^8.5.1",
@@ -3528,9 +3528,9 @@
 			}
 		},
 		"node_modules/@testing-library/jest-dom": {
-			"version": "5.16.3",
-			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.3.tgz",
-			"integrity": "sha512-u5DfKj4wfSt6akfndfu1eG06jsdyA/IUrlX2n3pyq5UXgXMhXY+NJb8eNK/7pqPWAhCKsCGWDdDO0zKMKAYkEA==",
+			"version": "5.16.4",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.4.tgz",
+			"integrity": "sha512-Gy+IoFutbMQcky0k+bqqumXZ1cTGswLsFqmNLzNdSKkU9KGV2u9oXhukCbbJ9/LRPKiqwxEE8VpV/+YZlfkPUA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.9.2",
@@ -3626,21 +3626,21 @@
 			}
 		},
 		"node_modules/@testing-library/react": {
-			"version": "12.1.4",
-			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.4.tgz",
-			"integrity": "sha512-jiPKOm7vyUw311Hn/HlNQ9P8/lHNtArAx0PisXyFixDDvfl8DbD6EUdbshK5eqauvBSvzZd19itqQ9j3nferJA==",
+			"version": "12.1.5",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz",
+			"integrity": "sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.12.5",
 				"@testing-library/dom": "^8.0.0",
-				"@types/react-dom": "*"
+				"@types/react-dom": "<18.0.0"
 			},
 			"engines": {
 				"node": ">=12"
 			},
 			"peerDependencies": {
-				"react": "*",
-				"react-dom": "*"
+				"react": "<18.0.0",
+				"react-dom": "<18.0.0"
 			}
 		},
 		"node_modules/@tootallnate/once": {
@@ -24513,9 +24513,9 @@
 			}
 		},
 		"@testing-library/jest-dom": {
-			"version": "5.16.3",
-			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.3.tgz",
-			"integrity": "sha512-u5DfKj4wfSt6akfndfu1eG06jsdyA/IUrlX2n3pyq5UXgXMhXY+NJb8eNK/7pqPWAhCKsCGWDdDO0zKMKAYkEA==",
+			"version": "5.16.4",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.4.tgz",
+			"integrity": "sha512-Gy+IoFutbMQcky0k+bqqumXZ1cTGswLsFqmNLzNdSKkU9KGV2u9oXhukCbbJ9/LRPKiqwxEE8VpV/+YZlfkPUA==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
@@ -24587,14 +24587,14 @@
 			}
 		},
 		"@testing-library/react": {
-			"version": "12.1.4",
-			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.4.tgz",
-			"integrity": "sha512-jiPKOm7vyUw311Hn/HlNQ9P8/lHNtArAx0PisXyFixDDvfl8DbD6EUdbshK5eqauvBSvzZd19itqQ9j3nferJA==",
+			"version": "12.1.5",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz",
+			"integrity": "sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.12.5",
 				"@testing-library/dom": "^8.0.0",
-				"@types/react-dom": "*"
+				"@types/react-dom": "<18.0.0"
 			}
 		},
 		"@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
 		"js-cookie": "^3.0.1"
 	},
 	"devDependencies": {
-		"@testing-library/jest-dom": "^5.16.2",
-		"@testing-library/react": "^12.1.4",
+		"@testing-library/jest-dom": "^5.16.4",
+		"@testing-library/react": "^12.1.5",
 		"@wordpress/api-fetch": "^6.3.0",
 		"@wordpress/babel-preset-default": "^6.8.0",
 		"@wordpress/block-editor": "^8.5.1",


### PR DESCRIPTION
## Description

Updating the testing dependencies. 

Note that Dependabot opened some PRs upgrading these dependencies that would not pass tests. This is because those bumps were upgrading conflicting dependencies with React 18. This PR upgrades dependencies to the last minor version.

## Motivation and Context

Staying up to date.

## How Has This Been Tested?

Dependencies install correctly and tests pass.