### PR TITLE
Remove Parse.ly options as a parameter for Metadata generation

### DIFF
--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -82,7 +82,7 @@ class Rest_Metadata extends Metadata_Endpoint {
 		if ( false === $post ) {
 			$metadata = '';
 		} else {
-			$metadata = ( new Metadata( $this->parsely ) )->construct_metadata( $options, $post );
+			$metadata = ( new Metadata( $this->parsely ) )->construct_metadata( $post );
 		}
 
 		$response = array(

--- a/src/UI/class-metadata-renderer.php
+++ b/src/UI/class-metadata-renderer.php
@@ -109,7 +109,7 @@ final class Metadata_Renderer {
 
 		// Assign default values for LD+JSON
 		// TODO: Mapping of an install's post types to Parse.ly post types (namely page/post).
-		$metadata = ( new Metadata( $this->parsely ) )->construct_metadata( $parsely_options, $post );
+		$metadata = ( new Metadata( $this->parsely ) )->construct_metadata( $post );
 
 		// Something went wrong - abort.
 		if ( 0 === count( $metadata ) || ! isset( $metadata['headline'] ) ) {

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -37,14 +37,15 @@ class Metadata {
 	}
 
 	/**
-	 * Creates parsely metadata object from post metadata.
+	 * Creates Parse.ly metadata object from post metadata.
 	 *
-	 * @param array<string, mixed> $parsely_options parsely_options array.
-	 * @param WP_Post              $post object.
+	 * @param WP_Post $post object.
 	 *
 	 * @return array<string, mixed>
 	 */
-	public function construct_metadata( array $parsely_options, WP_Post $post ): array {
+	public function construct_metadata( WP_Post $post ): array {
+		$options = $this->parsely->get_options();
+
 		$parsely_page      = array(
 			'@context' => 'https://schema.org',
 			'@type'    => 'WebPage',
@@ -98,9 +99,9 @@ class Metadata {
 			/* translators: %s: Tag name */
 			$parsely_page['headline'] = $this->get_clean_parsely_page_value( sprintf( __( 'Tagged - %s', 'wp-parsely' ), $tag ) );
 			$parsely_page['url']      = $current_url;
-		} elseif ( in_array( get_post_type( $post ), $parsely_options['track_post_types'], true ) && Parsely::post_has_trackable_status( $post ) ) {
+		} elseif ( in_array( get_post_type( $post ), $options['track_post_types'], true ) && Parsely::post_has_trackable_status( $post ) ) {
 			$authors  = $this->get_author_names( $post );
-			$category = $this->get_category_name( $post, $parsely_options );
+			$category = $this->get_category_name( $post, $options );
 
 			// Get featured image and thumbnail.
 			$image_url = get_the_post_thumbnail_url( $post, 'full' );
@@ -113,7 +114,7 @@ class Metadata {
 			}
 
 			$tags = $this->get_tags( $post->ID );
-			if ( $parsely_options['cats_as_tags'] ) {
+			if ( $options['cats_as_tags'] ) {
 				$tags = array_merge( $tags, $this->get_categories( $post->ID ) );
 				// add custom taxonomy values.
 				$tags = array_merge( $tags, $this->get_custom_taxonomy_values( $post ) );
@@ -125,7 +126,7 @@ class Metadata {
 			} else {
 				$lowercase_callback = 'strtolower';
 			}
-			if ( $parsely_options['lowercase_tags'] ) {
+			if ( $options['lowercase_tags'] ) {
 				$tags = array_map( $lowercase_callback, $tags );
 			}
 
@@ -197,10 +198,10 @@ class Metadata {
 			$parsely_page['publisher'] = array(
 				'@type' => 'Organization',
 				'name'  => get_bloginfo( 'name' ),
-				'logo'  => $parsely_options['logo'],
+				'logo'  => $options['logo'],
 			);
 			$parsely_page['keywords']  = $tags;
-		} elseif ( in_array( get_post_type(), $parsely_options['track_page_types'], true ) && Parsely::post_has_trackable_status( $post ) ) {
+		} elseif ( in_array( get_post_type(), $options['track_page_types'], true ) && Parsely::post_has_trackable_status( $post ) ) {
 			$parsely_page['headline'] = $this->get_clean_parsely_page_value( get_the_title( $post ) );
 			$parsely_page['url']      = $this->get_current_url( 'post' );
 		} elseif ( 'page' === get_option( 'show_on_front' ) && ! get_option( 'page_on_front' ) ) {
@@ -213,11 +214,11 @@ class Metadata {
 		 *
 		 * @param array $parsely_page Existing structured metadata for a page.
 		 * @param WP_Post $post Post object.
-		 * @param array $parsely_options The Parsely options.
+		 * @param array $options The Parse.ly options.
 		 *
 		 * @since 2.5.0
 		 */
-		$filtered = apply_filters( 'wp_parsely_metadata', $parsely_page, $post, $parsely_options );
+		$filtered = apply_filters( 'wp_parsely_metadata', $parsely_page, $post, $options );
 		if ( is_array( $filtered ) ) {
 			return $filtered;
 		}

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -238,7 +238,7 @@ class Parsely {
 	 */
 	public function construct_parsely_metadata( array $parsely_options, WP_Post $post ): array {
 		$metadata = new Metadata( $this );
-		return $metadata->construct_metadata( $parsely_options, $post );
+		return $metadata->construct_metadata( $post );
 	}
 
 	/**
@@ -258,7 +258,7 @@ class Parsely {
 			return;
 		}
 
-		$metadata = ( new Metadata( $this ) )->construct_metadata( $parsely_options, $post );
+		$metadata = ( new Metadata( $this ) )->construct_metadata( $post );
 
 		$endpoint_metadata = array(
 			'canonical_url' => $metadata['url'],

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -147,7 +147,7 @@ final class RestMetadataTest extends TestCase {
 		$metadata    = new Metadata( self::$parsely );
 		$expected    = array(
 			'version'     => '1.1.0',
-			'meta'        => $metadata->construct_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
+			'meta'        => $metadata->construct_metadata( get_post( $post_id ) ),
 			'rendered'    => self::$rest->get_rendered_meta( 'json_ld' ),
 			'tracker_url' => 'https://cdn.parsely.com/keys/testkey/p.js',
 		);
@@ -169,7 +169,7 @@ final class RestMetadataTest extends TestCase {
 		$metadata    = new Metadata( self::$parsely );
 		$expected    = array(
 			'version'     => '1.1.0',
-			'meta'        => $metadata->construct_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
+			'meta'        => $metadata->construct_metadata( get_post( $post_id ) ),
 			'tracker_url' => 'https://cdn.parsely.com/keys/testkey/p.js',
 		);
 
@@ -190,7 +190,7 @@ final class RestMetadataTest extends TestCase {
 		$metadata    = new Metadata( self::$parsely );
 		$expected    = array(
 			'version'  => '1.1.0',
-			'meta'     => $metadata->construct_metadata( self::$parsely->get_options(), get_post( $post_id ) ),
+			'meta'     => $metadata->construct_metadata( get_post( $post_id ) ),
 			'rendered' => self::$rest->get_rendered_meta( 'json_ld' ),
 		);
 

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -75,8 +75,7 @@ final class OtherTest extends TestCase {
 	 */
 	public function test_parsely_page_filter(): void {
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Create a single post.
 		$post_id = $this->factory->post->create();
@@ -97,7 +96,7 @@ final class OtherTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// The structured data should contain the headline from the filter.
 		self::assertSame( strpos( $structured_data['headline'], $headline ), 0 );
@@ -120,8 +119,6 @@ final class OtherTest extends TestCase {
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 */
 	public function test_filter_wp_parsely_post_type(): void {
-		$options = get_option( Parsely::OPTIONS_KEY );
-
 		$post_id  = $this->go_to_new_post();
 		$post_obj = get_post( $post_id );
 
@@ -134,7 +131,7 @@ final class OtherTest extends TestCase {
 		);
 
 		$metadata        = new Metadata( self::$parsely );
-		$structured_data = $metadata->construct_metadata( $options, $post_obj );
+		$structured_data = $metadata->construct_metadata( $post_obj );
 
 		self::assertSame( 'BlogPosting', $structured_data['@type'] );
 
@@ -148,7 +145,7 @@ final class OtherTest extends TestCase {
 
 		$this->expectWarning();
 		$this->expectWarningMessage( '@type Not_Supported_Type is not supported by Parse.ly. Please use a type mentioned in https://www.parse.ly/help/integration/jsonld#distinguishing-between-posts-and-pages' );
-		$metadata->construct_metadata( $options, $post_obj );
+		$metadata->construct_metadata( $post_obj );
 	}
 
 	/**

--- a/tests/Integration/StructuredData/AuthorArchiveTest.php
+++ b/tests/Integration/StructuredData/AuthorArchiveTest.php
@@ -42,8 +42,7 @@ final class AuthorArchiveTest extends NonPostTestCase {
 		$this->set_permalink_structure( '/%postname%/' );
 
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Insert a single user, and a Post assigned to them.
 		$user = self::factory()->user->create( array( 'user_login' => 'parsely' ) );
@@ -59,7 +58,7 @@ final class AuthorArchiveTest extends NonPostTestCase {
 		// Create the structured data for that category.
 		// The author archive metadata doesn't use the post data, but the construction method requires it for now.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, get_post() );
+		$structured_data = $metadata->construct_metadata( get_post() );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );

--- a/tests/Integration/StructuredData/BlogArchiveTest.php
+++ b/tests/Integration/StructuredData/BlogArchiveTest.php
@@ -38,8 +38,7 @@ final class BlogArchiveTest extends NonPostTestCase {
 	 */
 	public function test_blog_page_for_posts_paged(): void {
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Insert a page for the blog posts.
 		$page_id = self::factory()->post->create(
@@ -71,7 +70,7 @@ final class BlogArchiveTest extends NonPostTestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $page );
+		$structured_data = $metadata->construct_metadata( $page );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );

--- a/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
@@ -42,8 +42,7 @@ final class CustomPostTypeArchiveTest extends NonPostTestCase {
 		$this->set_permalink_structure( '/%postname%/' );
 
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Register Post Type with specific archive URL.
 		register_post_type(
@@ -75,7 +74,7 @@ final class CustomPostTypeArchiveTest extends NonPostTestCase {
 		// Create the structured data for that CPT.
 		// The CPT archive metadata doesn't use the post data, but the construction method requires it for now.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, get_post() );
+		$structured_data = $metadata->construct_metadata( get_post() );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );

--- a/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
@@ -42,8 +42,7 @@ class CustomTaxonomyTermArchiveTest extends NonPostTestCase {
 		$this->set_permalink_structure( '/%postname%/' );
 
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Register custom taxonomy.
 		register_taxonomy( 'custom_tax', array( 'post' ) );
@@ -75,7 +74,7 @@ class CustomTaxonomyTermArchiveTest extends NonPostTestCase {
 		// Create the structured data for that term archive.
 		// The term archive metadata doesn't use the post data, but the construction method requires it for now.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, get_post( $post_id ) );
+		$structured_data = $metadata->construct_metadata( get_post( $post_id ) );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );

--- a/tests/Integration/StructuredData/HomePageTest.php
+++ b/tests/Integration/StructuredData/HomePageTest.php
@@ -49,8 +49,7 @@ final class HomePageTest extends NonPostTestCase {
 	 */
 	public function test_home_page_for_posts(): void {
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Insert a single page.
 		$page_id = self::factory()->post->create(
@@ -66,7 +65,7 @@ final class HomePageTest extends NonPostTestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $page );
+		$structured_data = $metadata->construct_metadata( $page );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );
@@ -95,8 +94,7 @@ final class HomePageTest extends NonPostTestCase {
 	 */
 	public function test_home_page_for_posts_paged(): void {
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Insert 2 posts.
 		$page_id = self::factory()->post->create();
@@ -116,7 +114,7 @@ final class HomePageTest extends NonPostTestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $page );
+		$structured_data = $metadata->construct_metadata( $page );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );
@@ -146,8 +144,7 @@ final class HomePageTest extends NonPostTestCase {
 	 */
 	public function test_home_page_on_front(): void {
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Insert a single page.
 		$page_id = self::factory()->post->create(
@@ -167,7 +164,7 @@ final class HomePageTest extends NonPostTestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $page );
+		$structured_data = $metadata->construct_metadata( $page );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );
@@ -198,8 +195,7 @@ final class HomePageTest extends NonPostTestCase {
 	 */
 	public function test_home_for_misconfigured_settings(): void {
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Insert a single page.
 		$page_id = self::factory()->post->create(
@@ -219,7 +215,7 @@ final class HomePageTest extends NonPostTestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $page );
+		$structured_data = $metadata->construct_metadata( $page );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );

--- a/tests/Integration/StructuredData/SinglePageTest.php
+++ b/tests/Integration/StructuredData/SinglePageTest.php
@@ -39,8 +39,7 @@ final class SinglePageTest extends NonPostTestCase {
 	 */
 	public function test_single_page(): void {
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Insert a single page.
 		$page_id = self::factory()->post->create(
@@ -62,7 +61,7 @@ final class SinglePageTest extends NonPostTestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $page );
+		$structured_data = $metadata->construct_metadata( $page );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );

--- a/tests/Integration/StructuredData/SinglePostTest.php
+++ b/tests/Integration/StructuredData/SinglePostTest.php
@@ -49,8 +49,7 @@ final class SinglePostTest extends TestCase {
 	 */
 	public function test_single_post(): void {
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Insert a single post and set as global post.
 		$post_id = self::factory()->post->create();
@@ -61,7 +60,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );
@@ -88,8 +87,7 @@ final class SinglePostTest extends TestCase {
 	 */
 	public function test_category_data_for_single_post(): void {
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Insert a single category term, and a Post with that category.
 		$category = self::factory()->category->create( array( 'name' => 'Test Category' ) );
@@ -98,7 +96,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// The category in the structured data should match the category of the post.
 		self::assertSame( 'Test Category', $structured_data['articleSection'] );
@@ -142,7 +140,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// The structured data should contain both tags in lowercase form.
 		self::assertContains( 'sample', $structured_data['keywords'] );
@@ -188,7 +186,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// The structured data should contain all three categories as keywords.
 		self::assertContains( 'Test Category', $structured_data['keywords'] );
@@ -247,7 +245,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// The structured data should contain the category, the post tag, and the custom taxonomy term.
 		self::assertContains( 'my category', $structured_data['keywords'] );
@@ -296,7 +294,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// The structured data should contain the parent category.
 		self::assertSame( 'Parent Category', $structured_data['articleSection'] );
@@ -307,7 +305,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// The structured data should contain the child category.
 		self::assertSame( 'Child Category', $structured_data['articleSection'] );
@@ -367,7 +365,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		self::assertSame( 'Premier League', $structured_data['articleSection'] );
 
@@ -377,7 +375,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		self::assertSame( 'football', $structured_data['articleSection'] );
 	}
@@ -415,7 +413,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// The url scheme should be 'http'.
 		$url = wp_parse_url( $structured_data['url'] );
@@ -427,7 +425,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// The url scheme should be 'https'.
 		$url = wp_parse_url( $structured_data['url'] );
@@ -453,8 +451,7 @@ final class SinglePostTest extends TestCase {
 	 */
 	public function test_metadata_post_modified_date(): void {
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Create a post with a date in the past.
 		$time_format      = 'Y-m-d\TH:i:s\Z';
@@ -472,14 +469,14 @@ final class SinglePostTest extends TestCase {
 		// that the last modified date is identical.
 		$post     = get_post( $post_id );
 		$meta     = new Metadata( $parsely );
-		$metadata = $meta->construct_metadata( $parsely_options, $post );
+		$metadata = $meta->construct_metadata( $post );
 		self::assertSame( $date_created, $metadata['dateCreated'] );
 		self::assertSame( $date_created, $metadata['dateModified'] );
 
 		// Update the post and reload metadata.
 		wp_update_post( array( 'ID' => $post_id ) );
 		$post_updated     = get_post( $post_id );
-		$metadata_updated = $meta->construct_metadata( $parsely_options, $post_updated );
+		$metadata_updated = $meta->construct_metadata( $post_updated );
 
 		// In the metadata, check that the last modified date has been updated.
 		self::assertSame( $date_created, $metadata_updated['dateCreated'] );
@@ -495,8 +492,7 @@ final class SinglePostTest extends TestCase {
 	 */
 	public function test_empty_post_date_has_dates_omitted_from_metadata(): void {
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Create a single post.
 		$post_id = $this->factory->post->create();
@@ -507,7 +503,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// Without a post date, there should not be the following in the metadata.
 		self::assertArrayNotHasKey( 'dateCreated', $structured_data );
@@ -540,7 +536,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// Identical post creation and modified dates should be present in the metadata.
 		$expected_singular_datetime = '2021-12-30T20:11:42Z';
@@ -576,7 +572,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// Modified dates earlier than created dates should be "promoted" to the latter.
 		$expected_singular_datetime = '2021-12-30T20:11:42Z';
@@ -612,7 +608,7 @@ final class SinglePostTest extends TestCase {
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		// Modified dates later than created dates should be present in the metadata.
 		$expected_created_datetime  = '2021-12-30T20:11:42Z';
@@ -667,7 +663,7 @@ final class SinglePostTest extends TestCase {
 
 		$expected        = array();
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, $post );
+		$structured_data = $metadata->construct_metadata( $post );
 
 		self::assertSame( $expected, $structured_data['keywords'] );
 	}
@@ -682,8 +678,7 @@ final class SinglePostTest extends TestCase {
 	 */
 	public function test_post_featured_image_urls_in_metadata_are_correct(): void {
 		// Initialize required objects.
-		$metadata        = new Metadata( new Parsely() );
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$metadata = new Metadata( new Parsely() );
 
 		// Create a post with a featured image.
 		$post            = self::factory()->post->create_and_get();
@@ -692,7 +687,7 @@ final class SinglePostTest extends TestCase {
 		set_post_thumbnail( $post, $attachment_id );
 
 		// Generate metadata and expected results.
-		$actual_metadata    = $metadata->construct_metadata( $parsely_options, $post );
+		$actual_metadata    = $metadata->construct_metadata( $post );
 		$expected_image_url = get_the_post_thumbnail_url( $post, 'full' );
 		$expected_thumb_url = get_the_post_thumbnail_url( $post, 'thumbnail' );
 

--- a/tests/Integration/StructuredData/TermArchiveTest.php
+++ b/tests/Integration/StructuredData/TermArchiveTest.php
@@ -42,8 +42,7 @@ final class TermArchiveTest extends NonPostTestCase {
 		$this->set_permalink_structure( '/%postname%/' );
 
 		// Setup Parsely object.
-		$parsely         = new Parsely();
-		$parsely_options = get_option( Parsely::OPTIONS_KEY );
+		$parsely = new Parsely();
 
 		// Insert a single category term, and a Post with that category.
 		$category = self::factory()->category->create( array( 'name' => 'Test Category' ) );
@@ -59,7 +58,7 @@ final class TermArchiveTest extends NonPostTestCase {
 		// Create the structured data for that category.
 		// The category metadata doesn't use the post data, but the construction method requires it for now.
 		$metadata        = new Metadata( $parsely );
-		$structured_data = $metadata->construct_metadata( $parsely_options, get_post() );
+		$structured_data = $metadata->construct_metadata( get_post() );
 
 		// Check the required properties exist.
 		$this->assert_data_has_required_properties( $structured_data );


### PR DESCRIPTION
## Description

We keep moving towards improving our metadata generation. We will culminate this using a builder as described on the issue linked below. 

We aim to release the next version of the plugin with a common interface, in which the client code will pass a `$post` object and the function will return the metadata object. We want to keep this interface within the `Metadata` class for days to come. We will be calling the builder methods from within this class. 

In this PR, we are modifying that public interface. Until now, it has been required that users provide a `$parsely_options` object to generate the metadata. Since when constructing the `Metadata` class a `Parsely` instance is already provided, we can extract the plugin's configuration from there. Therefore, we are moving this redundant parameter.

## Motivation and Context

See https://github.com/Parsely/wp-parsely/issues/682.

## How Has This Been Tested?

Metadata generation works as it did before.