### PR TITLE
Signal filter overrides on settings page

### DIFF
--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -645,10 +645,8 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 */
 	private function print_filter_text( array $args ): void {
 		if ( isset( $args['filter'] ) && has_filter( $args['filter'] ) ) {
-			echo '<p><b>';
-			echo '<code>' . esc_html( $args['filter'] ) . '</code>';
-			echo esc_html__( 'filter hook is in use!', 'wp-parsely' );
-			echo '</b> ';
+			echo '<p>';
+			echo '<b><code>' . esc_html( $args['filter'] ) . '</code>' . esc_html__( 'filter hook is in use!', 'wp-parsely' ) . '</b>';
 			echo esc_html__( 'A callback is attached to the filter hook that might interfere and override this setting.', 'wp-parsely' );
 			echo '</p>';
 		}

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -646,7 +646,8 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	private function print_filter_text( array $args ): void {
 		if ( isset( $args['filter'] ) && has_filter( $args['filter'] ) ) {
 			echo '<p>';
-			echo sprintf( __( '<b>The <code>%s</code> filter hook is in use!</b> A callback is attached to the filter hook that might interfere and override this setting.', 'wp-parsely' ), esc_html( $args['filter'] ) );
+			/* translators: 1: filter hook name */
+			echo sprintf( esc_html( __( '<b>The <code>%s</code> filter hook is in use!</b> A callback is attached to the filter hook that might interfere and override this setting.', 'wp-parsely' ) ), esc_html( $args['filter'] ) );
 			echo '</p>';
 		}
 	}

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -456,6 +456,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 				'title'      => __( 'Track Post Types as', 'wp-parsely' ),
 				'option_key' => $field_id,
 				'help_text'  => $field_help,
+				'filter'     => 'wp_parsely_trackable_statuses',
 			)
 		);
 
@@ -472,6 +473,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 				'repeated_metas' => 'repeated_metas',
 			),
 			'label_for'      => Parsely::OPTIONS_KEY . "[$field_id]",
+			'filter'         => 'wp_parsely_metadata',
 		);
 		add_settings_field(
 			$field_id,
@@ -736,6 +738,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 		}
 		echo '</select>';
 
+		$this->print_filter_text( $args );
 		$this->print_description_text( $args );
 	}
 
@@ -847,6 +850,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 			</table>
 		</fieldset>
 		<?php
+		$this->print_filter_text( $args );
 		$this->print_description_text( $args );
 	}
 

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -643,7 +643,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 */
 	public function print_filter_text( array $args ): void {
 		if ( isset( $args['filter'] ) && has_filter( $args['filter'] ) ) {
-			echo '<p><b>The <code>' . esc_html( $args['filter'] ) . '</code> filter is defined!</b> You have defined it somewhere in your code, therefore it might interfere and override this setting.</p>';
+			echo '<p><b>The <code>' . esc_html( $args['filter'] ) . '</code> filter hook is in use!</b> A callback is attached to the filter hook that might interfere and override this setting.</p>';
 		}
 	}
 

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -643,9 +643,11 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 *
 	 * @param array $args The arguments for the form field. May contain 'filter'.
 	 */
