### PR TITLE
Preparation for release 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.3.0] - 2022-05-06
+## [3.3.1] - 2022-05-06
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2022-05-06
+
+### Fixed
+
+- Saving settings on a new installation would show a warning on wp-admin. [#845](https://github.com/Parsely/wp-parsely/pull/845)
+- Risky JSON-LD metadata views. [#842](https://github.com/Parsely/wp-parsely/pull/842)
+
+### Removed
+
+- Remove Recommendations Block README. [#844](https://github.com/Parsely/wp-parsely/pull/844)
+
 ## [3.3.0] - 2022-05-02
 
 ### Added
@@ -664,6 +675,7 @@ If you are using the plugin without any code-level customizations (for instance,
 - Initial version.
 - Add support for parsely-page and JavaScript on home page and published pages and posts as well as archive pages (date/author/category/tag).
 
+[3.3.1]: https://github.com/Parsely/wp-parsely/compare/3.3.0...3.3.1
 [3.3.0]: https://github.com/Parsely/wp-parsely/compare/3.2.1...3.3.0
 [3.2.1]: https://github.com/Parsely/wp-parsely/compare/3.2.0...3.2.1
 [3.2.0]: https://github.com/Parsely/wp-parsely/compare/3.1.3...3.2.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.3.0  
+Stable tag: 3.3.1
 Requires at least: 5.0  
 Tested up to: 5.9.3  
 Requires PHP: 7.1  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.3.1
+Stable tag: 3.3.1  
 Requires at least: 5.0  
 Tested up to: 5.9.3  
 Requires PHP: 7.1  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.3.0",
+			"version": "3.3.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/dom-ready": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, pauarge",

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -1,6 +1,6 @@
 import { activatePlugin, loginUser, visitAdminPage } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.3.0';
+export const PLUGIN_VERSION = '3.3.1';
 
 export const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://www.parse.ly/help/integration/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.3.0
+ * Version:           3.3.1
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -49,7 +49,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.3.0';
+const PARSELY_VERSION = '3.3.1';
 const PARSELY_FILE    = __FILE__;
 
 require __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
Prepares `develop` for the 3.3.1 release. We have updated the CHANGELOG and bumped the version numbers.
