### PR TITLE
Add wait on E2E Tests helper function

### DIFF
--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -70,6 +70,8 @@ export const selectScreenOptions = async ( sections ) => {
 
 	const [ input ] = await page.$x( '//p[contains(@class, \'submit\')]//input[contains(@name, \'screen-options-apply\')]' );
 	await input.click();
+
+	await waitForWpAdmin();
 };
 
 /**


### PR DESCRIPTION
## Description

Some E2E tests were repeatedly failing because they would call a helper function that sometimes would change the page too early. To prevent that, we're adding a wait so the execution doesn't proceed until we detect that `wp-admin` is fully loaded.

## Motivation and Context

E2E tests are becoming flaky lately, forcing us to retry until they succeed very often. 

## How Has This Been Tested?

Tests now pass with less retries.