### PR TITLE
Removing uses of deprecated metadata generation

### DIFF
--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Parsely\Tests\Integration\Endpoints;
 
+use Parsely\Metadata;
 use Parsely\Parsely;
 use Parsely\Endpoints\Rest_Metadata;
 use Parsely\Tests\Integration\TestCase;
@@ -143,9 +144,10 @@ final class RestMetadataTest extends TestCase {
 		$post_id = self::factory()->post->create();
 
 		$meta_object = self::$rest->get_callback( get_post( $post_id, 'ARRAY_A' ) );
+		$metadata    = new Metadata( self::$parsely );
 		$expected    = array(
 			'version'     => '1.1.0',
-			'meta'        => self::$parsely->construct_parsely_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
+			'meta'        => $metadata->construct_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
 			'rendered'    => self::$rest->get_rendered_meta( 'json_ld' ),
 			'tracker_url' => 'https://cdn.parsely.com/keys/testkey/p.js',
 		);
@@ -164,9 +166,10 @@ final class RestMetadataTest extends TestCase {
 		$post_id = self::factory()->post->create();
 
 		$meta_object = self::$rest->get_callback( get_post( $post_id, 'ARRAY_A' ) );
+		$metadata    = new Metadata( self::$parsely );
 		$expected    = array(
 			'version'     => '1.1.0',
-			'meta'        => self::$parsely->construct_parsely_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
+			'meta'        => $metadata->construct_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
 			'tracker_url' => 'https://cdn.parsely.com/keys/testkey/p.js',
 		);
 
@@ -184,9 +187,10 @@ final class RestMetadataTest extends TestCase {
 		$post_id = self::factory()->post->create();
 
 		$meta_object = self::$rest->get_callback( get_post( $post_id, 'ARRAY_A' ) );
+		$metadata    = new Metadata( self::$parsely );
 		$expected    = array(
 			'version'  => '1.1.0',
-			'meta'     => self::$parsely->construct_parsely_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
+			'meta'     => $metadata->construct_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
 			'rendered' => self::$rest->get_rendered_meta( 'json_ld' ),
 		);
 

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Parsely\Tests\Integration;
 
+use Parsely\Metadata;
 use Parsely\Parsely;
 use WP_Scripts;
 
@@ -57,7 +58,7 @@ final class OtherTest extends TestCase {
 	/**
 	 * Check out page filtering.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -95,7 +96,8 @@ final class OtherTest extends TestCase {
 		);
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// The structured data should contain the headline from the filter.
 		self::assertSame( strpos( $structured_data['headline'], $headline ), 0 );
@@ -104,7 +106,7 @@ final class OtherTest extends TestCase {
 	/**
 	 * Test the wp_parsely_post_type filter
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
@@ -131,8 +133,10 @@ final class OtherTest extends TestCase {
 			}
 		);
 
-		$metadata = self::$parsely->construct_parsely_metadata( $options, $post_obj );
-		self::assertSame( 'BlogPosting', $metadata['@type'] );
+		$metadata        = new Metadata( self::$parsely );
+		$structured_data = $metadata->construct_metadata( $options, $post_obj );
+
+		self::assertSame( 'BlogPosting', $structured_data['@type'] );
 
 		// Try to change the post type to a non-supported value - Not_Supported.
 		add_filter(
@@ -144,7 +148,7 @@ final class OtherTest extends TestCase {
 
 		$this->expectWarning();
 		$this->expectWarningMessage( '@type Not_Supported_Type is not supported by Parse.ly. Please use a type mentioned in https://www.parse.ly/help/integration/jsonld#distinguishing-between-posts-and-pages' );
-		self::$parsely->construct_parsely_metadata( $options, $post_obj );
+		$metadata->construct_metadata( $options, $post_obj );
 	}
 
 	/**

--- a/tests/Integration/StructuredData/AuthorArchiveTest.php
+++ b/tests/Integration/StructuredData/AuthorArchiveTest.php
@@ -16,7 +16,7 @@ use Parsely\Parsely;
  * Structured Data Tests for author archives.
  *
  * @see https://www.parse.ly/help/integration/jsonld
- * @covers \Parsely\Parsely::construct_parsely_metadata
+ * @covers \Parsely\Metadata::construct_metadata
  */
 final class AuthorArchiveTest extends NonPostTestCase {
 	/**

--- a/tests/Integration/StructuredData/AuthorArchiveTest.php
+++ b/tests/Integration/StructuredData/AuthorArchiveTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Parsely\Tests\Integration\StructuredData;
 
+use Parsely\Metadata;
 use Parsely\Parsely;
 
 /**
@@ -21,7 +22,7 @@ final class AuthorArchiveTest extends NonPostTestCase {
 	/**
 	 * Check metadata for author archive.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -57,7 +58,8 @@ final class AuthorArchiveTest extends NonPostTestCase {
 
 		// Create the structured data for that category.
 		// The author archive metadata doesn't use the post data, but the construction method requires it for now.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, get_post() );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, get_post() );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );

--- a/tests/Integration/StructuredData/BlogArchiveTest.php
+++ b/tests/Integration/StructuredData/BlogArchiveTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Parsely\Tests\Integration\StructuredData;
 
+use Parsely\Metadata;
 use Parsely\Parsely;
 
 /**
@@ -21,7 +22,7 @@ final class BlogArchiveTest extends NonPostTestCase {
 	/**
 	 * Create a single page, set as the posts page (blog archive) but not the home page, go to Page 2, and test the structured data.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -69,7 +70,8 @@ final class BlogArchiveTest extends NonPostTestCase {
 		$this->go_to( get_permalink( $page_id ) . 'page/2' );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $page );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );

--- a/tests/Integration/StructuredData/BlogArchiveTest.php
+++ b/tests/Integration/StructuredData/BlogArchiveTest.php
@@ -16,7 +16,7 @@ use Parsely\Parsely;
  * Structured Data Tests for the blog page (archive).
  *
  * @see https://www.parse.ly/help/integration/jsonld
- * @covers \Parsely\Parsely::construct_parsely_metadata
+ * @covers \Parsely\Metadata::construct_metadata
  */
 final class BlogArchiveTest extends NonPostTestCase {
 	/**

--- a/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
@@ -16,7 +16,7 @@ use Parsely\Parsely;
  * Structured Data Tests for the custom post type (archive).
  *
  * @see https://www.parse.ly/help/integration/jsonld
- * @covers \Parsely\Parsely::construct_parsely_metadata
+ * @covers \Parsely\Metadata::construct_metadata
  */
 final class CustomPostTypeArchiveTest extends NonPostTestCase {
 	/**

--- a/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Parsely\Tests\Integration\StructuredData;
 
+use Parsely\Metadata;
 use Parsely\Parsely;
 
 /**
@@ -21,8 +22,7 @@ final class CustomPostTypeArchiveTest extends NonPostTestCase {
 	/**
 	 * Check metadata for custom post type archive.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::__construct
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -74,7 +74,8 @@ final class CustomPostTypeArchiveTest extends NonPostTestCase {
 
 		// Create the structured data for that CPT.
 		// The CPT archive metadata doesn't use the post data, but the construction method requires it for now.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, get_post() );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, get_post() );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );

--- a/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Parsely\Tests\Integration\StructuredData;
 
+use Parsely\Metadata;
 use Parsely\Parsely;
 
 /**

--- a/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
@@ -16,7 +16,7 @@ use Parsely\Parsely;
  * Structured Data Tests for the custom taxonomy term (archive).
  *
  * @see https://www.parse.ly/help/integration/jsonld
- * @covers \Parsely\Parsely::construct_parsely_metadata
+ * @covers \Parsely\Metadata::construct_metadata
  */
 class CustomTaxonomyTermArchiveTest extends NonPostTestCase {
 	/**

--- a/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
@@ -21,8 +21,7 @@ class CustomTaxonomyTermArchiveTest extends NonPostTestCase {
 	/**
 	 * Check metadata for custom post type term archive.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
-	 * @uses \Parsely\Parsely::__construct
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -74,7 +73,8 @@ class CustomTaxonomyTermArchiveTest extends NonPostTestCase {
 
 		// Create the structured data for that term archive.
 		// The term archive metadata doesn't use the post data, but the construction method requires it for now.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, get_post( $post_id ) );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, get_post( $post_id ) );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );

--- a/tests/Integration/StructuredData/HomePageTest.php
+++ b/tests/Integration/StructuredData/HomePageTest.php
@@ -16,7 +16,7 @@ use Parsely\Parsely;
  * Structured Data Tests for the home page.
  *
  * @see https://www.parse.ly/help/integration/jsonld
- * @covers \Parsely\Parsely::construct_parsely_metadata
+ * @covers \Parsely\Metadata::construct_metadata
  */
 final class HomePageTest extends NonPostTestCase {
 	/**

--- a/tests/Integration/StructuredData/HomePageTest.php
+++ b/tests/Integration/StructuredData/HomePageTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Parsely\Tests\Integration\StructuredData;
 
+use Parsely\Metadata;
 use Parsely\Parsely;
 
 /**
@@ -32,7 +33,7 @@ final class HomePageTest extends NonPostTestCase {
 	/**
 	 * Create a single page, set as homepage (blog archive), and test the structured data.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -64,7 +65,8 @@ final class HomePageTest extends NonPostTestCase {
 		$this->go_to( '/' );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $page );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );
@@ -77,7 +79,7 @@ final class HomePageTest extends NonPostTestCase {
 	/**
 	 * Create 2 posts, set posts per page to 1, navigate to page 2 and test the structured data.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -113,7 +115,8 @@ final class HomePageTest extends NonPostTestCase {
 		$this->go_to( home_url( '/page/2' ) );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $page );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );
@@ -127,7 +130,7 @@ final class HomePageTest extends NonPostTestCase {
 	/**
 	 * Create a single page, set as homepage (page on front), and test the structured data.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -163,7 +166,8 @@ final class HomePageTest extends NonPostTestCase {
 		$this->go_to( '/' );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $page );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );
@@ -178,7 +182,7 @@ final class HomePageTest extends NonPostTestCase {
 	/**
 	 * Check for the case when the show_on_front setting is Page, but no Page has been selected.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -214,7 +218,8 @@ final class HomePageTest extends NonPostTestCase {
 		$this->go_to( '/' );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $page );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );

--- a/tests/Integration/StructuredData/SinglePageTest.php
+++ b/tests/Integration/StructuredData/SinglePageTest.php
@@ -16,7 +16,7 @@ use Parsely\Parsely;
  * Structured Data Tests for single Pages.
  *
  * @see https://www.parse.ly/help/integration/jsonld
- * @covers \Parsely\Parsely::construct_parsely_metadata
+ * @covers \Parsely\Metadata::construct_metadata
  */
 final class SinglePageTest extends NonPostTestCase {
 

--- a/tests/Integration/StructuredData/SinglePageTest.php
+++ b/tests/Integration/StructuredData/SinglePageTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Parsely\Tests\Integration\StructuredData;
 
+use Parsely\Metadata;
 use Parsely\Parsely;
 
 /**
@@ -22,7 +23,7 @@ final class SinglePageTest extends NonPostTestCase {
 	/**
 	 * Create a single page, and test the structured data.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -60,7 +61,8 @@ final class SinglePageTest extends NonPostTestCase {
 		$this->go_to( get_permalink( $page_id ) );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $page );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $page );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );

--- a/tests/Integration/StructuredData/SinglePostTest.php
+++ b/tests/Integration/StructuredData/SinglePostTest.php
@@ -33,7 +33,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Create a single post, and test the structured data.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -60,7 +60,8 @@ final class SinglePostTest extends TestCase {
 		$this->go_to( get_permalink( $post ) );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );
@@ -71,7 +72,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check the category.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -96,7 +97,8 @@ final class SinglePostTest extends TestCase {
 		$post     = get_post( $post_id );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// The category in the structured data should match the category of the post.
 		self::assertSame( 'Test Category', $structured_data['articleSection'] );
@@ -105,7 +107,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check that the tags assigned to a post are lowercase.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -139,7 +141,8 @@ final class SinglePostTest extends TestCase {
 		update_option( 'parsely', $parsely_options );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// The structured data should contain both tags in lowercase form.
 		self::assertContains( 'sample', $structured_data['keywords'] );
@@ -149,7 +152,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check the categories as tags.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -184,7 +187,8 @@ final class SinglePostTest extends TestCase {
 		$post    = get_post( $post_id );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// The structured data should contain all three categories as keywords.
 		self::assertContains( 'Test Category', $structured_data['keywords'] );
@@ -195,7 +199,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Test custom taxonomy terms, categories, and tags in the metadata.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -242,7 +246,8 @@ final class SinglePostTest extends TestCase {
 		wp_set_object_terms( $post_id, array( $tag ), 'post_tag' );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// The structured data should contain the category, the post tag, and the custom taxonomy term.
 		self::assertContains( 'my category', $structured_data['keywords'] );
@@ -253,7 +258,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Are the top level categories what we expect?
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -290,7 +295,8 @@ final class SinglePostTest extends TestCase {
 		$post    = get_post( $post_id );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// The structured data should contain the parent category.
 		self::assertSame( 'Parent Category', $structured_data['articleSection'] );
@@ -300,7 +306,8 @@ final class SinglePostTest extends TestCase {
 		update_option( 'parsely', $parsely_options );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// The structured data should contain the child category.
 		self::assertSame( 'Child Category', $structured_data['articleSection'] );
@@ -309,7 +316,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check out the custom taxonomy as section.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -359,7 +366,8 @@ final class SinglePostTest extends TestCase {
 		update_option( 'parsely', $parsely_options );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		self::assertSame( 'Premier League', $structured_data['articleSection'] );
 
@@ -368,7 +376,8 @@ final class SinglePostTest extends TestCase {
 		update_option( 'parsely', $parsely_options );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		self::assertSame( 'football', $structured_data['articleSection'] );
 	}
@@ -376,7 +385,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check the canonicals.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -405,7 +414,8 @@ final class SinglePostTest extends TestCase {
 		update_option( 'parsely', $parsely_options );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// The url scheme should be 'http'.
 		$url = wp_parse_url( $structured_data['url'] );
@@ -416,7 +426,8 @@ final class SinglePostTest extends TestCase {
 		update_option( 'parsely', $parsely_options );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// The url scheme should be 'https'.
 		$url = wp_parse_url( $structured_data['url'] );
@@ -426,7 +437,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check post modified date in Parsely metadata.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -460,14 +471,15 @@ final class SinglePostTest extends TestCase {
 		// In the metadata, check that the post's created date is correct and
 		// that the last modified date is identical.
 		$post     = get_post( $post_id );
-		$metadata = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$meta     = new Metadata( $parsely );
+		$metadata = $meta->construct_metadata( $parsely_options, $post );
 		self::assertSame( $date_created, $metadata['dateCreated'] );
 		self::assertSame( $date_created, $metadata['dateModified'] );
 
 		// Update the post and reload metadata.
 		wp_update_post( array( 'ID' => $post_id ) );
 		$post_updated     = get_post( $post_id );
-		$metadata_updated = $parsely->construct_parsely_metadata( $parsely_options, $post_updated );
+		$metadata_updated = $meta->construct_metadata( $parsely_options, $post_updated );
 
 		// In the metadata, check that the last modified date has been updated.
 		self::assertSame( $date_created, $metadata_updated['dateCreated'] );
@@ -477,7 +489,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check that post objects with valid creation date work with construct_parsely_metadata.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @group metadata
 	 */
@@ -494,7 +506,8 @@ final class SinglePostTest extends TestCase {
 		unset( $post->post_date_gmt );
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// Without a post date, there should not be the following in the metadata.
 		self::assertArrayNotHasKey( 'dateCreated', $structured_data );
@@ -505,7 +518,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check that post objects with identical creation & modified dates produce expected metadata.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @group metadata
 	 */
@@ -526,7 +539,8 @@ final class SinglePostTest extends TestCase {
 		$post->post_modified_gmt = $singular_datetime;
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// Identical post creation and modified dates should be present in the metadata.
 		$expected_singular_datetime = '2021-12-30T20:11:42Z';
@@ -539,7 +553,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check that posts with modified before creation date "promotes" modified in metadata.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @group metadata
 	 */
@@ -561,7 +575,8 @@ final class SinglePostTest extends TestCase {
 		$post->post_modified_gmt = $modified_datetime;
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// Modified dates earlier than created dates should be "promoted" to the latter.
 		$expected_singular_datetime = '2021-12-30T20:11:42Z';
@@ -574,7 +589,7 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check that posts with modified after creation date has both in metadata.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @group metadata
 	 */
@@ -596,7 +611,8 @@ final class SinglePostTest extends TestCase {
 		$post->post_modified_gmt = $modified_datetime;
 
 		// Create the structured data for that post.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
 		// Modified dates later than created dates should be present in the metadata.
 		$expected_created_datetime  = '2021-12-30T20:11:42Z';
@@ -629,7 +645,7 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @since 3.0.3
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_categories
 	 * @group metadata
 	 */
@@ -649,10 +665,11 @@ final class SinglePostTest extends TestCase {
 		$default_category_slug = get_category( get_option( 'default_category' ) )->slug;
 		wp_remove_object_terms( $post_id, $default_category_slug, 'category' );
 
-		$expected = array();
-		$metadata = $parsely->construct_parsely_metadata( $parsely_options, $post );
+		$expected        = array();
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
 
-		self::assertSame( $expected, $metadata['keywords'] );
+		self::assertSame( $expected, $structured_data['keywords'] );
 	}
 
 	/**

--- a/tests/Integration/StructuredData/TermArchiveTest.php
+++ b/tests/Integration/StructuredData/TermArchiveTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Parsely\Tests\Integration\StructuredData;
 
+use Parsely\Metadata;
 use Parsely\Parsely;
 
 /**
@@ -21,7 +22,7 @@ final class TermArchiveTest extends NonPostTestCase {
 	/**
 	 * Check metadata for term archive.
 	 *
-	 * @covers \Parsely\Parsely::construct_parsely_metadata
+	 * @covers \Parsely\Metadata::construct_metadata
 	 * @uses \Parsely\Metadata::get_author_name
 	 * @uses \Parsely\Metadata::get_author_names
 	 * @uses \Parsely\Metadata::get_bottom_level_term
@@ -57,7 +58,8 @@ final class TermArchiveTest extends NonPostTestCase {
 
 		// Create the structured data for that category.
 		// The category metadata doesn't use the post data, but the construction method requires it for now.
-		$structured_data = $parsely->construct_parsely_metadata( $parsely_options, get_post() );
+		$metadata        = new Metadata( $parsely );
+		$structured_data = $metadata->construct_metadata( $parsely_options, get_post() );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );

--- a/tests/Integration/StructuredData/TermArchiveTest.php
+++ b/tests/Integration/StructuredData/TermArchiveTest.php
@@ -16,7 +16,7 @@ use Parsely\Parsely;
  * Structured Data Tests for the term archives.
  *
  * @see https://www.parse.ly/help/integration/jsonld
- * @covers \Parsely\Parsely::construct_parsely_metadata
+ * @covers \Parsely\Metadata::construct_metadata
  */
 final class TermArchiveTest extends NonPostTestCase {
 	/**


### PR DESCRIPTION
## Description

This PR removes all usages of the deprecated way of generating metadata with the new `Metadata` class. The only remaining calls were in tests.

## Motivation and Context

Closes #796.

See #682.

## How Has This Been Tested?

Tests pass correctly.