### PR TITLE
Fixing disable autotrack issues

### DIFF
--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -933,12 +933,14 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 			$input['disable_javascript'] = 'true' === $input['disable_javascript'];
 		}
 
-		if ( 'true' !== $input['disable_autotrack'] && 'false' !== $input['disable_autotrack'] ) {
-			add_settings_error(
-				Parsely::OPTIONS_KEY,
-				'disable_autotrack',
-				__( 'Value passed for disable_autotrack must be either "Yes" or "No".', 'wp-parsely' )
-			);
+		if ( ! isset( $input['disable_autotrack'] ) ) {
+			$input['disable_autotrack'] = $options['disable_autotrack'];
+		} elseif ( 'true' !== $input['disable_autotrack'] && 'false' !== $input['disable_autotrack'] ) {
+				add_settings_error(
+					Parsely::OPTIONS_KEY,
+					'disable_autotrack',
+					__( 'Value passed for disable_autotrack must be either "Yes" or "No".', 'wp-parsely' )
+				);
 		} else {
 			$input['disable_autotrack'] = 'true' === $input['disable_autotrack'];
 		}

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -936,11 +936,11 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 		if ( ! isset( $input['disable_autotrack'] ) ) {
 			$input['disable_autotrack'] = $options['disable_autotrack'];
 		} elseif ( 'true' !== $input['disable_autotrack'] && 'false' !== $input['disable_autotrack'] ) {
-				add_settings_error(
-					Parsely::OPTIONS_KEY,
-					'disable_autotrack',
-					__( 'Value passed for disable_autotrack must be either "Yes" or "No".', 'wp-parsely' )
-				);
+			add_settings_error(
+				Parsely::OPTIONS_KEY,
+				'disable_autotrack',
+				__( 'Value passed for disable_autotrack must be either "Yes" or "No".', 'wp-parsely' )
+			);
 		} else {
 			$input['disable_autotrack'] = 'true' === $input['disable_autotrack'];
 		}

--- a/tests/Integration/UI/SettingsPageTest.php
+++ b/tests/Integration/UI/SettingsPageTest.php
@@ -139,7 +139,7 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Verify that trying to save tracking settings with an non-array value fails.
+	 * Verify that trying to save tracking settings with a non-array value fails.
 	 *
 	 * @since 3.2.0
 	 *
@@ -156,6 +156,25 @@ final class SettingsPageTest extends TestCase {
 
 		$options['track_post_types_as'] = 'string';
 		$actual                         = self::$settings_page->validate_options( $options );
+		self::assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Verify that trying to save tracking settings without autotrack value pulls default.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @covers \Parsely\UI\Settings_Page::__construct
+	 * @covers \Parsely\UI\Settings_Page::validate_options
+	 * @uses \Parsely\Parsely::get_options
+	 * @group ui
+	 */
+	public function test_saving_disable_autotrack_works_default_value(): void {
+		$expected = self::$parsely->get_options();
+		$options  = self::$parsely->get_options();
+
+		unset( $options['disable_autotrack'] );
+		$actual = self::$settings_page->validate_options( $options );
 		self::assertSame( $expected, $actual );
 	}
 

--- a/tests/Integration/UI/SettingsPageTest.php
+++ b/tests/Integration/UI/SettingsPageTest.php
@@ -166,6 +166,8 @@ final class SettingsPageTest extends TestCase {
 	 *
 	 * @covers \Parsely\UI\Settings_Page::__construct
 	 * @covers \Parsely\UI\Settings_Page::validate_options
+	 * @covers \Parsely\UI\Settings_Page::get_logo_default
+	 * @covers \Parsely\UI\Settings_Page::validate_options_post_type_tracking
 	 * @uses \Parsely\Parsely::get_options
 	 * @group ui
 	 */


### PR DESCRIPTION
## Description

This PR prevents an issue where a warning regarding autotracking could be triggered when updating the user was setting the plugin in an empty installation with the autotracking setting hidden. The issue did not affect autotracking.

We are now using the same technique we use in other hidden fields, and use the default option if `disable_autotrack` is not set.

## Motivation and Context

Prevent user warnings.

## How Has This Been Tested?

Destroy your current local install, by `npm run dev-env -- destroy`. Then recreate it and try to save settings. You will see the warning. Check out this branch and see that you can do the above normally.