-	public function print_filter_text( array $args ): void {
+	private function print_filter_text( array $args ): void {
 		if ( isset( $args['filter'] ) && has_filter( $args['filter'] ) ) {
-			echo '<p><b>The <code>' . esc_html( $args['filter'] ) . '</code> filter hook is in use!</b> A callback is attached to the filter hook that might interfere and override this setting.</p>';
+			echo '<p>';
+			echo sprintf( __( '<b>The <code>%s</code> filter hook is in use!</b> A callback is attached to the filter hook that might interfere and override this setting.', 'wp-parsely' ), esc_html( $args['filter'] ) );
+			echo '</p>';
 		}
 	}
 
@@ -656,7 +658,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 *
 	 * @param array $args The arguments for the form field. May contain 'help_text'.
 	 */
-	public function print_description_text( array $args ): void {
+	private function print_description_text( array $args ): void {
 		echo isset( $args['help_text'] ) ? '<p class="description" id="' . esc_attr( $args['option_key'] ) . '-description">' . wp_kses_post( $args['help_text'] ) . '</p>' : '';
 	}
 

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -645,9 +645,11 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	 */
 	private function print_filter_text( array $args ): void {
 		if ( isset( $args['filter'] ) && has_filter( $args['filter'] ) ) {
-			echo '<p>';
-			/* translators: 1: filter hook name */
-			echo sprintf( esc_html( __( '<b>The <code>%s</code> filter hook is in use!</b> A callback is attached to the filter hook that might interfere and override this setting.', 'wp-parsely' ) ), esc_html( $args['filter'] ) );
+			echo '<p><b>';
+			echo '<code>' . esc_html( $args['filter'] ) . '</code>';
+			echo esc_html__( 'filter hook is in use!', 'wp-parsely' );
+			echo '</b> ';
+			echo esc_html__( 'A callback is attached to the filter hook that might interfere and override this setting.', 'wp-parsely' );
 			echo '</p>';
 		}
 	}

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -646,7 +646,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	private function print_filter_text( array $args ): void {
 		if ( isset( $args['filter'] ) && has_filter( $args['filter'] ) ) {
 			echo '<p>';
-			echo '<b><code>' . esc_html( $args['filter'] ) . '</code>' . esc_html__( 'filter hook is in use!', 'wp-parsely' ) . '</b>';
+			echo '<b><code>' . esc_html( $args['filter'] ) . '</code>' . esc_html__( 'filter hook is in use!', 'wp-parsely' ) . '</b> ';
 			echo esc_html__( 'A callback is attached to the filter hook that might interfere and override this setting.', 'wp-parsely' );
 			echo '</p>';
 		}

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -401,6 +401,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 				'title'      => __( 'Disable JavaScript', 'wp-parsely' ), // Passed for legend element.
 				'option_key' => 'disable_javascript',
 				'help_text'  => $h,
+				'filter'     => 'wp_parsely_load_js_tracker',
 			)
 		);
 
@@ -634,13 +635,26 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 	}
 
 	/**
+	 * Prints out a warning if the filter for the setting is defined, if any.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param array $args The arguments for the form field. May contain 'filter'.
+	 */
+	public function print_filter_text( array $args ): void {
+		if ( isset( $args['filter'] ) && has_filter( $args['filter'] ) ) {
+			echo '<p><b>The <code>' . esc_html( $args['filter'] ) . '</code> filter is defined!</b> You have defined it somewhere in your code, therefore it might interfere and override this setting.</p>';
+		}
+	}
+
+	/**
 	 * Prints out the description text, if there is any.
 	 *
 	 * @since 3.1.0
 	 *
 	 * @param array $args The arguments for the form field. May contain 'help_text'.
 	 */
-	public function print_description_text( $args ): void {
+	public function print_description_text( array $args ): void {
 		echo isset( $args['help_text'] ) ? '<p class="description" id="' . esc_attr( $args['option_key'] ) . '-description">' . wp_kses_post( $args['help_text'] ) . '</p>' : '';
 	}
 
@@ -750,6 +764,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 			</p>
 		</fieldset>
 		<?php
+		$this->print_filter_text( $args );
 		$this->print_description_text( $args );
 	}
 


### PR DESCRIPTION
## Description

This PR adds a text that warns a user about a filter hook being defined somewhere in their code. We are adding this feature to help users debug behaviors in which those filters might override the setting defined in the UI.

## Motivation and Context

Closes #713 

## How Has This Been Tested?

Add some of the following filters in your code:

- `wp_parsely_load_js_tracker`
- `wp_parsely_trackable_statuses`
- `wp_parsely_metadata`

Then go to the settings page and you should see the notices under the appropriate settings.

## Screenshots (if appropriate)

<img width="913" alt="Screen Shot 2022-05-11 at 11 27 57 AM" src="https://user-images.githubusercontent.com/7188409/167817356-7f2138c8-ef46-48e6-bda2-ab13cc4acfde.png">