### PR TITLE
Fixing coverage annotations in tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -101,7 +101,7 @@ jobs:
         run: composer testwp-experimental --no-interaction
 
       - name: Run integration tests (multi site)
-        if: ${{ ! matrix.experimental }}
+        if: ${{ matrix.php != 8.0 && ! matrix.experimental }}
         run: composer testwp-ms --no-interaction
 
       - name: Run integration tests (multisite site with code coverage)

--- a/tests/Integration/Blocks/RecommendationsBlockTest.php
+++ b/tests/Integration/Blocks/RecommendationsBlockTest.php
@@ -39,6 +39,7 @@ final class RecommendationsBlockTest extends TestCase {
 	 * @since 3.3.0
 	 *
 	 * @covers \Parsely\Recommendations_Block::run
+	 * @uses \Parsely\Recommendations_Block::register_block
 	 *
 	 * @group blocks
 	 */

--- a/tests/Integration/Endpoints/GraphQLMetadataTest.php
+++ b/tests/Integration/Endpoints/GraphQLMetadataTest.php
@@ -47,6 +47,9 @@ final class GraphQLMetadataTest extends TestCase {
 	 * @since 3.2.0
 	 *
 	 * @covers \Parsely\Endpoints\GraphQL_Metadata::run
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_graphql_enqueued(): void {
 		self::set_options( array( 'apikey' => 'testkey' ) );
@@ -61,6 +64,7 @@ final class GraphQLMetadataTest extends TestCase {
 	 * @since 3.2.0
 	 *
 	 * @covers \Parsely\Endpoints\GraphQL_Metadata::run
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
 	 */
 	public function test_graphql_enqueued_filter(): void {
 		self::set_options( array( 'apikey' => 'testkey' ) );
@@ -76,6 +80,9 @@ final class GraphQLMetadataTest extends TestCase {
 	 * @since 3.2.0
 	 *
 	 * @covers \Parsely\Endpoints\GraphQL_Metadata::run
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_graphql_enqueued_no_api_key(): void {
 		self::$graphql->run();

--- a/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
@@ -66,7 +66,9 @@ final class RelatedProxyEndpointTest extends TestCase {
 	/**
 	 * Confirm the route is registered.
 	 *
-	 * @covers \Related_API_Proxy::run
+	 * @covers \Parsely\Endpoints\Related_API_Proxy::run
+	 * @uses \Parsely\Endpoints\Related_API_Proxy::__construct
+	 * @uses \Parsely\RemoteAPI\Base_Proxy::__construct
 	 */
 	public function test_register_routes_by_default() {
 		$routes = rest_get_server()->get_routes();
@@ -79,7 +81,9 @@ final class RelatedProxyEndpointTest extends TestCase {
 	 * Confirm the route is not registered when the wp_parsely_enable_related_api_proxy
 	 * filter is set to false.
 	 *
-	 * @covers \Related_API_Proxy::run
+	 * @covers \Parsely\Endpoints\Related_API_Proxy::run
+	 * @uses \Parsely\Endpoints\Related_API_Proxy::__construct
+	 * @uses \Parsely\RemoteAPI\Base_Proxy::__construct
 	 */
 	public function test_do_not_register_routes_when_related_proxy_is_disabled() {
 
@@ -101,7 +105,17 @@ final class RelatedProxyEndpointTest extends TestCase {
 	/**
 	 * Confirm that calls to `GET /wp-parsely/v1/related` get results in the expected format.
 	 *
-	 * @covers \Related_API_Proxy::get_items
+	 * @covers \Parsely\Endpoints\Related_API_Proxy::get_items
+	 * @uses \Parsely\Endpoints\Related_API_Proxy::__construct
+	 * @uses \Parsely\Endpoints\Related_API_Proxy::permission_callback
+	 * @uses \Parsely\Endpoints\Related_API_Proxy::run
+	 * @uses \Parsely\RemoteAPI\Base_Proxy::__construct
+	 * @uses \Parsely\RemoteAPI\Base_Proxy::get_api_url
+	 * @uses \Parsely\RemoteAPI\Base_Proxy::get_items
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_api_key
+	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_get_items() {
 		TestCase::set_options( array( 'apikey' => 'example.com' ) );
@@ -146,7 +160,14 @@ final class RelatedProxyEndpointTest extends TestCase {
 	/**
 	 * Confirm that calls to `GET /wp-parsely/v1/related` gets an error and makes no remote call when the apikey is not populated in site options.
 	 *
-	 * @covers \Related_API_Proxy::get_items
+	 * @covers \Parsely\Endpoints\Related_API_Proxy::get_items
+	 * @uses \Parsely\Endpoints\Related_API_Proxy::__construct
+	 * @uses \Parsely\Endpoints\Related_API_Proxy::permission_callback
+	 * @uses \Parsely\Endpoints\Related_API_Proxy::run
+	 * @uses \Parsely\RemoteAPI\Base_Proxy::__construct
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_get_items_fails_without_apikey_set() {
 		TestCase::set_options( array( 'apikey' => '' ) );

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -48,6 +48,9 @@ final class RestMetadataTest extends TestCase {
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::run
 	 * @uses \Parsely\Endpoints\Rest_Metadata::register_meta
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_register_enqueued_rest_init(): void {
 		global $wp_rest_additional_fields;
@@ -66,6 +69,7 @@ final class RestMetadataTest extends TestCase {
 	 * Verify that the logic has not been enqueued when the `run` method is called with a filter that disables it.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::run
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
 	 */
 	public function test_register_enqueued_rest_init_filter(): void {
 		global $wp_rest_additional_fields;
@@ -81,6 +85,9 @@ final class RestMetadataTest extends TestCase {
 	 * Verify that the logic has not been enqueued when the `run` method is called with no API key.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::run
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_register_enqueued_rest_init_no_api_key(): void {
 		global $wp_rest_additional_fields;
@@ -94,6 +101,9 @@ final class RestMetadataTest extends TestCase {
 	 * Test that the REST fields are registered to WordPress REST API.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::register_meta
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_register_meta_registers_fields(): void {
 		global $wp_rest_additional_fields;
@@ -111,6 +121,8 @@ final class RestMetadataTest extends TestCase {
 	 * Test that the REST fields are can be modified using the `wp_parsely_rest_object_types` filter.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::register_meta
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_register_meta_with_filter(): void {
 		global $wp_rest_additional_fields;
@@ -138,6 +150,26 @@ final class RestMetadataTest extends TestCase {
 	 * Test that the get_rest_callback method is able to generate the `parsely` object for the REST API.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::get_callback
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::get_rendered_meta
+	 * @uses \Parsely\Metadata::__construct
+	 * @uses \Parsely\Metadata::construct_metadata
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
+	 * @uses \Parsely\Metadata::get_tags
+	 * @uses \Parsely\Metadata::set_metadata_post_times
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_api_key
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::get_tracker_url
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\UI\Metadata_Renderer::__construct
+	 * @uses \Parsely\UI\Metadata_Renderer::render_metadata
 	 */
 	public function test_get_callback(): void {
 		self::set_options( array( 'apikey' => 'testkey' ) );
@@ -159,6 +191,22 @@ final class RestMetadataTest extends TestCase {
 	 * Test that the get_rest_callback method is able to generate the `parsely` object for the REST API.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::get_callback
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Metadata::__construct
+	 * @uses \Parsely\Metadata::construct_metadata
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
+	 * @uses \Parsely\Metadata::get_tags
+	 * @uses \Parsely\Metadata::set_metadata_post_times
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_api_key
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::get_tracker_url
+	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 */
 	public function test_get_callback_with_filter(): void {
 		add_filter( 'wp_parsely_enable_rest_rendered_support', '__return_false' );
@@ -180,6 +228,24 @@ final class RestMetadataTest extends TestCase {
 	 * Test that the get_rest_callback method is able to generate the `parsely` object for the REST API.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::get_callback
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::get_rendered_meta
+	 * @uses \Parsely\Metadata::__construct
+	 * @uses \Parsely\Metadata::construct_metadata
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
+	 * @uses \Parsely\Metadata::get_tags
+	 * @uses \Parsely\Metadata::set_metadata_post_times
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\UI\Metadata_Renderer::__construct
+	 * @uses \Parsely\UI\Metadata_Renderer::render_metadata
 	 */
 	public function test_get_callback_with_url_filter(): void {
 		add_filter( 'wp_parsely_enable_tracker_url', '__return_false' );
@@ -201,6 +267,14 @@ final class RestMetadataTest extends TestCase {
 	 * Test that the get_rest_callback method doesn't crash when the post does not exist.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::get_callback
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::get_rendered_meta
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::get_tracker_url
+	 * @uses \Parsely\UI\Metadata_Renderer::__construct
+	 * @uses \Parsely\UI\Metadata_Renderer::render_metadata
 	 */
 	public function test_get_callback_with_non_existent_post(): void {
 		$meta_object = self::$rest->get_callback( array() );
@@ -218,6 +292,23 @@ final class RestMetadataTest extends TestCase {
 	 * Test that the rendered meta function returns the meta HTML string with json ld.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::get_rendered_meta
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Metadata::__construct
+	 * @uses \Parsely\Metadata::construct_metadata
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
+	 * @uses \Parsely\Metadata::get_tags
+	 * @uses \Parsely\Metadata::set_metadata_post_times
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\UI\Metadata_Renderer::__construct
+	 * @uses \Parsely\UI\Metadata_Renderer::render_metadata
 	 */
 	public function test_get_rendered_meta_json_ld(): void {
 		// Set the default options prior to each test.
@@ -245,6 +336,25 @@ final class RestMetadataTest extends TestCase {
 	 * Test that the rendered meta function returns the meta HTML string with json ld.
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::get_rendered_meta
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Metadata::__construct
+	 * @uses \Parsely\Metadata::construct_metadata
+	 * @uses \Parsely\Metadata::get_author_names
+	 * @uses \Parsely\Metadata::get_bottom_level_term
+	 * @uses \Parsely\Metadata::get_category_name
+	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
+	 * @uses \Parsely\Metadata::get_coauthor_names
+	 * @uses \Parsely\Metadata::get_current_url
+	 * @uses \Parsely\Metadata::get_tags
+	 * @uses \Parsely\Metadata::set_metadata_post_times
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::convert_jsonld_to_parsely_type
+	 * @uses \Parsely\UI\Metadata_Renderer::__construct
+	 * @uses \Parsely\UI\Metadata_Renderer::render_metadata
+	 * @uses \Parsely\UI\Metadata_Renderer::filter_empty_and_not_string_from_array
 	 */
 	public function test_get_rendered_repeated_metas(): void {
 		global $post;

--- a/tests/Integration/GetCurrentUrlTest.php
+++ b/tests/Integration/GetCurrentUrlTest.php
@@ -104,6 +104,7 @@ final class GetCurrentUrlTest extends TestCase {
 	 * @testdox Given Force HTTPS is $force_https, when home is $home, then expect URLs starting with $expected.
 	 * @dataProvider data_for_test_get_current_url
 	 * @covers \Parsely\Metadata::get_current_url
+	 * @uses \Parsely\Metadata::__construct
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 *

--- a/tests/Integration/Integrations/AmpTest.php
+++ b/tests/Integration/Integrations/AmpTest.php
@@ -93,6 +93,7 @@ final class AmpTest extends TestCase {
 	 *
 	 * @covers \Parsely\Integrations\Amp::add_actions
 	 * @covers \Parsely\Integrations\Amp::register_parsely_for_amp_analytics
+	 * @covers \Parsely\Integrations\Amp::construct_amp_config
 	 * @uses \Parsely\Parsely::get_options
 	 * @group amp
 	 * @group settings
@@ -118,6 +119,8 @@ final class AmpTest extends TestCase {
 	 *
 	 * @covers \Parsely\Integrations\Amp::add_actions
 	 * @covers \Parsely\Integrations\Amp::register_parsely_for_amp_native_analytics
+	 * @covers \Parsely\Integrations\Amp::construct_amp_config
+	 * @covers \Parsely\Integrations\Amp::construct_amp_json
 	 * @uses \Parsely\Parsely::get_options
 	 * @group amp
 	 * @group settings

--- a/tests/Integration/Integrations/GoogleWebStoriesTest.php
+++ b/tests/Integration/Integrations/GoogleWebStoriesTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Parsely\Tests\Integration\Integrations;
 
 use Parsely\Integrations\Google_Web_Stories;
-use Parsely\Parsely;
 use Parsely\Tests\Integration\TestCase;
 
 /**
@@ -49,7 +48,9 @@ final class GoogleWebStoriesTest extends TestCase {
 	 *
 	 * @since 3.2.0
 	 *
-	 * @covers \Parsely\Scripts::run()
+	 * @covers \Parsely\Integrations\Google_Web_Stories::integrate
+	 * @uses \Parsely\Integrations\Amp::construct_amp_config
+	 * @uses \Parsely\Integrations\Amp::construct_amp_json
 	 * @group scripts
 	 */
 	public function test_web_stories_script_is_enqueued(): void {
@@ -67,7 +68,9 @@ final class GoogleWebStoriesTest extends TestCase {
 	 *
 	 * @since 3.2.0
 	 *
-	 * @covers \Parsely\Scripts::render_amp_analytics_tracker
+	 * @covers \Parsely\Integrations\Google_Web_Stories::render_amp_analytics_tracker
+	 * @uses \Parsely\Integrations\Amp::construct_amp_config
+	 * @uses \Parsely\Integrations\Amp::construct_amp_json
 	 * @group scripts
 	 */
 	public function test_render_amp_analytics_tracker(): void {

--- a/tests/Integration/Integrations/IntegrationsTest.php
+++ b/tests/Integration/Integrations/IntegrationsTest.php
@@ -27,6 +27,7 @@ final class IntegrationsTest extends TestCase {
 	 * @covers \Parsely\parsely_integrations
 	 * @uses \Parsely\Integrations\Amp::integrate
 	 * @uses \Parsely\Integrations\Facebook_Instant_Articles::integrate
+	 * @uses \Parsely\Integrations\Google_Web_Stories::integrate
 	 * @uses \Parsely\Integrations\Integrations::integrate
 	 * @uses \Parsely\Integrations\Integrations::register
 	 */

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -68,8 +68,8 @@ final class OtherTest extends TestCase {
 	 * @covers \Parsely\Metadata::get_coauthor_names
 	 * @covers \Parsely\Metadata::get_current_url
 	 * @covers \Parsely\Metadata::set_metadata_post_times
-	 * @uses \Parsely\Parsely::get_options
 	 * @covers \Parsely\Metadata::get_tags
+	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -58,16 +58,18 @@ final class OtherTest extends TestCase {
 	/**
 	 * Check out page filtering.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -107,15 +109,17 @@ final class OtherTest extends TestCase {
 	 * Test the wp_parsely_post_type filter
 	 *
 	 * @covers \Parsely\Metadata::construct_metadata
+	 * @covers \Parsely\Metadata::__construct
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 */
@@ -242,6 +246,9 @@ final class OtherTest extends TestCase {
 	 * @since 3.2.0
 	 *
 	 * @covers \Parsely\Parsely::get_tracker_url
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_api_key
+	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_get_tracker_url(): void {
 		$expected = 'https://cdn.parsely.com/keys/blog.parsely.com/p.js';
@@ -254,6 +261,8 @@ final class OtherTest extends TestCase {
 	 * @since 3.2.0
 	 *
 	 * @covers \Parsely\Parsely::get_tracker_url
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_get_tracker_no_api_key(): void {
 		self::set_options( array( 'apikey' => '' ) );

--- a/tests/Integration/RemoteAPI/RelatedRemoteAPITest.php
+++ b/tests/Integration/RemoteAPI/RelatedRemoteAPITest.php
@@ -85,7 +85,11 @@ final class RelatedRemoteAPITest extends TestCase {
 	 * Test the basic generation of the API URL.
 	 *
 	 * @dataProvider data_related_api_url
-	 * @covers \Parsely\RemoteAPI\Related_Proxy:get_api_url
+	 * @covers \Parsely\RemoteAPI\Related_Proxy::get_api_url
+	 * @uses \Parsely\RemoteAPI\Base_Proxy::__construct
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_api_key
+	 * @uses \Parsely\Parsely::get_options
 	 *
 	 * @param array  $query Test query arguments.
 	 * @param string $url Expected generated URL.
@@ -100,6 +104,7 @@ final class RelatedRemoteAPITest extends TestCase {
 	 * Test that the cache is used instead of the proxy when there's a cache hit.
 	 *
 	 * @covers \Parsely\RemoteAPI\Cached_Proxy::get_items
+	 * @covers \Parsely\RemoteAPI\Cached_Proxy::__construct
 	 */
 	public function test_related_cached_proxy_returns_cached_value(): void {
 		$proxy = $this->getMockBuilder( Related_Proxy::class )
@@ -136,6 +141,7 @@ final class RelatedRemoteAPITest extends TestCase {
 	 * Test that when the cache misses, the proxy is used instead and the resultant value is cached.
 	 *
 	 * @covers \Parsely\RemoteAPI\Cached_Proxy::get_items
+	 * @covers \Parsely\RemoteAPI\Cached_Proxy::__construct
 	 */
 	public function test_related_caching_decorator_returns_uncached_value(): void {
 		$proxy = $this->getMockBuilder( Related_Proxy::class )

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -47,6 +47,9 @@ final class ScriptsTest extends TestCase {
 	 * Test whether the run method adds the register and enqueue actions.
 	 *
 	 * @covers \Parsely\Scripts::run
+	 * @covers \Parsely\Scripts::__construct
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
 	 *
 	 * @group scripts
 	 */
@@ -64,6 +67,9 @@ final class ScriptsTest extends TestCase {
 	 * Test whether the run method adds the register and enqueue actions when no API key is set.
 	 *
 	 * @covers \Parsely\Scripts::run
+	 * @covers \Parsely\Scripts::__construct
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
 	 *
 	 * @group scripts
 	 */
@@ -80,6 +86,9 @@ final class ScriptsTest extends TestCase {
 	 * Test whether the run method adds the register and enqueue actions when the disable javascript option is set.
 	 *
 	 * @covers \Parsely\Scripts::run
+	 * @covers \Parsely\Scripts::__construct
+	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_options
 	 *
 	 * @group scripts
 	 */
@@ -96,9 +105,12 @@ final class ScriptsTest extends TestCase {
 	 * Test script registration functionality.
 	 *
 	 * @covers \Parsely\Scripts::register_scripts
+	 * @covers \Parsely\Scripts::__construct
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_api_key
 	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::get_tracker_url
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group scripts
 	 */
@@ -137,9 +149,12 @@ final class ScriptsTest extends TestCase {
 	 * Test the tracker script enqueue.
 	 *
 	 * @covers \Parsely\Scripts::enqueue_js_tracker
+	 * @covers \Parsely\Scripts::__construct
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_api_key
 	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::get_tracker_url
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @uses \Parsely\Scripts::register_scripts
@@ -173,9 +188,12 @@ final class ScriptsTest extends TestCase {
 	 * Tests the tracker script enqueue.
 	 *
 	 * @covers \Parsely\Scripts::enqueue_js_tracker
+	 * @covers \Parsely\Scripts::__construct
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::get_api_key
+	 * @uses \Parsely\Parsely::get_tracker_url
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @uses \Parsely\Scripts::register_scripts
@@ -212,8 +230,12 @@ final class ScriptsTest extends TestCase {
 	 * When it returns false, the tracking script should not be enqueued.
 	 *
 	 * @covers \Parsely\Scripts::enqueue_js_tracker
+	 * @covers \Parsely\Scripts::register_scripts
+	 * @covers \Parsely\Scripts::__construct
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::api_key_is_set
+	 * @uses \Parsely\Parsely::get_api_key
+	 * @uses \Parsely\Parsely::get_tracker_url
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -251,9 +273,13 @@ final class ScriptsTest extends TestCase {
 	 * Test the API init script enqueue.
 	 *
 	 * @covers \Parsely\Scripts::enqueue_js_tracker
+	 * @covers \Parsely\Scripts::__construct
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::get_api_key
+	 * @uses \Parsely\Parsely::get_tracker_url
+	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @uses \Parsely\Scripts::register_scripts
 	 * @uses \Parsely\Scripts::script_loader_tag
@@ -281,10 +307,15 @@ final class ScriptsTest extends TestCase {
 	 * Make sure that disabling authenticated user tracking works.
 	 *
 	 * @covers \Parsely\Scripts::enqueue_js_tracker
+	 * @covers \Parsely\Scripts::register_scripts
+	 * @covers \Parsely\Scripts::__construct
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::parsely_is_user_logged_in
+	 * @uses \Parsely\Parsely::get_api_key
+	 * @uses \Parsely\Parsely::get_tracker_url
+	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @group scripts
 	 * @group settings
 	 */
@@ -323,14 +354,17 @@ final class ScriptsTest extends TestCase {
 	 * activity.
 	 *
 	 * @covers \Parsely\Scripts::enqueue_js_tracker
+	 * @covers \Parsely\Scripts::__construct
+	 * @covers \Parsely\Scripts::register_scripts
+	 * @covers \Parsely\Scripts::script_loader_tag
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::parsely_is_user_logged_in
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
-	 * @uses \Parsely\Scripts::register_scripts
-	 * @uses \Parsely\Scripts::script_loader_tag
+	 * @uses \Parsely\Parsely::get_api_key
+	 * @uses \Parsely\Parsely::get_tracker_url
 	 * @group scripts
 	 * @group settings
 	 */
@@ -403,13 +437,16 @@ final class ScriptsTest extends TestCase {
 	 * when the wp_parsely_enable_cfasync_attribute filter is used.
 	 *
 	 * @covers \Parsely\Scripts::enqueue_js_tracker
+	 * @uses \Parsely\Scripts::script_loader_tag
+	 * @uses \Parsely\Scripts::register_scripts
+	 * @uses \Parsely\Scripts::__construct
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
-	 * @uses \Parsely\Scripts::register_scripts
-	 * @uses \Parsely\Scripts::script_loader_tag
+	 * @uses \Parsely\Parsely::get_api_key
+	 * @uses \Parsely\Parsely::get_tracker_url
 	 * @group scripts
 	 * @group scripts-output
 	 */

--- a/tests/Integration/StructuredData/AuthorArchiveTest.php
+++ b/tests/Integration/StructuredData/AuthorArchiveTest.php
@@ -23,15 +23,16 @@ final class AuthorArchiveTest extends NonPostTestCase {
 	 * Check metadata for author archive.
 	 *
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::__construct
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/StructuredData/BlogArchiveTest.php
+++ b/tests/Integration/StructuredData/BlogArchiveTest.php
@@ -22,16 +22,17 @@ final class BlogArchiveTest extends NonPostTestCase {
 	/**
 	 * Create a single page, set as the posts page (blog archive) but not the home page, go to Page 2, and test the structured data.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
@@ -22,16 +22,17 @@ final class CustomPostTypeArchiveTest extends NonPostTestCase {
 	/**
 	 * Check metadata for custom post type archive.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
@@ -22,16 +22,17 @@ class CustomTaxonomyTermArchiveTest extends NonPostTestCase {
 	/**
 	 * Check metadata for custom post type term archive.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/StructuredData/HomePageTest.php
+++ b/tests/Integration/StructuredData/HomePageTest.php
@@ -33,16 +33,17 @@ final class HomePageTest extends NonPostTestCase {
 	/**
 	 * Create a single page, set as homepage (blog archive), and test the structured data.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -79,16 +80,17 @@ final class HomePageTest extends NonPostTestCase {
 	/**
 	 * Create 2 posts, set posts per page to 1, navigate to page 2 and test the structured data.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -130,16 +132,17 @@ final class HomePageTest extends NonPostTestCase {
 	/**
 	 * Create a single page, set as homepage (page on front), and test the structured data.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -182,16 +185,17 @@ final class HomePageTest extends NonPostTestCase {
 	/**
 	 * Check for the case when the show_on_front setting is Page, but no Page has been selected.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/StructuredData/SinglePageTest.php
+++ b/tests/Integration/StructuredData/SinglePageTest.php
@@ -23,16 +23,17 @@ final class SinglePageTest extends NonPostTestCase {
 	/**
 	 * Create a single page, and test the structured data.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/StructuredData/SinglePostTest.php
+++ b/tests/Integration/StructuredData/SinglePostTest.php
@@ -33,16 +33,18 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Create a single post, and test the structured data.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -72,16 +74,18 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check the category.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -107,16 +111,18 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check that the tags assigned to a post are lowercase.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -152,18 +158,20 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check the categories as tags.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_categories
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
-	 * @uses \Parsely\Metadata::get_custom_taxonomy_values
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_categories
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_custom_taxonomy_values
+	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -199,18 +207,20 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Test custom taxonomy terms, categories, and tags in the metadata.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_categories
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
-	 * @uses \Parsely\Metadata::get_custom_taxonomy_values
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_categories
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_custom_taxonomy_values
+	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -258,17 +268,19 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Are the top level categories what we expect?
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata::get_top_level_term
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
-	 * @uses \Parsely\Metadata::get_top_level_term
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -316,17 +328,19 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check out the custom taxonomy as section.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata::get_top_level_term
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
-	 * @uses \Parsely\Metadata::get_top_level_term
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -385,16 +399,18 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check the canonicals.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -437,16 +453,18 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check post modified date in Parsely metadata.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata::set_metadata_post_times
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata
@@ -489,8 +507,19 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check that post objects with valid creation date work with construct_parsely_metadata.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
 	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @group metadata
 	 */
 	public function test_empty_post_date_has_dates_omitted_from_metadata(): void {
@@ -518,8 +547,18 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check that post objects with identical creation & modified dates produce expected metadata.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
 	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @group metadata
 	 */
 	public function test_post_date_with_same_create_modified_dates_included_in_metadata(): void {
@@ -553,8 +592,18 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check that posts with modified before creation date "promotes" modified in metadata.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
 	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @group metadata
 	 */
 	public function test_post_date_with_modified_before_created_date_in_metadata(): void {
@@ -589,8 +638,18 @@ final class SinglePostTest extends TestCase {
 	/**
 	 * Check that posts with modified after creation date has both in metadata.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
 	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @group metadata
 	 */
 	public function test_post_date_with_modified_after_created_date_in_metadata(): void {
@@ -645,8 +704,20 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @since 3.0.3
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_categories
+	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata::get_categories
+	 * @covers \Parsely\Metadata::get_custom_taxonomy_values
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @group metadata
 	 */
 	public function test_post_with_categories_as_tags_without_categories(): void {
@@ -677,7 +748,18 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @since 3.3.0
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
+	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @group metadata
 	 */
 	public function test_post_featured_image_urls_in_metadata_are_correct(): void {

--- a/tests/Integration/StructuredData/TermArchiveTest.php
+++ b/tests/Integration/StructuredData/TermArchiveTest.php
@@ -22,16 +22,17 @@ final class TermArchiveTest extends NonPostTestCase {
 	/**
 	 * Check metadata for term archive.
 	 *
+	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_name
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_author_name
+	 * @covers \Parsely\Metadata::get_author_names
+	 * @covers \Parsely\Metadata::get_bottom_level_term
+	 * @covers \Parsely\Metadata::get_category_name
+	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
+	 * @covers \Parsely\Metadata::get_coauthor_names
+	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::get_options
-	 * @uses \Parsely\Metadata::get_tags
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
 	 * @group metadata

--- a/tests/Integration/UI/AdminBarTest.php
+++ b/tests/Integration/UI/AdminBarTest.php
@@ -38,6 +38,7 @@ final class AdminBarTest extends TestCase {
 	/**
 	 * Check that the function to render the stats button is enqueued on the admin menu.
 	 *
+	 * @covers \Parsely\UI\Admin_Bar::__construct
 	 * @covers \Parsely\UI\Admin_Bar::run
 	 */
 	public function test_admin_bar_enqueued(): void {
@@ -49,6 +50,7 @@ final class AdminBarTest extends TestCase {
 	/**
 	 * Check that the function to render the stats button is not enqueued on the admin menu when there's the filter.
 	 *
+	 * @covers \Parsely\UI\Admin_Bar::__construct
 	 * @covers \Parsely\UI\Admin_Bar::run
 	 */
 	public function test_admin_bar_not_enqueued_with_filter(): void {

--- a/tests/Integration/UI/AdminWarningTest.php
+++ b/tests/Integration/UI/AdminWarningTest.php
@@ -39,7 +39,9 @@ final class AdminWarningTest extends TestCase {
 	 * Test that test_display_admin_warning action returns a warning when there is no key
 	 *
 	 * @covers \Parsely\UI\Admin_Warning::should_display_admin_warning
-	 * @uses \Parsely\UI\Admin_Warning::__construct
+	 * @covers \Parsely\UI\Admin_Warning::__construct
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_display_admin_warning_without_key(): void {
@@ -58,7 +60,9 @@ final class AdminWarningTest extends TestCase {
 	 * Test that test_display_admin_warning action returns a warning when there is no key
 	 *
 	 * @covers \Parsely\UI\Admin_Warning::should_display_admin_warning
-	 * @uses \Parsely\UI\Admin_Warning::__construct
+	 * @covers \Parsely\UI\Admin_Warning::__construct
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_display_admin_warning_without_key_old_wp(): void {
@@ -74,7 +78,7 @@ final class AdminWarningTest extends TestCase {
 	 * Test that test_display_admin_warning action returns a warning when there is no key
 	 *
 	 * @covers \Parsely\UI\Admin_Warning::should_display_admin_warning
-	 * @uses \Parsely\UI\Admin_Warning::__construct
+	 * @covers \Parsely\UI\Admin_Warning::__construct
 	 */
 	public function test_display_admin_warning_network_admin(): void {
 		$should_display_admin_warning = self::get_method( 'should_display_admin_warning', Admin_Warning::class );
@@ -89,7 +93,9 @@ final class AdminWarningTest extends TestCase {
 	 * Test that test_display_admin_warning action doesn't return a warning when there is a key
 	 *
 	 * @covers \Parsely\UI\Admin_Warning::should_display_admin_warning
-	 * @uses \Parsely\UI\Admin_Warning::__construct
+	 * @covers \Parsely\UI\Admin_Warning::__construct
+	 * @uses \Parsely\Parsely::api_key_is_missing
+	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_display_admin_warning_with_key(): void {

--- a/tests/Integration/UI/SettingsPageTest.php
+++ b/tests/Integration/UI/SettingsPageTest.php
@@ -46,7 +46,12 @@ final class SettingsPageTest extends TestCase {
 	 *
 	 * @since 3.2.0
 	 *
+	 * @covers \Parsely\UI\Settings_Page::__construct
 	 * @covers \Parsely\UI\Settings_Page::validate_options
+	 * @covers \Parsely\UI\Settings_Page::get_logo_default
+	 * @covers \Parsely\UI\Settings_Page::sanitize_option_array
+	 * @covers \Parsely\UI\Settings_Page::validate_options_post_type_tracking
+	 * @uses \Parsely\Parsely::get_options
 	 * @group ui
 	 */
 	public function test_save_tracking_settings(): void {
@@ -68,7 +73,12 @@ final class SettingsPageTest extends TestCase {
 	 *
 	 * @since 3.2.0
 	 *
+	 * @covers \Parsely\UI\Settings_Page::__construct
 	 * @covers \Parsely\UI\Settings_Page::validate_options
+	 * @covers \Parsely\UI\Settings_Page::get_logo_default
+	 * @covers \Parsely\UI\Settings_Page::sanitize_option_array
+	 * @covers \Parsely\UI\Settings_Page::validate_options_post_type_tracking
+	 * @uses \Parsely\Parsely::get_options
 	 * @group ui
 	 */
 	public function test_saving_tracking_settings_for_non_existent_post_type_should_fail(): void {
@@ -91,7 +101,11 @@ final class SettingsPageTest extends TestCase {
 	 *
 	 * @since 3.2.0
 	 *
+	 * @covers \Parsely\UI\Settings_Page::__construct
 	 * @covers \Parsely\UI\Settings_Page::validate_options
+	 * @covers \Parsely\UI\Settings_Page::get_logo_default
+	 * @covers \Parsely\UI\Settings_Page::validate_options_post_type_tracking
+	 * @uses \Parsely\Parsely::get_options
 	 * @group ui
 	 */
 	public function test_trying_to_save_unset_tracking_settings_should_fail(): void {
@@ -108,7 +122,11 @@ final class SettingsPageTest extends TestCase {
 	 *
 	 * @since 3.2.0
 	 *
+	 * @covers \Parsely\UI\Settings_Page::__construct
 	 * @covers \Parsely\UI\Settings_Page::validate_options
+	 * @covers \Parsely\UI\Settings_Page::get_logo_default
+	 * @covers \Parsely\UI\Settings_Page::validate_options_post_type_tracking
+	 * @uses \Parsely\Parsely::get_options
 	 * @group ui
 	 */
 	public function test_trying_to_save_empty_array_tracking_settings_should_fail(): void {
@@ -125,7 +143,11 @@ final class SettingsPageTest extends TestCase {
 	 *
 	 * @since 3.2.0
 	 *
+	 * @covers \Parsely\UI\Settings_Page::__construct
 	 * @covers \Parsely\UI\Settings_Page::validate_options
+	 * @covers \Parsely\UI\Settings_Page::get_logo_default
+	 * @covers \Parsely\UI\Settings_Page::validate_options_post_type_tracking
+	 * @uses \Parsely\Parsely::get_options
 	 * @group ui
 	 */
 	public function test_trying_to_save_non_array_tracking_settings_should_fail(): void {


### PR DESCRIPTION
## Description

We have had outdated PHPUnit documentation for a while, which hurts our coverage tests. This PR updates all comments to properly represent what the tests are covering. From now on, it is very important that every newly introduced PR checks that tests are correctly annotated.

## Motivation and Context

We want the coverage tests to provide relevant metrics.

## How Has This Been Tested?

See tests runs on GitHub Actions 8.0, where they run with coverage. No coverage warnings should appear.

## Screenshots (if appropriate)

We went from:

```
Classes: 12.50% (3/24)    
Methods: 19.40% (26/134)  
Lines:   10.74% (138/1285)
```

To:

```
Classes: 25.00% (6/24)    
Methods: 36.57% (49/134)  
Lines:   36.50% (469/1285)
```