### PR TITLE
Improve PHP comments conformity to Inline Documentation Standards

### DIFF
--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -26,8 +26,6 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	 * Registers fields in WPGraphQL plugin.
 	 *
 	 * @since 3.2.0
-	 *
-	 * @return void
 	 */
 	public function run(): void {
 		/**
@@ -47,8 +45,6 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	 * API.
 	 *
 	 * @since 3.2.0
-	 *
-	 * @return void
 	 */
 	public function register_meta(): void {
 		$this->register_object_types();
@@ -60,8 +56,6 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	 * instance.
 	 *
 	 * @since 3.2.0
-	 *
-	 * @return void
 	 */
 	private function register_object_types(): void {
 		$container_type = array(
@@ -125,8 +119,6 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	 * Registers the custom metadata fields, so they can be queried in GraphQL.
 	 *
 	 * @since 3.2.0
-	 *
-	 * @return void
 	 */
 	private function register_fields(): void {
 		$resolve = function ( \WPGraphQL\Model\Post $graphql_post ) {

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -1,10 +1,12 @@
 <?php
 /**
- * GraphQL support class.
- * Note: this class will only work if the WPGraphQL plugin is installed.
+ * Endpoints: GraphQL metadata endpoint class
+ *
+ * Adds support for GraphQL.
+ * Note: This class will only work if the WPGraphQL plugin is installed.
  *
  * @package Parsely
- * @since 3.2.0
+ * @since   3.2.0
  */
 
 declare(strict_types=1);

--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -14,7 +14,7 @@ namespace Parsely\Endpoints;
 use WP_Post;
 
 /**
- * Add Parse.ly metadata fields to the WP GraphQL server.
+ * Adds Parse.ly metadata fields to the WP GraphQL server.
  *
  * @since 3.2.0
  */
@@ -23,7 +23,7 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	private const GRAPHQL_CONTAINER_TYPE = 'ParselyMetaContainer';
 
 	/**
-	 * Register fields in WPGraphQL plugin.
+	 * Registers fields in WPGraphQL plugin.
 	 *
 	 * @since 3.2.0
 	 *
@@ -31,7 +31,7 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	 */
 	public function run(): void {
 		/**
-		 * Filter whether GraphQL support is enabled or not.
+		 * Filters whether GraphQL support is enabled or not.
 		 *
 		 * @since 3.2.0
 		 *
@@ -43,7 +43,8 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	}
 
 	/**
-	 * Register the meta field on the appropriate resource types in the REST API.
+	 * Registers the meta field on the appropriate resource types in the REST
+	 * API.
 	 *
 	 * @since 3.2.0
 	 *
@@ -55,7 +56,8 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	}
 
 	/**
-	 * Register the new custom types for Parse.ly Metadata into the GraphQL instance.
+	 * Registers the new custom types for Parse.ly Metadata into the GraphQL
+	 * instance.
 	 *
 	 * @since 3.2.0
 	 *
@@ -120,7 +122,7 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 	}
 
 	/**
-	 * Register the custom metadata fields, so they can be queried in GraphQL.
+	 * Registers the custom metadata fields, so they can be queried in GraphQL.
 	 *
 	 * @since 3.2.0
 	 *

--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Metadata endpoint abstract class
+ * Endpoints: Metadata endpoint abstract class
  *
  * @package Parsely\Endpoints
- * @since 3.2.0
+ * @since   3.2.0
  */
 
 declare(strict_types=1);

--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -42,8 +42,6 @@ abstract class Metadata_Endpoint {
 	 * Starts up the class and enqueues necessary actions.
 	 *
 	 * @since 3.2.0
-	 *
-	 * @return void
 	 */
 	abstract public function run(): void;
 
@@ -51,8 +49,6 @@ abstract class Metadata_Endpoint {
 	 * Registers the metadata fields on the appropriate resource types.
 	 *
 	 * @since 3.2.0
-	 *
-	 * @return void
 	 */
 	abstract public function register_meta(): void;
 

--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -2,7 +2,7 @@
 /**
  * Endpoints: Metadata endpoint abstract class
  *
- * @package Parsely\Endpoints
+ * @package Parsely
  * @since   3.2.0
  */
 

--- a/src/Endpoints/class-metadata-endpoint.php
+++ b/src/Endpoints/class-metadata-endpoint.php
@@ -14,7 +14,8 @@ use Parsely\Parsely;
 use Parsely\UI\Metadata_Renderer;
 
 /**
- * Metadata endpoint classes are expected to implement the remaining functions of the class.
+ * Metadata endpoint classes are expected to implement the remaining functions
+ * of the class.
  *
  * @since 3.2.0
  */
@@ -38,7 +39,7 @@ abstract class Metadata_Endpoint {
 	}
 
 	/**
-	 * Function to start up the class and enqueue necessary actions.
+	 * Starts up the class and enqueues necessary actions.
 	 *
 	 * @since 3.2.0
 	 *
@@ -56,7 +57,7 @@ abstract class Metadata_Endpoint {
 	abstract public function register_meta(): void;
 
 	/**
-	 * Get the metadata in string format.
+	 * Returns the metadata in string format.
 	 *
 	 * @since 3.2.0
 	 *

--- a/src/Endpoints/class-related-api-proxy.php
+++ b/src/Endpoints/class-related-api-proxy.php
@@ -18,7 +18,7 @@ use WP_REST_Server;
 use WP_REST_Request;
 
 /**
- * Configure a REST API endpoint for use e.g. by the Recommendations Block.
+ * Configures a REST API endpoint for use e.g. by the Recommendations Block.
  */
 final class Related_API_Proxy {
 	/**
@@ -36,7 +36,7 @@ final class Related_API_Proxy {
 	private $proxy;
 
 	/**
-	 * Used to inject dependencies.
+	 * Constructor.
 	 *
 	 * @param Parsely $parsely Instance of Parsely class.
 	 * @param Proxy   $proxy   Proxy object which does the actual calls to the Parse.ly API.
@@ -47,7 +47,7 @@ final class Related_API_Proxy {
 	}
 
 	/**
-	 * Entrypoint to register the endpoint and otherwise initialize this class.
+	 * Registers the endpoint and initializes this class.
 	 *
 	 * @return void
 	 */
@@ -79,7 +79,7 @@ final class Related_API_Proxy {
 	}
 
 	/**
-	 * Determine if the endpoint can be called.
+	 * Determines if the endpoint can be called.
 	 *
 	 * @return bool
 	 */

--- a/src/Endpoints/class-related-api-proxy.php
+++ b/src/Endpoints/class-related-api-proxy.php
@@ -39,7 +39,8 @@ final class Related_API_Proxy {
 	 * Constructor.
 	 *
 	 * @param Parsely $parsely Instance of Parsely class.
-	 * @param Proxy   $proxy   Proxy object which does the actual calls to the Parse.ly API.
+	 * @param Proxy   $proxy   Proxy object which does the actual calls to the
+	 *                         Parse.ly API.
 	 */
 	public function __construct( Parsely $parsely, Proxy $proxy ) {
 		$this->parsely = $parsely;

--- a/src/Endpoints/class-related-api-proxy.php
+++ b/src/Endpoints/class-related-api-proxy.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Parsely Related REST API Endpoint
+ * Endpoints: Parse.ly `/related` API proxy endpoint class
  *
  * @package Parsely
- * @since 3.2.0
+ * @since   3.2.0
  */
 
 declare(strict_types=1);

--- a/src/Endpoints/class-related-api-proxy.php
+++ b/src/Endpoints/class-related-api-proxy.php
@@ -48,8 +48,6 @@ final class Related_API_Proxy {
 
 	/**
 	 * Registers the endpoint and initializes this class.
-	 *
-	 * @return void
 	 */
 	public function run(): void {
 		if ( ! apply_filters( 'wp_parsely_enable_related_api_proxy', true ) ) {

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -54,7 +54,8 @@ class Rest_Metadata extends Metadata_Endpoint {
 		 *
 		 * @since 3.1.0
 		 *
-		 * @param string[] $object_types Array of strings containing the object types, i.e. `page`, `post`, `term`.
+		 * @param string[] $object_types Array of strings containing the object types, i.e. `page`,
+		 *                 `post`, `term`.
 		 */
 		$object_types = apply_filters( 'wp_parsely_rest_object_types', $object_types );
 
@@ -66,9 +67,11 @@ class Rest_Metadata extends Metadata_Endpoint {
 	 * Function to get hooked into the `get_callback` property of the `parsely`
 	 * REST API field. It generates the `parsely` object in the REST API.
 	 *
-	 * @param array $object The WordPress object to extract to render the metadata for, usually a post or a page.
-	 * @return array<string, mixed> The `parsely` object to be rendered in the REST API. Contains a version number describing the
-	 * response and the `meta` object containing the actual metadata.
+	 * @param array $object         The WordPress object to extract to render the metadata for,
+	 *                              usually a post or a page.
+	 * @return array<string, mixed> The `parsely` object to be rendered in the REST API. Contains a
+	 *                              version number describing the response and the `meta` object
+	 *                              containing the actual metadata.
 	 */
 	public function get_callback( array $object ): array {
 		$post_id = $object['ID'] ?? $object['id'] ?? 0;
@@ -87,7 +90,8 @@ class Rest_Metadata extends Metadata_Endpoint {
 		);
 
 		/**
-		 * Filter whether REST API support in rendered string format is enabled or not.
+		 * Filter whether REST API support in rendered string format is enabled
+		 * or not.
 		 *
 		 * @since 3.1.0
 		 *

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -23,7 +23,7 @@ class Rest_Metadata extends Metadata_Endpoint {
 	private const REST_VERSION = '1.1.0';
 
 	/**
-	 * Register fields in WordPress REST API
+	 * Registers fields in WordPress REST API.
 	 *
 	 * @since 3.1.0
 	 *
@@ -67,8 +67,8 @@ class Rest_Metadata extends Metadata_Endpoint {
 	}
 
 	/**
-	 * Function to get hooked into the `get_callback` property of the `parsely` REST API field. It generates
-	 * the `parsely` object in the REST API.
+	 * Function to get hooked into the `get_callback` property of the `parsely`
+	 * REST API field. It generates the `parsely` object in the REST API.
 	 *
 	 * @param array $object The WordPress object to extract to render the metadata for, usually a post or a page.
 	 * @return array<string, mixed> The `parsely` object to be rendered in the REST API. Contains a version number describing the

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST API class
+ * REST API class.
  *
  * @package Parsely
  * @since 3.1.0
@@ -14,7 +14,7 @@ use Parsely\Metadata;
 use WP_Post;
 
 /**
- * Injects Parse.ly Metadata to WordPress REST API
+ * Injects Parse.ly Metadata to WordPress REST API.
  *
  * @since 3.1.0
  * @since 3.2.0 Renamed FQCN from `Parsely\Rest` to `Parsely\Endpoints\Rest_Metadata`.

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * REST API class.
+ * Endpoints: REST Metadata endpoint class
  *
  * @package Parsely
- * @since 3.1.0
+ * @since   3.1.0
  */
 
 declare(strict_types=1);

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -26,8 +26,6 @@ class Rest_Metadata extends Metadata_Endpoint {
 	 * Registers fields in WordPress REST API.
 	 *
 	 * @since 3.1.0
-	 *
-	 * @return void
 	 */
 	public function run(): void {
 		/**
@@ -46,8 +44,6 @@ class Rest_Metadata extends Metadata_Endpoint {
 	 * Registers the meta field on the appropriate resource types in the REST API.
 	 *
 	 * @since 3.1.0
-	 *
-	 * @return void
 	 */
 	public function register_meta(): void {
 		$options      = $this->parsely->get_options();

--- a/src/Integrations/class-amp.php
+++ b/src/Integrations/class-amp.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * AMP integration class.
+ * Integrations: AMP integration class
  *
  * @package Parsely\Integrations
- * @since 2.6.0
+ * @since   2.6.0
  */
 
 declare(strict_types=1);

--- a/src/Integrations/class-amp.php
+++ b/src/Integrations/class-amp.php
@@ -23,8 +23,6 @@ class Amp implements Integration {
 	 * plugin.
 	 *
 	 * @since 2.6.0
-	 *
-	 * @return void
 	 */
 	public function integrate(): void {
 		if ( defined( 'AMP__VERSION' ) ) {
@@ -64,8 +62,6 @@ class Amp implements Integration {
 	 * Adds AMP actions.
 	 *
 	 * @since 2.6.0
-	 *
-	 * @return void
 	 */
 	public function add_actions(): void {
 		if ( $this->can_handle_amp_request() ) {

--- a/src/Integrations/class-amp.php
+++ b/src/Integrations/class-amp.php
@@ -2,7 +2,7 @@
 /**
  * Integrations: AMP integration class
  *
- * @package Parsely\Integrations
+ * @package Parsely
  * @since   2.6.0
  */
 

--- a/src/Integrations/class-amp.php
+++ b/src/Integrations/class-amp.php
@@ -19,7 +19,8 @@ use Parsely\Parsely;
  */
 class Amp implements Integration {
 	/**
-	 * Apply the hooks that integrate the plugin or theme with the Parse.ly plugin.
+	 * Applies the hooks that integrate the plugin or theme with the Parse.ly
+	 * plugin.
 	 *
 	 * @since 2.6.0
 	 *
@@ -32,9 +33,10 @@ class Amp implements Integration {
 	}
 
 	/**
-	 * Verify if request is an AMP request.
+	 * Verifies that request is an AMP request.
 	 *
-	 * This is needed to make it easier to mock whether the function exists ot not during tests.
+	 * This is needed to make it easier to mock whether the function exists or
+	 * not during tests.
 	 *
 	 * @since 2.6.0
 	 *
@@ -45,7 +47,8 @@ class Amp implements Integration {
 	}
 
 	/**
-	 * Verify if request is an AMP request, and that AMP support is not disabled.
+	 * Verifies that request is an AMP request, and that AMP support is not
+	 * disabled.
 	 *
 	 * @since 2.6.0
 	 *
@@ -58,7 +61,7 @@ class Amp implements Integration {
 	}
 
 	/**
-	 * Add AMP actions.
+	 * Adds AMP actions.
 	 *
 	 * @since 2.6.0
 	 *
@@ -72,7 +75,7 @@ class Amp implements Integration {
 	}
 
 	/**
-	 * Register Parse.ly for AMP analytics.
+	 * Registers Parse.ly for AMP analytics.
 	 *
 	 * @since 2.6.0
 	 *
@@ -99,7 +102,7 @@ class Amp implements Integration {
 	}
 
 	/**
-	 * Register Parse.ly for AMP native analytics.
+	 * Registers Parse.ly for AMP native analytics.
 	 *
 	 * @since 2.6.0
 	 *
@@ -132,8 +135,9 @@ class Amp implements Integration {
 	}
 
 	/**
-	 * Returns a string containing the JSON-encoded configuration required for AMP. It consists of the site's API
-	 * key if that's defined, an empty string otherwise.
+	 * Returns a string containing the JSON-encoded configuration required for
+	 * AMP. It consists of the site's Site ID if that's defined, an empty string
+	 * otherwise.
 	 *
 	 * @since 3.2.0
 	 *
@@ -150,8 +154,9 @@ class Amp implements Integration {
 	}
 
 	/**
-	 * Returns an array containing the configuration required for AMP. It consists of the site's API key if that's
-	 * defined, or an empty array otherwise.
+	 * Returns an array containing the configuration required for AMP. It
+	 * consists of the site's Site ID if that's defined, or an empty array
+	 * otherwise.
 	 *
 	 * @since 3.2.0
 	 *

--- a/src/Integrations/class-amp.php
+++ b/src/Integrations/class-amp.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * AMP integration class
+ * AMP integration class.
  *
  * @package Parsely\Integrations
  * @since 2.6.0

--- a/src/Integrations/class-facebook-instant-articles.php
+++ b/src/Integrations/class-facebook-instant-articles.php
@@ -26,8 +26,6 @@ final class Facebook_Instant_Articles implements Integration {
 	 * plugin.
 	 *
 	 * @since 2.6.0
-	 *
-	 * @return void
 	 */
 	public function integrate(): void {
 		if ( defined( 'IA_PLUGIN_VERSION' ) ) {
@@ -41,7 +39,6 @@ final class Facebook_Instant_Articles implements Integration {
 	 * @since 2.6.0
 	 *
 	 * @param array $registry The registry info for Facebook Instant Articles.
-	 * @return void
 	 */
 	public function insert_parsely_tracking( &$registry ): void {
 		$parsely = new Parsely();

--- a/src/Integrations/class-facebook-instant-articles.php
+++ b/src/Integrations/class-facebook-instant-articles.php
@@ -22,7 +22,8 @@ final class Facebook_Instant_Articles implements Integration {
 	private const REGISTRY_DISPLAY_NAME = 'Parse.ly Analytics';
 
 	/**
-	 * Apply the hooks that integrate the plugin or theme with the Parse.ly plugin.
+	 * Applies the hooks that integrate the plugin or theme with the Parse.ly
+	 * plugin.
 	 *
 	 * @since 2.6.0
 	 *
@@ -35,7 +36,7 @@ final class Facebook_Instant_Articles implements Integration {
 	}
 
 	/**
-	 * Add Parse.ly tracking to Facebook instant articles.
+	 * Adds Parse.ly tracking to Facebook instant articles.
 	 *
 	 * @since 2.6.0
 	 *
@@ -55,7 +56,7 @@ final class Facebook_Instant_Articles implements Integration {
 	}
 
 	/**
-	 * Get the payload / embed code.
+	 * Returns the payload / embed code.
 	 *
 	 * @since 2.6.0
 	 *

--- a/src/Integrations/class-facebook-instant-articles.php
+++ b/src/Integrations/class-facebook-instant-articles.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Facebook Instant Articles integration class
+ * Facebook Instant Articles integration class.
  *
  * @package Parsely\Integrations
  * @since 2.6.0

--- a/src/Integrations/class-facebook-instant-articles.php
+++ b/src/Integrations/class-facebook-instant-articles.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Facebook Instant Articles integration class.
+ * Integrations: Facebook Instant Articles integration class
  *
  * @package Parsely\Integrations
- * @since 2.6.0
+ * @since   2.6.0
  */
 
 declare(strict_types=1);

--- a/src/Integrations/class-facebook-instant-articles.php
+++ b/src/Integrations/class-facebook-instant-articles.php
@@ -2,7 +2,7 @@
 /**
  * Integrations: Facebook Instant Articles integration class
  *
- * @package Parsely\Integrations
+ * @package Parsely
  * @since   2.6.0
  */
 

--- a/src/Integrations/class-google-web-stories.php
+++ b/src/Integrations/class-google-web-stories.php
@@ -21,8 +21,6 @@ final class Google_Web_Stories implements Integration {
 	 * plugin.
 	 *
 	 * @since 3.2.0
-	 *
-	 * @return void
 	 */
 	public function integrate(): void {
 		if ( defined( 'WEBSTORIES_PLUGIN_FILE' ) ) {
@@ -37,8 +35,6 @@ final class Google_Web_Stories implements Integration {
 	 * See more at: https://www.parse.ly/help/integration/google-amp.
 	 *
 	 * @since 3.2.0
-	 *
-	 * @return void
 	 */
 	public function render_amp_analytics_tracker(): void {
 		$json = Amp::construct_amp_json();

--- a/src/Integrations/class-google-web-stories.php
+++ b/src/Integrations/class-google-web-stories.php
@@ -2,7 +2,7 @@
 /**
  * Integrations: Google Web Stories integration class
  *
- * @package Parsely\Integrations
+ * @package Parsely
  * @since   3.2.0
  */
 

--- a/src/Integrations/class-google-web-stories.php
+++ b/src/Integrations/class-google-web-stories.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Google Web Stories integration class
+ * Google Web Stories integration class.
  *
  * @package Parsely\Integrations
  * @since 3.2.0

--- a/src/Integrations/class-google-web-stories.php
+++ b/src/Integrations/class-google-web-stories.php
@@ -17,7 +17,8 @@ namespace Parsely\Integrations;
  */
 final class Google_Web_Stories implements Integration {
 	/**
-	 * Apply the hooks that integrate the plugin or theme with the Parse.ly plugin.
+	 * Applies the hooks that integrate the plugin or theme with the Parse.ly
+	 * plugin.
 	 *
 	 * @since 3.2.0
 	 *
@@ -30,7 +31,9 @@ final class Google_Web_Stories implements Integration {
 	}
 
 	/**
-	 * Load additional JavaScript for Google's Web Stories WordPress plugin. This relies on the `amp-analytics` element.
+	 * Loads additional JavaScript for Google's Web Stories WordPress plugin.
+	 * This relies on the `amp-analytics` element.
+	 *
 	 * See more at: https://www.parse.ly/help/integration/google-amp.
 	 *
 	 * @since 3.2.0

--- a/src/Integrations/class-google-web-stories.php
+++ b/src/Integrations/class-google-web-stories.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Google Web Stories integration class.
+ * Integrations: Google Web Stories integration class
  *
  * @package Parsely\Integrations
- * @since 3.2.0
+ * @since   3.2.0
  */
 
 declare(strict_types=1);

--- a/src/Integrations/class-integration.php
+++ b/src/Integrations/class-integration.php
@@ -2,7 +2,7 @@
 /**
  * Integrations: Integration interface
  *
- * @package Parsely\Integrations
+ * @package Parsely
  * @since   2.6.0
  */
 

--- a/src/Integrations/class-integration.php
+++ b/src/Integrations/class-integration.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Integration interface.
+ * Integrations: Integration interface
  *
  * @package Parsely\Integrations
- * @since 2.6.0
+ * @since   2.6.0
  */
 
 declare(strict_types=1);

--- a/src/Integrations/class-integration.php
+++ b/src/Integrations/class-integration.php
@@ -17,7 +17,8 @@ namespace Parsely\Integrations;
  */
 interface Integration {
 	/**
-	 * Apply the hooks that integrate the plugin or theme with the Parse.ly plugin.
+	 * Applies the hooks that integrate the plugin or theme with the Parse.ly
+	 * plugin.
 	 *
 	 * @since 2.6.0
 	 */

--- a/src/Integrations/class-integration.php
+++ b/src/Integrations/class-integration.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Integration interface
+ * Integration interface.
  *
  * @package Parsely\Integrations
  * @since 2.6.0

--- a/src/Integrations/class-integrations.php
+++ b/src/Integrations/class-integrations.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Integrations collection
+ * Integrations collection.
  *
  * @package Parsely\Integrations
  * @since   2.6.0

--- a/src/Integrations/class-integrations.php
+++ b/src/Integrations/class-integrations.php
@@ -34,7 +34,6 @@ class Integrations {
 	 * @param string        $key             A unique identifier for the integration.
 	 * @param string|object $class_or_object Fully-qualified class name, or an instantiated object.
 	 *                             If a class name is passed, it will be instantiated.
-	 * @return void
 	 */
 	public function register( string $key, $class_or_object ): void {
 		// If a Foo::class or other fully qualified class name is passed, instantiate it.
@@ -49,8 +48,6 @@ class Integrations {
 	 * add_action() and add_filter() calls.
 	 *
 	 * @since 2.6.0
-	 *
-	 * @return void
 	 */
 	public function integrate(): void {
 		foreach ( $this->integrations as $integration ) {

--- a/src/Integrations/class-integrations.php
+++ b/src/Integrations/class-integrations.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Integrations collection.
+ * Integrations: Integrations collection class
  *
  * @package Parsely\Integrations
  * @since   2.6.0

--- a/src/Integrations/class-integrations.php
+++ b/src/Integrations/class-integrations.php
@@ -2,7 +2,7 @@
 /**
  * Integrations: Integrations collection class
  *
- * @package Parsely\Integrations
+ * @package Parsely
  * @since   2.6.0
  */
 

--- a/src/Integrations/class-integrations.php
+++ b/src/Integrations/class-integrations.php
@@ -13,7 +13,8 @@ namespace Parsely\Integrations;
 /**
  * Integrations are registered to this collection.
  *
- * The `integrate()` method is called on each registered integration, on the init hook.
+ * The `integrate()` method is called on each registered integration, on the
+ * init hook.
  *
  * @since 2.6.0
  */
@@ -26,7 +27,7 @@ class Integrations {
 	private $integrations = array();
 
 	/**
-	 * Register an integration.
+	 * Registers an integration.
 	 *
 	 * @since 2.6.0
 	 *
@@ -44,7 +45,8 @@ class Integrations {
 	}
 
 	/**
-	 * Integrate each integration by calling the method that does the add_action() and add_filter() calls.
+	 * Integrates each integration by calling the method that does the
+	 * add_action() and add_filter() calls.
 	 *
 	 * @since 2.6.0
 	 *

--- a/src/Integrations/class-integrations.php
+++ b/src/Integrations/class-integrations.php
@@ -33,7 +33,7 @@ class Integrations {
 	 *
 	 * @param string        $key             A unique identifier for the integration.
 	 * @param string|object $class_or_object Fully-qualified class name, or an instantiated object.
-	 *                             If a class name is passed, it will be instantiated.
+	 *                                       If a class name is passed, it will be instantiated.
 	 */
 	public function register( string $key, $class_or_object ): void {
 		// If a Foo::class or other fully qualified class name is passed, instantiate it.

--- a/src/RemoteAPI/class-base-proxy.php
+++ b/src/RemoteAPI/class-base-proxy.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Base Proxy for all Parse.ly API endpoints.
+ * Remote API: Base Proxy class for all Parse.ly API endpoints
  *
  * @package Parsely
- * @since 3.2.0
+ * @since   3.2.0
  */
 
 declare(strict_types=1);

--- a/src/RemoteAPI/class-base-proxy.php
+++ b/src/RemoteAPI/class-base-proxy.php
@@ -17,7 +17,8 @@ use WP_Error;
 /**
  * Base Proxy for all Parse.ly API endpoints.
  *
- * Child classes must add a protected `ENDPOINT` constant, and a protected QUERY_FILTER constant.
+ * Child classes must add a protected `ENDPOINT` constant, and a protected
+ * QUERY_FILTER constant.
  *
  * @since 3.2.0
  */
@@ -43,7 +44,7 @@ abstract class Base_Proxy implements Proxy {
 	}
 
 	/**
-	 * Get URL for a particular Parse.ly API endpoint.
+	 * Gets the URL for a particular Parse.ly API endpoint.
 	 *
 	 * @since 3.2.0
 	 *

--- a/src/RemoteAPI/class-cached-proxy.php
+++ b/src/RemoteAPI/class-cached-proxy.php
@@ -46,7 +46,8 @@ class Cached_Proxy implements Proxy {
 	 * Implements caching for the proxy interface.
 	 *
 	 * @param array<string, mixed> $query The query arguments to send to the remote API.
-	 * @return array<string, mixed>|false The response from the remote API, or false if the response is empty.
+	 * @return array<string, mixed>|false The response from the remote API, or false if the
+	 *                                    response is empty.
 	 */
 	public function get_items( array $query ) {
 		$cache_key = 'parsely_api_' . wp_hash( (string) wp_json_encode( $this->proxy ) ) . '_' . wp_hash( (string) wp_json_encode( $query ) );

--- a/src/RemoteAPI/class-cached-proxy.php
+++ b/src/RemoteAPI/class-cached-proxy.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Parsely Related REST API Caching Decorator.
+ * Remote API: `/related` REST API caching decorator class
  *
  * @package Parsely
- * @since 3.2.0
+ * @since   3.2.0
  */
 
 declare(strict_types=1);

--- a/src/RemoteAPI/class-cached-proxy.php
+++ b/src/RemoteAPI/class-cached-proxy.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely Related REST API Caching Decorator
+ * Parsely Related REST API Caching Decorator.
  *
  * @package Parsely
  * @since 3.2.0

--- a/src/RemoteAPI/class-related-proxy.php
+++ b/src/RemoteAPI/class-related-proxy.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Parsely Related REST API Proxy.
+ * Remote API: `/related` REST API Proxy class
  *
  * @package Parsely
- * @since 3.2.0
+ * @since   3.2.0
  */
 
 declare(strict_types=1);

--- a/src/RemoteAPI/class-related-proxy.php
+++ b/src/RemoteAPI/class-related-proxy.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely Related REST API Proxy
+ * Parsely Related REST API Proxy.
  *
  * @package Parsely
  * @since 3.2.0
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace Parsely\RemoteAPI;
 
 /**
- * Proxy for the /related endpoint.
+ * Proxy for the `/related` endpoint.
  *
  * @since 3.2.0
  */

--- a/src/RemoteAPI/class-wordpress-cache.php
+++ b/src/RemoteAPI/class-wordpress-cache.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Parsely Remote API Adapter for the WordPress Object Cache.
+ * Remote API: Adapter class for the WordPress Object Cache
  *
  * @package Parsely
- * @since 3.2.0
+ * @since   3.2.0
  */
 
 declare(strict_types=1);

--- a/src/RemoteAPI/class-wordpress-cache.php
+++ b/src/RemoteAPI/class-wordpress-cache.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely Remote API Adapter for the WordPress Object Cache
+ * Parsely Remote API Adapter for the WordPress Object Cache.
  *
  * @package Parsely
  * @since 3.2.0

--- a/src/RemoteAPI/interface-cache.php
+++ b/src/RemoteAPI/interface-cache.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Parsely Remote API Cache Interface.
+ * Remote API: Cache interface
  *
  * @package Parsely
- * @since 3.2.0
+ * @since   3.2.0
  */
 
 declare(strict_types=1);

--- a/src/RemoteAPI/interface-cache.php
+++ b/src/RemoteAPI/interface-cache.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely Remote API Cache Interface
+ * Parsely Remote API Cache Interface.
  *
  * @package Parsely
  * @since 3.2.0

--- a/src/RemoteAPI/interface-proxy.php
+++ b/src/RemoteAPI/interface-proxy.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely Remote API Proxy Interface
+ * Parsely Remote API Proxy Interface.
  *
  * @package Parsely
  * @since 3.2.0
@@ -13,7 +13,7 @@ namespace Parsely\RemoteAPI;
 use WP_Error;
 
 /**
- * Remote API Proxy Interface
+ * Remote API Proxy Interface.
  */
 interface Proxy {
 	/**

--- a/src/RemoteAPI/interface-proxy.php
+++ b/src/RemoteAPI/interface-proxy.php
@@ -17,7 +17,7 @@ use WP_Error;
  */
 interface Proxy {
 	/**
-	 * Return the items provided by this interface.
+	 * Returns the items provided by this interface.
 	 *
 	 * @param array<string, mixed> $query The query arguments to send to the remote API.
 	 * @return WP_Error|array<string, mixed>

--- a/src/RemoteAPI/interface-proxy.php
+++ b/src/RemoteAPI/interface-proxy.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Parsely Remote API Proxy Interface.
+ * Remote API: Proxy interface
  *
  * @package Parsely
- * @since 3.2.0
+ * @since   3.2.0
  */
 
 declare(strict_types=1);

--- a/src/UI/class-admin-bar.php
+++ b/src/UI/class-admin-bar.php
@@ -1,9 +1,11 @@
 <?php
 /**
- * Parsely tweaks to WordPress admin bar.
+ * UI: Admin bar class
+ *
+ * Enhances the WordPress admin bar with Parse.ly tweaks.
  *
  * @package Parsely
- * @since 3.1.0
+ * @since   3.1.0
  */
 
 declare(strict_types=1);

--- a/src/UI/class-admin-bar.php
+++ b/src/UI/class-admin-bar.php
@@ -40,8 +40,6 @@ final class Admin_Bar {
 	 * Registers admin bar buttons.
 	 *
 	 * @since 3.1.0
-	 *
-	 * @return void
 	 */
 	public function run(): void {
 		/**
@@ -63,8 +61,6 @@ final class Admin_Bar {
 	 * is a post or a page.
 	 *
 	 * @param WP_Admin_Bar $admin_bar WP_Admin_Bar instance, passed by reference.
-	 *
-	 * @return void
 	 */
 	public function admin_bar_parsely_stats_button( WP_Admin_Bar $admin_bar ): void {
 		$current_object = $GLOBALS['wp_the_query']->get_queried_object();

--- a/src/UI/class-admin-bar.php
+++ b/src/UI/class-admin-bar.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely tweaks to WordPress admin bar
+ * Parsely tweaks to WordPress admin bar.
  *
  * @package Parsely
  * @since 3.1.0

--- a/src/UI/class-admin-bar.php
+++ b/src/UI/class-admin-bar.php
@@ -15,7 +15,7 @@ use Parsely\Parsely;
 use Parsely\Dashboard_Link;
 
 /**
- * Render Parse.ly related buttons in the WordPress administrator top bar.
+ * Renders Parse.ly related buttons in the WordPress administrator top bar.
  *
  * @since 3.1.0
  */
@@ -37,7 +37,7 @@ final class Admin_Bar {
 	}
 
 	/**
-	 * Register admin bar buttons.
+	 * Registers admin bar buttons.
 	 *
 	 * @since 3.1.0
 	 *
@@ -45,7 +45,8 @@ final class Admin_Bar {
 	 */
 	public function run(): void {
 		/**
-		 * Filter whether the Open on Parse.ly button is enabled or not on the admin bar menu.
+		 * Filter whether the Open on Parse.ly button is enabled or not on the
+		 * admin bar menu.
 		 *
 		 * @since 3.1.2
 		 *
@@ -58,7 +59,8 @@ final class Admin_Bar {
 	}
 
 	/**
-	 * Adds the `Parse.ly Stats` button on the admin bar when the current object is a post or a page.
+	 * Adds the `Parse.ly Stats` button on the admin bar when the current object
+	 * is a post or a page.
 	 *
 	 * @param WP_Admin_Bar $admin_bar WP_Admin_Bar instance, passed by reference.
 	 *

--- a/src/UI/class-admin-warning.php
+++ b/src/UI/class-admin-warning.php
@@ -38,8 +38,6 @@ final class Admin_Warning {
 	 * Registers admin warning.
 	 *
 	 * @since 3.0.0
-	 *
-	 * @return void
 	 */
 	public function run(): void {
 		add_action( 'admin_notices', array( $this, 'display_admin_warning' ) );
@@ -47,8 +45,6 @@ final class Admin_Warning {
 
 	/**
 	 * Displays the admin warning if needed.
-	 *
-	 * @return void
 	 */
 	public function display_admin_warning(): void {
 		if ( ! $this->should_display_admin_warning() ) {

--- a/src/UI/class-admin-warning.php
+++ b/src/UI/class-admin-warning.php
@@ -66,7 +66,7 @@ final class Admin_Warning {
 	 *
 	 * @since 2.6.0
 	 *
-	 * @return bool True if the admin warning should be displayed
+	 * @return bool True if the admin warning should be displayed.
 	 */
 	private function should_display_admin_warning(): bool {
 		if ( is_network_admin() ) {

--- a/src/UI/class-admin-warning.php
+++ b/src/UI/class-admin-warning.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely wp-admin warning
+ * Parsely wp-admin warning.
  *
  * @package Parsely
  * @since 3.0.0
@@ -13,7 +13,7 @@ namespace Parsely\UI;
 use Parsely\Parsely;
 
 /**
- * Conditionally render a warning message on wp-admin
+ * Conditionally renders a warning message on wp-admin.
  *
  * @since 3.0.0
  */
@@ -35,7 +35,7 @@ final class Admin_Warning {
 	}
 
 	/**
-	 * Register admin warning.
+	 * Registers admin warning.
 	 *
 	 * @since 3.0.0
 	 *
@@ -46,7 +46,7 @@ final class Admin_Warning {
 	}
 
 	/**
-	 * Display the admin warning if needed.
+	 * Displays the admin warning if needed.
 	 *
 	 * @return void
 	 */
@@ -66,7 +66,7 @@ final class Admin_Warning {
 	}
 
 	/**
-	 * Decide whether the admin display warning should be displayed
+	 * Returns whether the admin display warning should be displayed.
 	 *
 	 * @since 2.6.0
 	 *

--- a/src/UI/class-admin-warning.php
+++ b/src/UI/class-admin-warning.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Parsely wp-admin warning.
+ * UI: Parse.ly wp-admin warning class
  *
  * @package Parsely
- * @since 3.0.0
+ * @since   3.0.0
  */
 
 declare(strict_types=1);

--- a/src/UI/class-metadata-renderer.php
+++ b/src/UI/class-metadata-renderer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parse.ly header metadata class
+ * Parse.ly header metadata class.
  *
  * @package Parsely
  * @since 3.3.0
@@ -17,7 +17,7 @@ use WP_Post;
 use const Parsely\PARSELY_FILE;
 
 /**
- * Render metadata in the WordPress front-end header.
+ * Renders metadata in the WordPress front-end header.
  *
  * @since 3.3.0
  */
@@ -39,7 +39,7 @@ final class Metadata_Renderer {
 	}
 
 	/**
-	 * Register metadata actions.
+	 * Registers metadata actions.
 	 *
 	 * @since 3.3.0
 	 *
@@ -73,7 +73,7 @@ final class Metadata_Renderer {
 	}
 
 	/**
-	 * Insert the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
+	 * Inserts the code for the meta parameter within the head tag.
 	 *
 	 * @since 3.2.0
 	 * @since 3.3.0 Moved from `Parsely` class to `Metadata_Header`

--- a/src/UI/class-metadata-renderer.php
+++ b/src/UI/class-metadata-renderer.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Parse.ly header metadata class.
+ * UI: Metadata renderer class.
  *
  * @package Parsely
- * @since 3.3.0
+ * @since   3.3.0
  */
 
 declare(strict_types=1);

--- a/src/UI/class-metadata-renderer.php
+++ b/src/UI/class-metadata-renderer.php
@@ -42,8 +42,6 @@ final class Metadata_Renderer {
 	 * Registers metadata actions.
 	 *
 	 * @since 3.3.0
-	 *
-	 * @return void
 	 */
 	public function run(): void {
 		/**
@@ -64,8 +62,6 @@ final class Metadata_Renderer {
 	 * Renders metadata on site's head using the format from the site's options.
 	 *
 	 * @since 3.3.0
-	 *
-	 * @return void
 	 */
 	public function render_metadata_on_head(): void {
 		$parsely_options = $this->parsely->get_options();
@@ -79,7 +75,6 @@ final class Metadata_Renderer {
 	 * @since 3.3.0 Moved from `Parsely` class to `Metadata_Header`
 	 *
 	 * @param string $meta_type `json_ld` or `repeated_metas`.
-	 * @return void
 	 */
 	public function render_metadata( string $meta_type ): void {
 		$parsely_options = $this->parsely->get_options();

--- a/src/UI/class-network-admin-sites-list.php
+++ b/src/UI/class-network-admin-sites-list.php
@@ -49,7 +49,8 @@ final class Network_Admin_Sites_List {
 	 *
 	 * @since 3.2.0
 	 *
-	 * @param array $actions The list of actions meant to be displayed for the current site's context in the row actions.
+	 * @param array $actions The list of actions meant to be displayed for the current site's
+	 *                       context in the row actions.
 	 * @param int   $_blog_id The blog ID for the current context.
 	 * @return array The list of actions including ours.
 	 */

--- a/src/UI/class-network-admin-sites-list.php
+++ b/src/UI/class-network-admin-sites-list.php
@@ -36,7 +36,6 @@ final class Network_Admin_Sites_List {
 	 * filter hooks.
 	 *
 	 * @since 3.2.0
-	 * @return void
 	 */
 	public function run(): void {
 		add_filter( 'manage_sites_action_links', array( __CLASS__, 'add_action_link' ), 10, 2 );
@@ -109,7 +108,6 @@ final class Network_Admin_Sites_List {
 	 *
 	 * @param string $column_name The column name for the current context.
 	 * @param int    $_blog_id The blog ID for the current context.
-	 * @return void
 	 */
 	public function populate_api_key_column( string $column_name, int $_blog_id ): void {
 		if ( self::COLUMN_NAME !== $column_name ) {

--- a/src/UI/class-network-admin-sites-list.php
+++ b/src/UI/class-network-admin-sites-list.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely Network Admin Site List class
+ * Parsely Network Admin Site List class.
  *
  * @package Parsely
  * @since 3.2.0
@@ -14,7 +14,8 @@ use Parsely\Parsely;
 use WP_Site;
 
 /**
- * Render the additions to the WordPress Multisite Network Admin Sites List page
+ * Renders the additions to the WordPress Multisite Network Admin Sites List
+ * page.
  *
  * @since 3.2.0
  */
@@ -31,7 +32,8 @@ final class Network_Admin_Sites_List {
 	}
 
 	/**
-	 * Attach network admin page functionality to the appropriate action and filter hooks.
+	 * Attaches network admin page functionality to the appropriate action and
+	 * filter hooks.
 	 *
 	 * @since 3.2.0
 	 * @return void
@@ -43,7 +45,8 @@ final class Network_Admin_Sites_List {
 	}
 
 	/**
-	 * Use the manage_sites_action_links filter to append a link to the settings page in the "row actions."
+	 * Uses the manage_sites_action_links filter to append a link to the settings
+	 * page in the "row actions".
 	 *
 	 * @since 3.2.0
 	 *
@@ -67,7 +70,7 @@ final class Network_Admin_Sites_List {
 	}
 
 	/**
-	 * Generate ARIA label content.
+	 * Generates ARIA label content.
 	 *
 	 * @since 3.2.0
 	 *
@@ -85,7 +88,8 @@ final class Network_Admin_Sites_List {
 	}
 
 	/**
-	 * Use the wpmu_blogs_columns filter to register the column where we'll display the site's API Key (if configured).
+	 * Uses the wpmu_blogs_columns filter to register the column where we'll
+	 * display the site's Site ID (if configured).
 	 *
 	 * @since 3.2.0
 	 *
@@ -98,7 +102,8 @@ final class Network_Admin_Sites_List {
 	}
 
 	/**
-	 * Use the manage_sites_custom_column action to output each site's API Key (if configured).
+	 * Uses the manage_sites_custom_column action to output each site's Site ID
+	 * (if configured).
 	 *
 	 * @since 3.2.0
 	 *

--- a/src/UI/class-network-admin-sites-list.php
+++ b/src/UI/class-network-admin-sites-list.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Parsely Network Admin Site List class.
+ * UI: Network Admin site list class
  *
  * @package Parsely
- * @since 3.2.0
+ * @since   3.2.0
  */
 
 declare(strict_types=1);

--- a/src/UI/class-plugins-actions.php
+++ b/src/UI/class-plugins-actions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely plugins actions class
+ * Parsely plugins actions class.
  *
  * @package Parsely
  * @since 2.6.0
@@ -22,7 +22,7 @@ use const Parsely\PARSELY_FILE;
 final class Plugins_Actions {
 
 	/**
-	 * Register action and filter hook callbacks.
+	 * Registers action and filter hook callbacks.
 	 *
 	 * @return void
 	 */

--- a/src/UI/class-plugins-actions.php
+++ b/src/UI/class-plugins-actions.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Parsely plugins actions class.
+ * UI: plugins actions class
  *
  * @package Parsely
- * @since 2.6.0
+ * @since   2.6.0
  */
 
 declare(strict_types=1);

--- a/src/UI/class-plugins-actions.php
+++ b/src/UI/class-plugins-actions.php
@@ -23,8 +23,6 @@ final class Plugins_Actions {
 
 	/**
 	 * Registers action and filter hook callbacks.
-	 *
-	 * @return void
 	 */
 	public function run(): void {
 		add_filter( 'plugin_action_links_' . plugin_basename( PARSELY_FILE ), array( $this, 'add_plugin_meta_links' ) );

--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -4,9 +4,7 @@
  *
  * Provides a widget with Parse.ly recommended articles.
  *
- * @category   Components
- * @package    WordPress
- * @subpackage Parse.ly
+ * @package Parsely
  */
 
 declare(strict_types=1);

--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Recommended Widget file
+ * Recommended Widget class.
  *
- * This provides a widget to put on a page, will have parsely recommended articles
+ * Provides a widget with Parse.ly recommended articles.
  *
  * @category   Components
  * @package    WordPress
@@ -18,11 +18,11 @@ use WP_Widget;
 use const Parsely\PARSELY_FILE;
 
 /**
- * This is the class for the recommended widget.
+ * Provides a widget with Parse.ly recommended articles.
  */
 final class Recommended_Widget extends WP_Widget {
 	/**
-	 * This is the constructor function.
+	 * Constructor.
 	 */
 	public function __construct() {
 		parent::__construct(
@@ -36,7 +36,7 @@ final class Recommended_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Get the URL for the Recommendations API (GET /related).
+	 * Gets the URL for the Recommendations API (GET /related).
 	 *
 	 * @see https://www.parse.ly/help/api/recommendations#get-related
 	 *
@@ -274,7 +274,7 @@ final class Recommended_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Return the list of boost parameters, values and labels.
+	 * Returns the list of boost parameters, values and labels.
 	 *
 	 * @since 2.5.0
 	 *
@@ -306,7 +306,8 @@ final class Recommended_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Check if both the API key and API secret settings are populated with non-empty values.
+	 * Checks if both the API key and API secret settings are populated with
+	 * non-empty values.
 	 *
 	 * @since 2.5.0
 	 *

--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Recommended Widget class.
+ * UI: Recommended Widget class
  *
  * Provides a widget with Parse.ly recommended articles.
  *

--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -80,7 +80,6 @@ final class Recommended_Widget extends WP_Widget {
 	 *
 	 * @param array $args Widget Arguments.
 	 * @param array $instance Values saved to the db.
-	 * @return void
 	 */
 	public function widget( $args, $instance ): void {
 		if ( ! $this->api_key_and_secret_are_populated() ) {

--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -76,7 +76,7 @@ final class Recommended_Widget extends WP_Widget {
 	}
 
 	/**
-	 * This is the widget function
+	 * This is the widget function.
 	 *
 	 * @param array $args Widget Arguments.
 	 * @param array $instance Values saved to the db.
@@ -146,7 +146,7 @@ final class Recommended_Widget extends WP_Widget {
 	}
 
 	/**
-	 * This is the form function
+	 * This is the form function.
 	 *
 	 * @param array $instance Values saved to the db.
 	 */
@@ -252,7 +252,7 @@ final class Recommended_Widget extends WP_Widget {
 	}
 
 	/**
-	 * This is the update function
+	 * This is the update function.
 	 *
 	 * @param array $new_instance The new values for the db.
 	 * @param array $old_instance Values saved to the db.

--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -46,12 +46,12 @@ final class Recommended_Widget extends WP_Widget {
 	 *
 	 * @param string      $api_key          Publisher Site ID (API key).
 	 * @param int|null    $published_within Publication filter start date; see https://www.parse.ly/help/api/time for
-	 *                                 formatting details. No restriction by default.
-	 * @param string|null $sort             What to sort the results by. There are currently 2 valid options: `score`, which
-	 *                                 will sort articles by overall relevance and `pub_date` which will sort results by
-	 *                                 their publication date. The default is `score`.
+	 *                                      formatting details. No restriction by default.
+	 * @param string|null $sort             What to sort the results by. There are currently 2 valid options: `score`,
+	 *                                      which will sort articles by overall relevance and `pub_date` which will sort
+	 *                                      results by their publication date. The default is `score`.
 	 * @param string|null $boost            Available for sort=score only. Sub-sort value to re-rank relevant posts that
-	 *                                 received high e.g. views; default is undefined.
+	 *                                      received high e.g. views; default is undefined.
 	 * @param int         $return_limit     Number of records to retrieve; defaults to "10".
 	 * @return string API URL.
 	 */
@@ -310,7 +310,8 @@ final class Recommended_Widget extends WP_Widget {
 	 *
 	 * @since 2.5.0
 	 *
-	 * @return bool True if apikey and api_secret settings are not empty strings. False otherwise.
+	 * @return bool True if apikey and api_secret settings are not empty strings.
+	 *              False otherwise.
 	 */
 	private function api_key_and_secret_are_populated(): bool {
 		$options = get_option( 'parsely' );

--- a/src/UI/class-row-actions.php
+++ b/src/UI/class-row-actions.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Row actions class.
+ * UI: Row actions class.
  *
  * @package Parsely
- * @since 2.6.0
+ * @since   2.6.0
  */
 
 declare(strict_types=1);

--- a/src/UI/class-row-actions.php
+++ b/src/UI/class-row-actions.php
@@ -40,8 +40,6 @@ final class Row_Actions {
 	 * Registers action and filter hook callbacks.
 	 *
 	 * @since 2.6.0
-	 *
-	 * @return void
 	 */
 	public function run(): void {
 		/**

--- a/src/UI/class-row-actions.php
+++ b/src/UI/class-row-actions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely row actions class
+ * Row actions class.
  *
  * @package Parsely
  * @since 2.6.0
@@ -15,7 +15,7 @@ use Parsely\Dashboard_Link;
 use WP_Post;
 
 /**
- * Handle the post/page row actions.
+ * Handles the post/page row actions.
  *
  * @since 2.6.0
  */
@@ -37,7 +37,7 @@ final class Row_Actions {
 	}
 
 	/**
-	 * Register action and filter hook callbacks.
+	 * Registers action and filter hook callbacks.
 	 *
 	 * @since 2.6.0
 	 *
@@ -58,9 +58,11 @@ final class Row_Actions {
 	}
 
 	/**
-	 * Include a link to the statistics page for an article in the wp-admin Posts List.
+	 * Includes a link to the statistics page for an article in the wp-admin
+	 * Posts List.
 	 *
-	 * If the post object is the "front page," this will include the main dashboard link instead.
+	 * If the post object is the "front page," this will include the main
+	 * dashboard link instead.
 	 *
 	 * @since 2.6.0
 	 *
@@ -86,7 +88,7 @@ final class Row_Actions {
 	}
 
 	/**
-	 * Generate the HTML link to Parse.ly.
+	 * Generates the HTML link to Parse.ly.
 	 *
 	 * @since 2.6.0
 	 * @since 3.1.2 Added `url` parameter.
@@ -105,7 +107,7 @@ final class Row_Actions {
 	}
 
 	/**
-	 * Generate ARIA label content.
+	 * Generates ARIA label content.
 	 *
 	 * @since 2.6.0
 	 *

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -16,7 +16,7 @@ use WP_Screen;
 use const Parsely\PARSELY_FILE;
 
 /**
- * Renders the wp-admin Parse.ly plugin settings page
+ * Renders the wp-admin Parse.ly plugin settings page.
  *
  * @since 3.0.0
  */
@@ -255,7 +255,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Displays the Parse.ly settings screen ( options-general.php?page=[SLUG] ).
+	 * Displays the Parse.ly settings screen (options-general.php?page=[SLUG]).
 	 */
 	public function display_settings(): void {
 		if ( ! current_user_can( Parsely::CAPABILITY ) ) {
@@ -726,7 +726,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Prints out the radio buttons
+	 * Prints out the radio buttons.
 	 *
 	 * @param array $args The arguments for the radio buttons.
 	 */

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Settings page class.
+ * UI: Settings page class
  *
  * @package Parsely
- * @since 3.0.0
+ * @since   3.0.0
  */
 
 declare(strict_types=1);

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -61,8 +61,6 @@ final class Settings_Page {
 	 * Registers settings page.
 	 *
 	 * @since 3.0.0
-	 *
-	 * @return void
 	 */
 	public function run(): void {
 		add_action( 'admin_menu', array( $this, 'add_settings_sub_menu' ) );
@@ -79,7 +77,6 @@ final class Settings_Page {
 	 * Enqueues all needed scripts and styles for Parse.ly plugin settings page.
 	 *
 	 * @param string $hook_suffix The current page being loaded.
-	 * @return void
 	 */
 	public function enqueue_settings_assets( string $hook_suffix ): void {
 		if ( 'settings_page_parsely' === $hook_suffix ) {
@@ -108,8 +105,6 @@ final class Settings_Page {
 
 	/**
 	 * Adds the Parse.ly settings page in WordPress settings menu.
-	 *
-	 * @return void
 	 */
 	public function add_settings_sub_menu(): void {
 		$suffix = add_options_page(
@@ -159,8 +154,6 @@ final class Settings_Page {
 	 * Registers screen options.
 	 *
 	 * @since 3.2.0
-	 *
-	 * @return void
 	 */
 	public function add_screen_options(): void {
 		add_screen_option(
@@ -261,8 +254,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 
 	/**
 	 * Displays the Parse.ly settings screen ( options-general.php?page=[SLUG] ).
-	 *
-	 * @return void
 	 */
 	public function display_settings(): void {
 		if ( ! current_user_can( Parsely::CAPABILITY ) ) {
@@ -274,8 +265,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 
 	/**
 	 * Initializes the settings for Parse.ly.
-	 *
-	 * @return void
 	 */
 	public function initialize_settings(): void {
 		// All our options are actually stored in one single array to reduce DB queries.
@@ -302,8 +291,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 * Registers section and settings for Basic section.
 	 *
 	 * @since 3.2.0
-	 *
-	 * @return void
 	 */
 	private function initialize_basic_section(): void {
 		add_settings_section(
@@ -437,8 +424,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 * Registers section and settings for Requires Recrawl section.
 	 *
 	 * @since 3.2.0
-	 *
-	 * @return void
 	 */
 	private function initialize_requires_recrawl_section(): void {
 		add_settings_section(
@@ -606,8 +591,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 * Registers section and settings for Advanced section.
 	 *
 	 * @since 3.2.0
-	 *
-	 * @return void
 	 */
 	private function initialize_advanced_section(): void {
 		// These are Advanced Settings.
@@ -654,7 +637,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 * @since 3.1.0
 	 *
 	 * @param array $args The arguments for the form field. May contain 'help_text'.
-	 * @return void
 	 */
 	public function print_description_text( $args ): void {
 		echo isset( $args['help_text'] ) ? '<p class="description" id="' . esc_attr( $args['option_key'] ) . '-description">' . wp_kses_post( $args['help_text'] ) . '</p>' : '';
@@ -664,7 +646,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 * Prints out an input text tag.
 	 *
 	 * @param array $args The arguments for text tag.
-	 * @return void
 	 */
 	public function print_text_tag( array $args ): void {
 		$options       = $this->parsely->get_options();
@@ -694,7 +675,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 * Prints a checkbox tag in the settings page.
 	 *
 	 * @param array $args Arguments to print to checkbox tag.
-	 * @return void
 	 */
 	public function print_checkbox_tag( array $args ): void {
 		$options = $this->parsely->get_options();
@@ -717,7 +697,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 * Prints out the select tags
 	 *
 	 * @param array $args The arguments for the select dropdowns.
-	 * @return void
 	 */
 	public function print_select_tag( array $args ): void {
 		$options        = $this->parsely->get_options();
@@ -748,7 +727,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 * Prints out the radio buttons
 	 *
 	 * @param array $args The arguments for the radio buttons.
-	 * @return void
 	 */
 	public function print_binary_radio_tag( array $args ): void {
 		$options = $this->parsely->get_options();
@@ -778,7 +756,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 * input to store image path and a button to browse for images.
 	 *
 	 * @param array $args The arguments for the control.
-	 * @return void
 	 */
 	public function print_media_single_image( array $args ): void {
 		$key         = $args['option_key'];
@@ -803,7 +780,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 * @since 3.2.0
 	 *
 	 * @param array<string, string> $args The arguments used in the output HTML elements.
-	 * @return void
 	 */
 	public function print_track_post_types_table( array $args ): void {
 		$option_key = esc_attr( $args['option_key'] );
@@ -1132,7 +1108,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 * @since 3.2.0
 	 *
 	 * @param array $input Array passed to validate_options() function.
-	 * @return void
 	 */
 	private function validate_options_post_type_tracking( array &$input ): void {
 		$options         = $this->parsely->get_options();

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -40,7 +40,8 @@ final class Settings_Page {
 	/**
 	 * Screen options name.
 	 *
-	 * Name must end in `_page` so that set-screen-option hook is triggered for WP < 5.4.2.
+	 * Name must end in `_page` so that set-screen-option hook is triggered for
+	 * WP < 5.4.2.
 	 *
 	 * @since 3.2.0
 	 *
@@ -132,7 +133,8 @@ final class Settings_Page {
 	 *
 	 * @since 3.2.0
 	 *
-	 * @param mixed  $screen_option The value to save instead of the option value. Default false (to skip saving the current option).
+	 * @param mixed  $screen_option The value to save instead of the option value.
+	 *                              Default false (to skip saving the current option).
 	 * @param string $option        The option name.
 	 * @param mixed  $value         The option value.
 	 * @return mixed Updated option value.
@@ -752,8 +754,8 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Prints out a "single-image browse control" which includes a text
-	 * input to store image path and a button to browse for images.
+	 * Prints out a "single-image browse control" which includes a text input to
+	 * store image path and a button to browse for images.
 	 *
 	 * @param array $args The arguments for the control.
 	 */

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely settings page class
+ * Settings page class.
  *
  * @package Parsely
  * @since 3.0.0
@@ -16,7 +16,7 @@ use WP_Screen;
 use const Parsely\PARSELY_FILE;
 
 /**
- * Render the wp-admin Parse.ly plugin settings page
+ * Renders the wp-admin Parse.ly plugin settings page
  *
  * @since 3.0.0
  */
@@ -58,7 +58,7 @@ final class Settings_Page {
 	}
 
 	/**
-	 * Register settings page.
+	 * Registers settings page.
 	 *
 	 * @since 3.0.0
 	 *
@@ -76,7 +76,7 @@ final class Settings_Page {
 	}
 
 	/**
-	 * Enqueue all needed scripts and styles for Parse.ly plugin settings page.
+	 * Enqueues all needed scripts and styles for Parse.ly plugin settings page.
 	 *
 	 * @param string $hook_suffix The current page being loaded.
 	 * @return void
@@ -107,7 +107,7 @@ final class Settings_Page {
 	}
 
 	/**
-	 * Parse.ly settings page in WordPress settings menu.
+	 * Adds the Parse.ly settings page in WordPress settings menu.
 	 *
 	 * @return void
 	 */
@@ -131,7 +131,7 @@ final class Settings_Page {
 	}
 
 	/**
-	 * Save the screen option setting.
+	 * Saves the screen option setting.
 	 *
 	 * Nonce is already checked in set_screen_options() - no need to check here.
 	 *
@@ -156,7 +156,7 @@ final class Settings_Page {
 	}
 
 	/**
-	 * Register screen options.
+	 * Registers screen options.
 	 *
 	 * @since 3.2.0
 	 *
@@ -180,7 +180,7 @@ final class Settings_Page {
 	}
 
 	/**
-	 * Render the screen options block.
+	 * Renders the screen options block.
 	 *
 	 * @since 3.2.0
 	 *
@@ -224,7 +224,7 @@ final class Settings_Page {
 	}
 
 	/**
-	 * Add help tab to the settings page.
+	 * Adds the help tab to the settings page.
 	 *
 	 * @since 3.1.0
 	 */
@@ -260,7 +260,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Parse.ly settings screen ( options-general.php?page=[MENU_SLUG] ).
+	 * Displays the Parse.ly settings screen ( options-general.php?page=[SLUG] ).
 	 *
 	 * @return void
 	 */
@@ -273,7 +273,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Initialize the settings for Parsely.
+	 * Initializes the settings for Parse.ly.
 	 *
 	 * @return void
 	 */
@@ -299,7 +299,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Register section and settings for Basic section.
+	 * Registers section and settings for Basic section.
 	 *
 	 * @since 3.2.0
 	 *
@@ -434,7 +434,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Register section and settings for Requires Recrawl section.
+	 * Registers section and settings for Requires Recrawl section.
 	 *
 	 * @since 3.2.0
 	 *
@@ -603,7 +603,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Register section and settings for Advanced section.
+	 * Registers section and settings for Advanced section.
 	 *
 	 * @since 3.2.0
 	 *
@@ -649,7 +649,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Print out the description text, if there is any.
+	 * Prints out the description text, if there is any.
 	 *
 	 * @since 3.1.0
 	 *
@@ -661,7 +661,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Print out an input text tag.
+	 * Prints out an input text tag.
 	 *
 	 * @param array $args The arguments for text tag.
 	 * @return void
@@ -714,7 +714,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Print out the select tags
+	 * Prints out the select tags
 	 *
 	 * @param array $args The arguments for the select dropdowns.
 	 * @return void
@@ -745,7 +745,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Print out the radio buttons
+	 * Prints out the radio buttons
 	 *
 	 * @param array $args The arguments for the radio buttons.
 	 * @return void
@@ -774,7 +774,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Print out a "single-image browse control" which includes a text
+	 * Prints out a "single-image browse control" which includes a text
 	 * input to store image path and a button to browse for images.
 	 *
 	 * @param array $args The arguments for the control.
@@ -798,7 +798,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Print out the post tracking options table.
+	 * Prints out the post tracking options table.
 	 *
 	 * @since 3.2.0
 	 *
@@ -858,7 +858,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Return the custom post type tracking values in a format that is easily
+	 * Returns the custom post type tracking values in a format that is easily
 	 * consumable by the print_track_post_types_table() function.
 	 *
 	 * @since 3.2.0
@@ -1124,7 +1124,9 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Receive the $input array from the validate_options() function and validate post tracking options.
+	 * Receives the $input array from the validate_options() function and
+	 * validate post tracking options.
+	 *
 	 * This function will mutate the $input array.
 	 *
 	 * @since 3.2.0
@@ -1188,7 +1190,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
-	 * Sanitize all elements in an option array.
+	 * Sanitizes all elements in an option array.
 	 *
 	 * @param array $array Array of options to be sanitized.
 	 * @return array

--- a/src/blocks/recommendations/class-recommendations-block.php
+++ b/src/blocks/recommendations/class-recommendations-block.php
@@ -22,8 +22,6 @@ class Recommendations_Block {
 	 * Determines whether the block and its assets should be registered.
 	 *
 	 * @since 3.2.0
-	 *
-	 * @return void
 	 */
 	public function run(): void {
 		global $wp_version;
@@ -41,8 +39,6 @@ class Recommendations_Block {
 	 * WordPress Block Editor in the corresponding context.
 	 *
 	 * @since 3.3.0
-	 *
-	 * @return void
 	 */
 	public static function register_block(): void {
 		/**

--- a/src/blocks/recommendations/class-recommendations-block.php
+++ b/src/blocks/recommendations/class-recommendations-block.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parse.ly Recommendations Block class file.
+ * Parse.ly Recommendations Block class
  *
  * @package Parsely
  * @since 3.2.0

--- a/src/blocks/recommendations/class-recommendations-block.php
+++ b/src/blocks/recommendations/class-recommendations-block.php
@@ -42,9 +42,10 @@ class Recommendations_Block {
 	 */
 	public static function register_block(): void {
 		/**
-		 * Register the block by passing the path to it's block.json file that contains the
-		 * majority of it's definition. This file will be copied into `build/blocks/recommendations`
-		 * by the build process and should be accessed there.
+		 * Register the block by passing the path to it's block.json file that
+		 * contains the majority of it's definition. This file will be copied
+		 * into `build/blocks/recommendations`by the build process and should be
+		 * accessed there.
 		 *
 		 * @see https://developer.wordpress.org/reference/functions/register_block_type/
 		 */
@@ -66,8 +67,8 @@ class Recommendations_Block {
 	 */
 	public static function render_callback( array $attributes ): string {
 		/**
-		 * In block.json we define a `viewScript` that is mean to only be loaded on the front end.
-		 * We need to manually enqueue this script here.
+		 * In block.json we define a `viewScript` that is mean to only be loaded
+		 * on the front end. We need to manually enqueue this script here.
 		 *
 		 * The slug is automatically generated as {namespace}-{block-name}-view-script
 		 */

--- a/src/class-dashboard-link.php
+++ b/src/class-dashboard-link.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Dashboard Link utility class.
+ * Dashboard link utility class
  *
  * @package Parsely
- * @since 3.1.0
+ * @since   3.1.0
  */
 
 declare(strict_types=1);

--- a/src/class-dashboard-link.php
+++ b/src/class-dashboard-link.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parse.ly Dashboard Link utility class.
+ * Dashboard Link utility class.
  *
  * @package Parsely
  * @since 3.1.0
@@ -19,7 +19,8 @@ use WP_Post;
  */
 class Dashboard_Link {
 	/**
-	 * Generate the Parse.ly dashboard URL for the post. Returns an empty string if the URL could not be generated.
+	 * Generates the Parse.ly dashboard URL for the post. Returns an empty
+	 * string if the URL could not be generated.
 	 *
 	 * @since 2.6.0
 	 * @since 3.1.0 Moved to class-dashboard-link.php. Added source parameter.
@@ -49,7 +50,7 @@ class Dashboard_Link {
 	}
 
 	/**
-	 * Determine whether Parse.ly dashboard link should be shown or not.
+	 * Determines whether Parse.ly dashboard link should be shown or not.
 	 *
 	 * @since 2.6.0
 	 * @since 3.1.0 Moved to class-dashboard-link.php. Renamed from `cannot_show_parsely_link`.

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -334,7 +334,7 @@ class Metadata {
 	}
 
 	/**
-	 * Returns the tags associated with this page or post
+	 * Returns the tags associated with this page or post.
 	 *
 	 * @since 3.3.0 Moved to class-metadata
 	 *
@@ -353,7 +353,7 @@ class Metadata {
 	}
 
 	/**
-	 * Returns an array of all the child categories for the current post
+	 * Returns an array of all the child categories for the current post.
 	 *
 	 * @since 3.3.0 Moved to class-metadata
 	 *
@@ -567,7 +567,7 @@ class Metadata {
 
 	/**
 	 * Returns the top-most category/taxonomy value in a hierarcy given a
-	 * taxonomy value's ID
+	 * taxonomy value's ID.
 	 *
 	 * (WordPress calls taxonomy values 'terms').
 	 *
@@ -587,7 +587,7 @@ class Metadata {
 
 	/**
 	 * Returns the bottom-most category/taxonomy value in a hierarchy given a
-	 * post ID
+	 * post ID.
 	 *
 	 * (WordPress calls taxonomy values 'terms').
 	 *

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -456,7 +456,6 @@ class Metadata {
 	 *
 	 * @param array   $metadata Array containing all metadata. It will be potentially mutated to add keys: dateCreated, dateModified, & datePublished.
 	 * @param WP_Post $post     Post object from which to extract time data.
-	 * @return void
 	 */
 	private function set_metadata_post_times( array &$metadata, WP_Post $post ): void {
 		$date_format      = 'Y-m-d\TH:i:s\Z';

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Metadata class
+ * Metadata class.
  *
  * @package Parsely
  * @since 3.3.0
@@ -226,7 +226,7 @@ class Metadata {
 	}
 
 	/**
-	 * Sanitize content
+	 * Sanitizes content.
 	 *
 	 * @since 2.6.0
 	 * @since 3.3.0 Moved to class-metadata
@@ -246,7 +246,7 @@ class Metadata {
 	}
 
 	/**
-	 * Retrieve all the authors for a post as an array. Can include multiple
+	 * Retrieves all the authors for a post as an array. Can include multiple
 	 * authors if coauthors plugin is in use.
 	 *
 	 * @since 3.3.0 Moved to class-metadata
@@ -290,8 +290,9 @@ class Metadata {
 	}
 
 	/**
-	 * Returns a properly cleaned category/taxonomy value and will optionally use the top-level category/taxonomy value
-	 * if so instructed via the `use_top_level_cats` option.
+	 * Returns a properly cleaned category/taxonomy value and will optionally
+	 * use the top-level category/taxonomy value, if so instructed via the
+	 * `use_top_level_cats` option.
 	 *
 	 * @since 3.3.0 Moved to class-metadata
 	 *
@@ -381,7 +382,7 @@ class Metadata {
 	}
 
 	/**
-	 * Get all term values from custom taxonomies.
+	 * Gets all term values from custom taxonomies.
 	 *
 	 * @since 3.3.0 Moved to class-metadata
 	 *
@@ -406,8 +407,9 @@ class Metadata {
 	}
 
 	/**
-	 * Get the URL of the current PHP script.
-	 * A fall-back implementation to determine permalink
+	 * Gets the URL of the current PHP script.
+	 *
+	 * A fall-back implementation to determine permalink.
 	 *
 	 * @since 3.0.0 $parsely_type Default parameter changed to `non-post`.
 	 * @since 3.3.0 Moved to class-metadata
@@ -476,8 +478,10 @@ class Metadata {
 	}
 
 	/**
-	 * Returns a list of coauthors for a post assuming the Co-Authors Plus plugin is
-	 * installed. Borrowed from
+	 * Returns a list of coauthors for a post assuming the Co-Authors Plus plugin
+	 * is installed.
+	 *
+	 * Borrowed from
 	 * https://github.com/Automattic/Co-Authors-Plus/blob/master/template-tags.php#L3-35
 	 *
 	 * @since 3.3.0 Moved to class-metadata
@@ -525,7 +529,7 @@ class Metadata {
 	}
 
 	/**
-	 * Determine author name from display name, falling back to firstname
+	 * Determines author name from display name, falling back to firstname
 	 * lastname, then nickname and finally the nicename.
 	 *
 	 * @since 3.3.0 Moved to class-metadata
@@ -560,8 +564,10 @@ class Metadata {
 	}
 
 	/**
-	 * Return the top-most category/taxonomy value in a hierarcy given a taxonomy value's ID
-	 * ( WordPress calls taxonomy values 'terms' ).
+	 * Returns the top-most category/taxonomy value in a hierarcy given a
+	 * taxonomy value's ID
+	 *
+	 * (WordPress calls taxonomy values 'terms').
 	 *
 	 * @since 3.3.0 Moved to class-metadata
 	 *
@@ -578,8 +584,10 @@ class Metadata {
 	}
 
 	/**
-	 * Return the bottom-most category/taxonomy value in a hierarchy given a post ID
-	 * ( WordPress calls taxonomy values 'terms' ).
+	 * Returns the bottom-most category/taxonomy value in a hierarchy given a
+	 * post ID
+	 *
+	 * (WordPress calls taxonomy values 'terms').
 	 *
 	 * @since 3.3.0 Moved to class-metadata
 	 *

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -414,8 +414,10 @@ class Metadata {
 	 * @since 3.0.0 $parsely_type Default parameter changed to `non-post`.
 	 * @since 3.3.0 Moved to class-metadata
 	 *
-	 * @param string $parsely_type Optional. Parse.ly post type you're interested in, either 'post' or 'non-post'. Default is 'non-post'.
-	 * @param int    $post_id      Optional. ID of the post you want to get the URL for. Default is 0, which means the global `$post` is used.
+	 * @param string $parsely_type Optional. Parse.ly post type you're interested in, either 'post'
+	 *                             or 'non-post'. Default is 'non-post'.
+	 * @param int    $post_id      Optional. ID of the post you want to get the URL for. Default is
+	 *                             0, which means the global `$post` is used.
 	 * @return string
 	 */
 	private function get_current_url( string $parsely_type = 'non-post', int $post_id = 0 ): string {
@@ -428,10 +430,10 @@ class Metadata {
 			 * @since 1.14.0
 			 * @since 2.5.0  Added $post_id.
 			 *
-			 * @param string $permalink         The permalink URL or false if post does not exist.
-			 * @param string $parsely_type      Parse.ly type ("post" or "non-post").
-			 * @param int    $post_id           ID of the post you want to get the URL for. May be 0, so $permalink will be
-			 *                                  for the global $post.
+			 * @param string $permalink    The permalink URL or false if post does not exist.
+			 * @param string $parsely_type Parse.ly type ("post" or "non-post").
+			 * @param int    $post_id      ID of the post you want to get the URL for. May be 0, so
+			 *                             $permalink will be for the global $post.
 			 */
 			$url = apply_filters( 'wp_parsely_permalink', $permalink, $parsely_type, $post_id );
 		} else {
@@ -454,7 +456,8 @@ class Metadata {
 	 * @since 3.0.2
 	 * @since 3.3.0 Moved to class-metadata
 	 *
-	 * @param array   $metadata Array containing all metadata. It will be potentially mutated to add keys: dateCreated, dateModified, & datePublished.
+	 * @param array   $metadata Array containing all metadata. It will be potentially mutated to add
+	 *                          keys: dateCreated, dateModified, & datePublished.
 	 * @param WP_Post $post     Post object from which to extract time data.
 	 */
 	private function set_metadata_post_times( array &$metadata, WP_Post $post ): void {

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Metadata class.
+ * Metadata class
  *
  * @package Parsely
- * @since 3.3.0
+ * @since   3.3.0
  */
 
 declare(strict_types=1);

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Parsely class.
+ * Parsely class
  *
  * @package Parsely
- * @since 2.5.0
+ * @since   2.5.0
  */
 
 declare(strict_types=1);

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parsely class
+ * Parsely class.
  *
  * @package Parsely
  * @since 2.5.0
@@ -90,9 +90,8 @@ class Parsely {
 	);
 
 	/**
-	 * Register action and filter hook callbacks.
-	 *
-	 * Also, immediately upgrade options if needed.
+	 * Registers action and filter hook callbacks, and immediately upgrades
+	 * options if needed.
 	 *
 	 * @return void
 	 */
@@ -130,7 +129,8 @@ class Parsely {
 	}
 
 	/**
-	 * Get the full URL of the JavaScript tracker file for the site. If an API key is not set, return an empty string.
+	 * Gets the full URL of the JavaScript tracker file for the site. If an API
+	 * key is not set, return an empty string.
 	 *
 	 * @since 3.2.0
 	 *
@@ -146,7 +146,8 @@ class Parsely {
 
 	/**
 	 * Deprecated.
-	 * Insert the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
+	 * Inserts the code for the <meta name='parsely-page'> parameter within the
+	 * head tag.
 	 *
 	 * @since 3.2.0
 	 * @deprecated 3.3.0
@@ -163,7 +164,8 @@ class Parsely {
 
 	/**
 	 * Deprecated.
-	 * Insert the code for the <meta name='parsely-page'> parameter within the <head></head> tag.
+	 * Insert the code for the <meta name='parsely-page'> parameter within the
+	 * head tag.
 	 *
 	 * @since 3.0.0
 	 * @deprecated 3.3.0
@@ -179,7 +181,9 @@ class Parsely {
 	}
 
 	/**
-	 * Compare the post_status key against an allowed list (by default, only 'publish'ed content includes tracking data).
+	 * Compares the post_status key against an allowed list.
+	 *
+	 * By default, only 'publish'ed content includes tracking data.
 	 *
 	 * @since 2.5.0
 	 *
@@ -343,9 +347,11 @@ class Parsely {
 	}
 
 	/**
-	 * Safely returns options for the plugin by assigning defaults contained in optionDefaults.  As soon as actual
-	 * options are saved, they override the defaults. This prevents us from having to do a lot of isset() checking
-	 * on variables.
+	 * Safely returns options for the plugin by assigning defaults contained in
+	 * optionDefaults.
+	 *
+	 * As soon as actual options are saved, they override the defaults. This
+	 * prevents us from having to do a lot of isset() checking on variables.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -360,7 +366,7 @@ class Parsely {
 	}
 
 	/**
-	 * Get the URL of the plugin settings page.
+	 * Gets the URL of the plugin's settings page.
 	 *
 	 * @param int|null $_blog_id The Blog ID for the multisite subsite to use for context (Default null for current).
 	 *
@@ -371,7 +377,7 @@ class Parsely {
 	}
 
 	/**
-	 * Check to see if parsely user is logged in.
+	 * Checks to see if Parse.ly user is logged in.
 	 *
 	 * @return bool
 	 */
@@ -383,10 +389,11 @@ class Parsely {
 	}
 
 	/**
-	 * Convert JSON-LD type to respective Parse.ly page type.
+	 * Converts JSON-LD type to respective Parse.ly page type.
 	 *
-	 * If the JSON-LD type is one of the types Parse.ly supports as a "post", then "post" will be returned.
-	 * Otherwise, for "non-posts" and unknown types, "index" is returned.
+	 * If the JSON-LD type is one of the types Parse.ly supports as a "post",
+	 * then "post" will be returned. Otherwise, for "non-posts" and unknown
+	 * types, "index" is returned.
 	 *
 	 * @since 2.5.0
 	 *
@@ -400,7 +407,7 @@ class Parsely {
 	}
 
 	/**
-	 * Determine if an API key is saved in the options.
+	 * Determines if an API key is saved in the options.
 	 *
 	 * @since 2.6.0
 	 *
@@ -417,7 +424,7 @@ class Parsely {
 	}
 
 	/**
-	 * Determine if an API key is not saved in the options.
+	 * Determines if an API key is not saved in the options.
 	 *
 	 * @since 2.6.0
 	 *
@@ -428,7 +435,7 @@ class Parsely {
 	}
 
 	/**
-	 * Get the API key if set.
+	 * Gets the API key if set.
 	 *
 	 * @since 2.6.0
 	 *

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -24,9 +24,9 @@ class Parsely {
 	 * Declare our constants
 	 */
 	public const VERSION     = PARSELY_VERSION;
-	public const MENU_SLUG   = 'parsely';             // Defines the page param passed to options-general.php.
-	public const OPTIONS_KEY = 'parsely';             // Defines the key used to store options in the WP database.
-	public const CAPABILITY  = 'manage_options';      // The capability required for the user to administer settings.
+	public const MENU_SLUG   = 'parsely';        // Defines the page param passed to options-general.php.
+	public const OPTIONS_KEY = 'parsely';        // Defines the key used to store options in the WP database.
+	public const CAPABILITY  = 'manage_options'; // The capability required for the user to administer settings.
 
 	/**
 	 * Declare some class properties
@@ -183,7 +183,8 @@ class Parsely {
 	 * @since 2.5.0
 	 *
 	 * @param int|WP_Post $post Which post object or ID to check.
-	 * @return bool Should the post status be tracked for the provided post's post_type. By default, only 'publish' is allowed.
+	 * @return bool Should the post status be tracked for the provided post's post_type.
+	 *              By default,only 'publish' is allowed.
 	 */
 	public static function post_has_trackable_status( $post ): bool {
 		static $cache = array();
@@ -193,7 +194,8 @@ class Parsely {
 		}
 
 		/**
-		 * Filters whether the post password check should be skipped when getting the post trackable status.
+		 * Filters whether the post password check should be skipped when getting
+		 * the post trackable status.
 		 *
 		 * @since 3.0.1
 		 *
@@ -211,7 +213,8 @@ class Parsely {
 		/**
 		 * Filters the statuses that are permitted to be tracked.
 		 *
-		 * By default, the only status tracked is 'publish'. Use this filter if you have other published content that has a different (custom) status.
+		 * By default, the only status tracked is 'publish'. Use this filter if
+		 * you have other published content that has a different (custom) status.
 		 *
 		 * @since 2.5.0
 		 *
@@ -360,7 +363,8 @@ class Parsely {
 	/**
 	 * Gets the URL of the plugin's settings page.
 	 *
-	 * @param int|null $_blog_id The Blog ID for the multisite subsite to use for context (Default null for current).
+	 * @param int|null $_blog_id The Blog ID for the multisite subsite to use
+	 *                           for context (Default null for current).
 	 *
 	 * @return string
 	 */

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -92,8 +92,6 @@ class Parsely {
 	/**
 	 * Registers action and filter hook callbacks, and immediately upgrades
 	 * options if needed.
-	 *
-	 * @return void
 	 */
 	public function run(): void {
 		// Run upgrade options if they exist for the version currently defined.
@@ -154,7 +152,6 @@ class Parsely {
 	 * @see Metadata_Renderer::render_metadata
 	 *
 	 * @param string $meta_type `json_ld` or `repeated_metas`.
-	 * @return void
 	 */
 	public function render_metadata( string $meta_type ): void {
 		_deprecated_function( __FUNCTION__, '3.3', 'Metadata_Renderer::render_metadata()' );
@@ -170,8 +167,6 @@ class Parsely {
 	 * @since 3.0.0
 	 * @deprecated 3.3.0
 	 * @see Metadata_Renderer::render_metadata
-	 *
-	 * @return void
 	 */
 	public function insert_page_header_metadata(): void {
 		_deprecated_function( __FUNCTION__, '3.3', 'Metadata_Renderer::render_metadata()' );
@@ -249,7 +244,6 @@ class Parsely {
 	 * Updates the Parsely metadata endpoint with the new metadata of the post.
 	 *
 	 * @param int $post_id id of the post to update.
-	 * @return void
 	 */
 	public function update_metadata_endpoint( int $post_id ): void {
 		$parsely_options = $this->get_options();
@@ -306,8 +300,6 @@ class Parsely {
 
 	/**
 	 * Updates posts with Parsely metadata api in bulk.
-	 *
-	 * @return void
 	 */
 	public function bulk_update_posts(): void {
 		global $wpdb;

--- a/src/class-scripts.php
+++ b/src/class-scripts.php
@@ -37,8 +37,6 @@ class Scripts {
 	 * Registers scripts.
 	 *
 	 * @since 3.0.0
-	 *
-	 * @return void
 	 */
 	public function run(): void {
 		$parsely_options = $this->parsely->get_options();
@@ -53,8 +51,6 @@ class Scripts {
 	 *
 	 * @since 2.5.0
 	 * @since 3.0.0 Rename from register_js
-	 *
-	 * @return void
 	 */
 	public function register_scripts(): void {
 		wp_register_script(
@@ -80,8 +76,6 @@ class Scripts {
 	 *
 	 * @since 2.5.0 Rename from insert_parsely_javascript
 	 * @since 3.0.0 Rename from load_js_tracker
-	 *
-	 * @return void
 	 */
 	public function enqueue_js_tracker(): void {
 		$parsely_options = $this->parsely->get_options();

--- a/src/class-scripts.php
+++ b/src/class-scripts.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace Parsely;
 
 /**
- * Inserts the scripts and tracking code into the site's front-end
+ * Inserts the scripts and tracking code into the site's front-end.
  *
  * @since 1.0.0
  * @since 3.0.0 Moved from class-parsely to separate file

--- a/src/class-scripts.php
+++ b/src/class-scripts.php
@@ -34,7 +34,7 @@ class Scripts {
 	}
 
 	/**
-	 * Register js scripts.
+	 * Registers scripts.
 	 *
 	 * @since 3.0.0
 	 *
@@ -49,7 +49,7 @@ class Scripts {
 	}
 
 	/**
-	 * Register JavaScripts, if there's an API key value saved.
+	 * Registers scripts, if there's an API key value saved.
 	 *
 	 * @since 2.5.0
 	 * @since 3.0.0 Rename from register_js
@@ -132,7 +132,7 @@ class Scripts {
 	}
 
 	/**
-	 * Filter the script tag for certain scripts to add needed attributes.
+	 * Filters the script tag for certain scripts to add needed attributes.
 	 *
 	 * @since 2.5.0
 	 *

--- a/src/class-scripts.php
+++ b/src/class-scripts.php
@@ -3,7 +3,7 @@
  * Scripts class
  *
  * @package Parsely
- * @since 3.0.0
+ * @since   3.0.0
  */
 
 declare(strict_types=1);

--- a/tests/Integration/Blocks/RecommendationsBlockTest.php
+++ b/tests/Integration/Blocks/RecommendationsBlockTest.php
@@ -2,7 +2,7 @@
 /**
  * Parse.ly Recommendations Block tests.
  *
- * @package Parsely\Tests\Blocks
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);

--- a/tests/Integration/DashboardLinkTest.php
+++ b/tests/Integration/DashboardLinkTest.php
@@ -2,7 +2,7 @@
 /**
  * Tests of the Dashboard Link class
  *
- * @package Parsely\Tests\Unit
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);

--- a/tests/Integration/Integrations/AmpTest.php
+++ b/tests/Integration/Integrations/AmpTest.php
@@ -2,7 +2,7 @@
 /**
  * AMP integration tests.
  *
- * @package Parsely\Tests\Integrations
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);

--- a/tests/Integration/Integrations/FacebookInstantArticlesTest.php
+++ b/tests/Integration/Integrations/FacebookInstantArticlesTest.php
@@ -2,7 +2,7 @@
 /**
  * Facebook Instant Articles integration tests.
  *
- * @package Parsely\Tests\Integrations
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);

--- a/tests/Integration/Integrations/GoogleWebStoriesTest.php
+++ b/tests/Integration/Integrations/GoogleWebStoriesTest.php
@@ -2,7 +2,7 @@
 /**
  * Google Web Stories integration tests.
  *
- * @package Parsely\Tests\Integrations
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);

--- a/tests/Integration/Integrations/IntegrationsTest.php
+++ b/tests/Integration/Integrations/IntegrationsTest.php
@@ -2,7 +2,7 @@
 /**
  * Integrations collection tests.
  *
- * @package Parsely\Tests\Integrations
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);
@@ -68,8 +68,6 @@ final class IntegrationsTest extends TestCase {
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 /**
  * Class FakeIntegration2
- *
- * @package Parsely\Tests\Integrations
  */
 class FakeIntegration2 {
 	/**

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -2,7 +2,7 @@
 /**
  * Class SampleTest
  *
- * @package WordPress
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);

--- a/tests/Integration/RemoteAPI/RelatedRemoteAPITest.php
+++ b/tests/Integration/RemoteAPI/RelatedRemoteAPITest.php
@@ -13,7 +13,6 @@ use Parsely\Parsely;
 use Parsely\RemoteAPI\Cache;
 use Parsely\RemoteAPI\Cached_Proxy;
 use Parsely\RemoteAPI\Related_Proxy;
-use WP_Error;
 
 /**
  * Parsely `/related` Remote API tests.

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -3,7 +3,6 @@
  * Base unit test case
  *
  * @package Parsely\Tests
- * @license GPL-2.0-or-later
  */
 
 declare(strict_types=1);

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -15,8 +15,6 @@ use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;
 
 /**
  * Abstract base class for all test case implementations.
- *
- * @package Parsely\Tests
  */
 abstract class TestCase extends WPIntegrationTestCase {
 

--- a/tests/Integration/UI/AdminBarTest.php
+++ b/tests/Integration/UI/AdminBarTest.php
@@ -2,7 +2,7 @@
 /**
  * Admin bar tests.
  *
- * @package Parsely
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);

--- a/tests/Integration/UI/AdminWarningTest.php
+++ b/tests/Integration/UI/AdminWarningTest.php
@@ -2,7 +2,7 @@
 /**
  * Admin page warning tests.
  *
- * @package Parsely
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);

--- a/tests/Integration/UI/NetworkAdminSitesListTest.php
+++ b/tests/Integration/UI/NetworkAdminSitesListTest.php
@@ -2,7 +2,7 @@
 /**
  * UI Tests for the Network Admin Sites List.
  *
- * @package Parsely
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);

--- a/tests/Integration/UI/RowActionsTest.php
+++ b/tests/Integration/UI/RowActionsTest.php
@@ -2,7 +2,7 @@
 /**
  * Row actions tests.
  *
- * @package Parsely
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);

--- a/tests/Integration/UI/SettingsPageTest.php
+++ b/tests/Integration/UI/SettingsPageTest.php
@@ -2,7 +2,7 @@
 /**
  * Settings page tests.
  *
- * @package Parsely
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * PHPUnit bootstrap file
  *
- * @package Parsely
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Integrations/IntegrationsTest.php
+++ b/tests/Unit/Integrations/IntegrationsTest.php
@@ -2,7 +2,7 @@
 /**
  * Integrations collection tests.
  *
- * @package Parsely\Tests\Unit
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);
@@ -71,16 +71,12 @@ final class IntegrationsTest extends TestCase {
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 /**
  * Class FakeIntegration
- *
- * @package Parsely\Tests\Unit
  */
 class FakeIntegration {
 }
 
 /**
  * Class FakeIntegration2
- *
- * @package Parsely\Tests\Unit
  */
 class FakeIntegration2 {
 	/**

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * PHPUnit bootstrap file.
  *
- * @package Parsely
+ * @package Parsely\Tests
  */
 
 declare(strict_types=1);

--- a/tests/trait-tests-reflection.php
+++ b/tests/trait-tests-reflection.php
@@ -3,7 +3,6 @@
  * Contains reflection functions used by tests.
  *
  * @package Parsely\Tests
- * @license GPL-2.0-or-later
  */
 
 declare(strict_types=1);

--- a/uninstall.php
+++ b/uninstall.php
@@ -3,8 +3,8 @@
  * Uninstalls script for wp-parsely. It deletes the `parsely` option on the
  * database.
  *
- * @package      Parsely\wp-parsely
- * @since 3.0.0
+ * @package Parsely\wp-parsely
+ * @since   3.0.0
  */
 
 declare(strict_types=1);

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * Uninstalls script for wp-parsely. It deletes the `parsely` option on the
- * database.
+ * Parse.ly plugin uninstaller
+ *
+ * Deletes the `parsely` option from the database.
  *
  * @package Parsely\wp-parsely
  * @since   3.0.0

--- a/uninstall.php
+++ b/uninstall.php
@@ -4,7 +4,7 @@
  *
  * Deletes the `parsely` option from the database.
  *
- * @package Parsely\wp-parsely
+ * @package Parsely
  * @since   3.0.0
  */
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * Uninstall script for wp-parsely. It deletes the `parsely` option on the database.
+ * Uninstalls script for wp-parsely. It deletes the `parsely` option on the
+ * database.
  *
  * @package      Parsely\wp-parsely
  * @since 3.0.0

--- a/views/custom-metadata.php
+++ b/views/custom-metadata.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Parse.ly custom metadata output
+ * Parse.ly custom metadata output.
  *
- * @package      Parsely\wp-parsely
- * @author       Parse.ly
- * @copyright    2012 Parse.ly
- * @license      GPL-2.0-or-later
+ * @package   Parsely\wp-parsely
+ * @author    Parse.ly
+ * @copyright 2012 Parse.ly
+ * @license   GPL-2.0-or-later
  */
 
 declare(strict_types=1);

--- a/views/custom-metadata.php
+++ b/views/custom-metadata.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parse.ly custom metadata output.
+ * Views: Parse.ly custom metadata output
  *
  * @package   Parsely\wp-parsely
  * @author    Parse.ly

--- a/views/custom-metadata.php
+++ b/views/custom-metadata.php
@@ -3,7 +3,6 @@
  * Views: Parse.ly custom metadata output
  *
  * @package   Parsely\wp-parsely
- * @copyright 2012 Parse.ly
  * @license   GPL-2.0-or-later
  */
 

--- a/views/custom-metadata.php
+++ b/views/custom-metadata.php
@@ -2,7 +2,7 @@
 /**
  * Views: Parse.ly custom metadata output
  *
- * @package Parsely\wp-parsely
+ * @package Parsely
  */
 
 declare(strict_types=1);

--- a/views/custom-metadata.php
+++ b/views/custom-metadata.php
@@ -3,7 +3,6 @@
  * Views: Parse.ly custom metadata output
  *
  * @package   Parsely\wp-parsely
- * @author    Parse.ly
  * @copyright 2012 Parse.ly
  * @license   GPL-2.0-or-later
  */

--- a/views/custom-metadata.php
+++ b/views/custom-metadata.php
@@ -2,8 +2,7 @@
 /**
  * Views: Parse.ly custom metadata output
  *
- * @package   Parsely\wp-parsely
- * @license   GPL-2.0-or-later
+ * @package Parsely\wp-parsely
  */
 
 declare(strict_types=1);

--- a/views/json-ld.php
+++ b/views/json-ld.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Parse.ly JSON-LD output
+ * Parse.ly JSON-LD output.
  *
- * @package      Parsely\wp-parsely
- * @author       Parse.ly
- * @copyright    2012 Parse.ly
- * @license      GPL-2.0-or-later
+ * @package   Parsely\wp-parsely
+ * @author    Parse.ly
+ * @copyright 2012 Parse.ly
+ * @license   GPL-2.0-or-later
  */
 
 declare(strict_types=1);

--- a/views/json-ld.php
+++ b/views/json-ld.php
@@ -3,7 +3,6 @@
  * Views: Parse.ly JSON-LD output
  *
  * @package   Parsely\wp-parsely
- * @copyright 2012 Parse.ly
  * @license   GPL-2.0-or-later
  */
 

--- a/views/json-ld.php
+++ b/views/json-ld.php
@@ -2,7 +2,7 @@
 /**
  * Views: Parse.ly JSON-LD output
  *
- * @package Parsely\wp-parsely
+ * @package Parsely
  */
 
 declare(strict_types=1);

--- a/views/json-ld.php
+++ b/views/json-ld.php
@@ -2,8 +2,7 @@
 /**
  * Views: Parse.ly JSON-LD output
  *
- * @package   Parsely\wp-parsely
- * @license   GPL-2.0-or-later
+ * @package Parsely\wp-parsely
  */
 
 declare(strict_types=1);

--- a/views/json-ld.php
+++ b/views/json-ld.php
@@ -3,7 +3,6 @@
  * Views: Parse.ly JSON-LD output
  *
  * @package   Parsely\wp-parsely
- * @author    Parse.ly
  * @copyright 2012 Parse.ly
  * @license   GPL-2.0-or-later
  */

--- a/views/json-ld.php
+++ b/views/json-ld.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parse.ly JSON-LD output.
+ * Views: Parse.ly JSON-LD output
  *
  * @package   Parsely\wp-parsely
  * @author    Parse.ly

--- a/views/parsely-settings.php
+++ b/views/parsely-settings.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Settings file.
+ * Views: Plugin settings view
  *
- * Create the settings page for parse.ly.
+ * Shows the settings page.
  *
  * @package   Parsely\wp-parsely
  * @author    Parse.ly

--- a/views/parsely-settings.php
+++ b/views/parsely-settings.php
@@ -4,7 +4,7 @@
  *
  * Shows the settings page.
  *
- * @package Parsely\wp-parsely
+ * @package Parsely
  */
 
 declare(strict_types=1);

--- a/views/parsely-settings.php
+++ b/views/parsely-settings.php
@@ -5,7 +5,6 @@
  * Shows the settings page.
  *
  * @package   Parsely\wp-parsely
- * @author    Parse.ly
  * @copyright 2012 Parse.ly
  * @license   GPL-2.0-or-later
  */

--- a/views/parsely-settings.php
+++ b/views/parsely-settings.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Settings file
+ * Settings file.
  *
- * Create the settings page for parse.ly
+ * Create the settings page for parse.ly.
  *
- * @package      Parsely\wp-parsely
- * @author       Parse.ly
- * @copyright    2012 Parse.ly
- * @license      GPL-2.0-or-later
+ * @package   Parsely\wp-parsely
+ * @author    Parse.ly
+ * @copyright 2012 Parse.ly
+ * @license   GPL-2.0-or-later
  */
 
 declare(strict_types=1);

--- a/views/parsely-settings.php
+++ b/views/parsely-settings.php
@@ -5,7 +5,6 @@
  * Shows the settings page.
  *
  * @package   Parsely\wp-parsely
- * @copyright 2012 Parse.ly
  * @license   GPL-2.0-or-later
  */
 

--- a/views/parsely-settings.php
+++ b/views/parsely-settings.php
@@ -4,8 +4,7 @@
  *
  * Shows the settings page.
  *
- * @package   Parsely\wp-parsely
- * @license   GPL-2.0-or-later
+ * @package Parsely\wp-parsely
  */
 
 declare(strict_types=1);

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Parse.ly repeated meta elements output
+ * Parse.ly repeated meta elements output.
  *
- * @package      Parsely\wp-parsely
- * @author       Parse.ly
- * @copyright    2012 Parse.ly
- * @license      GPL-2.0-or-later
+ * @package   Parsely\wp-parsely
+ * @author    Parse.ly
+ * @copyright 2012 Parse.ly
+ * @license   GPL-2.0-or-later
  */
 
 declare(strict_types=1);

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -2,8 +2,7 @@
 /**
  * Views: Parse.ly repeated metas output
  *
- * @package   Parsely\wp-parsely
- * @license   GPL-2.0-or-later
+ * @package Parsely\wp-parsely
  */
 
 declare(strict_types=1);

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -2,7 +2,7 @@
 /**
  * Views: Parse.ly repeated metas output
  *
- * @package Parsely\wp-parsely
+ * @package Parsely
  */
 
 declare(strict_types=1);

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -3,7 +3,6 @@
  * Views: Parse.ly repeated metas output
  *
  * @package   Parsely\wp-parsely
- * @author    Parse.ly
  * @copyright 2012 Parse.ly
  * @license   GPL-2.0-or-later
  */

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Parse.ly repeated meta elements output.
+ * Views: Parse.ly repeated metas output
  *
  * @package   Parsely\wp-parsely
  * @author    Parse.ly

--- a/views/repeated-metas.php
+++ b/views/repeated-metas.php
@@ -3,7 +3,6 @@
  * Views: Parse.ly repeated metas output
  *
  * @package   Parsely\wp-parsely
- * @copyright 2012 Parse.ly
  * @license   GPL-2.0-or-later
  */
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -63,7 +63,7 @@ require __DIR__ . '/src/Endpoints/class-graphql-metadata.php';
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\parsely_initialize_plugin' );
 /**
- * Register the basic classes to initialize the plugin.
+ * Registers the basic classes to initialize the plugin.
  *
  * @return void
  */
@@ -92,7 +92,7 @@ require __DIR__ . '/src/UI/class-row-actions.php';
 
 add_action( 'admin_init', __NAMESPACE__ . '\\parsely_admin_init_register' );
 /**
- * Register the Parse.ly wp-admin warnings, plugin actions and row actions.
+ * Registers the Parse.ly wp-admin warnings, plugin actions and row actions.
  *
  * @return void
  */
@@ -112,7 +112,8 @@ require __DIR__ . '/src/UI/class-network-admin-sites-list.php';
 
 add_action( 'init', __NAMESPACE__ . '\\parsely_wp_admin_early_register' );
 /**
- * Register the additions the Parse.ly wp-admin settings page and Multisite Network Admin Sites List table.
+ * Registers the additions the Parse.ly wp-admin settings page and Multisite
+ * Network Admin Sites List table.
  *
  * @return void
  */
@@ -135,7 +136,7 @@ require __DIR__ . '/src/Endpoints/class-rest-metadata.php';
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\\parsely_rest_api_init' );
 /**
- * Register REST Endpoints that act as a proxy to the Parse.ly API.
+ * Registers REST Endpoints that act as a proxy to the Parse.ly API.
  * This is needed to get around a CORS issues with Firefox.
  *
  * @since 3.2.0
@@ -156,7 +157,7 @@ require __DIR__ . '/src/blocks/recommendations/class-recommendations-block.php';
 
 add_action( 'init', __NAMESPACE__ . '\\init_recommendations_block' );
 /**
- * Register the Recommendations Block.
+ * Registers the Recommendations Block.
  *
  * @return void
  */
@@ -169,7 +170,7 @@ require __DIR__ . '/src/UI/class-recommended-widget.php';
 
 add_action( 'widgets_init', __NAMESPACE__ . '\\parsely_recommended_widget_register' );
 /**
- * Register the Parse.ly Recommended widget.
+ * Registers the Parse.ly Recommended widget.
  *
  * @return void
  */
@@ -185,7 +186,7 @@ require __DIR__ . '/src/Integrations/class-google-web-stories.php';
 
 add_action( 'init', __NAMESPACE__ . '\\parsely_integrations' );
 /**
- * Instantiate Integrations collection and register built-in integrations.
+ * Instantiates Integrations collection and registers built-in integrations.
  *
  * @since 2.6.0
  *

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -5,7 +5,6 @@
  * Requires any necessary files and loads the plugin.
  *
  * @package   Parsely\wp-parsely
- * @author    Parse.ly
  * @copyright 2012 Parse.ly
  * @license   GPL-2.0-or-later
  *

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -4,7 +4,7 @@
  *
  * Requires any necessary files and loads the plugin.
  *
- * @package Parsely\wp-parsely
+ * @package Parsely
  *
  * @wordpress-plugin
  * Plugin Name:       Parse.ly

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Parse.ly
+ * Parse.ly plugin loader
+ *
+ * Requires any necessary files and loads the plugin.
  *
  * @package   Parsely\wp-parsely
  * @author    Parse.ly

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -64,8 +64,6 @@ require __DIR__ . '/src/Endpoints/class-graphql-metadata.php';
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\parsely_initialize_plugin' );
 /**
  * Registers the basic classes to initialize the plugin.
- *
- * @return void
  */
 function parsely_initialize_plugin(): void {
 	$GLOBALS['parsely'] = new Parsely();
@@ -93,8 +91,6 @@ require __DIR__ . '/src/UI/class-row-actions.php';
 add_action( 'admin_init', __NAMESPACE__ . '\\parsely_admin_init_register' );
 /**
  * Registers the Parse.ly wp-admin warnings, plugin actions and row actions.
- *
- * @return void
  */
 function parsely_admin_init_register(): void {
 	$admin_warning = new Admin_Warning( $GLOBALS['parsely'] );
@@ -114,8 +110,6 @@ add_action( 'init', __NAMESPACE__ . '\\parsely_wp_admin_early_register' );
 /**
  * Registers the additions the Parse.ly wp-admin settings page and Multisite
  * Network Admin Sites List table.
- *
- * @return void
  */
 function parsely_wp_admin_early_register(): void {
 	$settings_page = new Settings_Page( $GLOBALS['parsely'] );
@@ -140,8 +134,6 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\\parsely_rest_api_init' );
  * This is needed to get around a CORS issues with Firefox.
  *
  * @since 3.2.0
- *
- * @return void
  */
 function parsely_rest_api_init(): void {
 	$rest = new Rest_Metadata( $GLOBALS['parsely'] );
@@ -158,8 +150,6 @@ require __DIR__ . '/src/blocks/recommendations/class-recommendations-block.php';
 add_action( 'init', __NAMESPACE__ . '\\init_recommendations_block' );
 /**
  * Registers the Recommendations Block.
- *
- * @return void
  */
 function init_recommendations_block(): void {
 	$recommendations_block = new Recommendations_Block();
@@ -171,8 +161,6 @@ require __DIR__ . '/src/UI/class-recommended-widget.php';
 add_action( 'widgets_init', __NAMESPACE__ . '\\parsely_recommended_widget_register' );
 /**
  * Registers the Parse.ly Recommended widget.
- *
- * @return void
  */
 function parsely_recommended_widget_register(): void {
 	register_widget( Recommended_Widget::class );

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -5,7 +5,6 @@
  * Requires any necessary files and loads the plugin.
  *
  * @package   Parsely\wp-parsely
- * @copyright 2012 Parse.ly
  * @license   GPL-2.0-or-later
  *
  * @wordpress-plugin

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -4,8 +4,7 @@
  *
  * Requires any necessary files and loads the plugin.
  *
- * @package   Parsely\wp-parsely
- * @license   GPL-2.0-or-later
+ * @package Parsely\wp-parsely
  *
  * @wordpress-plugin
  * Plugin Name:       Parse.ly

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -2,10 +2,10 @@
 /**
  * Parse.ly
  *
- * @package      Parsely\wp-parsely
- * @author       Parse.ly
- * @copyright    2012 Parse.ly
- * @license      GPL-2.0-or-later
+ * @package   Parsely\wp-parsely
+ * @author    Parse.ly
+ * @copyright 2012 Parse.ly
+ * @license   GPL-2.0-or-later
  *
  * @wordpress-plugin
  * Plugin Name:       Parse.ly

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -1,10 +1,11 @@
 <?php
 /**
- * Parse.ly plugin loader
+ * Parse.ly
  *
- * Requires any necessary files and loads the plugin.
- *
- * @package Parsely
+ * @package   Parsely
+ * @author    Parse.ly
+ * @copyright 2012 Parse.ly
+ * @license   GPL-2.0-or-later
  *
  * @wordpress-plugin
  * Plugin Name:       Parse.ly


### PR DESCRIPTION
## Description
As described in #730, many of our comments do not conform to the [Inline Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/). This PR is an attempt to quickly skim through the codebase and correct the most obvious comment issues.

Please note that:
- This is not a comment rewriting PR, where comments are rewritten to be better or provide more context.
- Changes to function comments that are in tests were avoided in order to avoid clashes with #837. Another PR will be made for tests.
- Minimal effort has been put in parts of the code that are deprecated or will be removed in version 4.0.0 of the plugin (Recommended Widget and some deprecated functions).

## Motivation and Context
- Solve as many comment issues as fast as possible.
- Related to #730.
- Related PRs for tests and JS will come in the future.

## How Has This Been Tested?
No code changes, automated tests pass.