### PR TITLE
Deprecate construct_parsely_metadata

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -239,6 +239,7 @@ class Parsely {
 	 * @return array<string, mixed>
 	 */
 	public function construct_parsely_metadata( array $parsely_options, WP_Post $post ): array {
+		_deprecated_function( __FUNCTION__, '3.3', 'Metadata::construct_metadata()' );
 		$metadata = new Metadata( $this );
 		return $metadata->construct_metadata( $post );
 	}


### PR DESCRIPTION
## Description

After soft deprecating the `construct_parsely_metadata` in 3.3.0, we want to hard deprecate it in 3.4.0. That means all usages of the function will trigger a warning. We're doing this in anticipation of completely removing the function in 4.0.0.

## Motivation and Context

See #796 

## How Has This Been Tested?

Calling the function directly triggers a warning in debug mode.