### PR TITLE
Add debug information in the Site Health page

### DIFF
--- a/src/UI/class-site-health.php
+++ b/src/UI/class-site-health.php
@@ -74,7 +74,7 @@ final class Site_Health {
 			if ( $this->parsely->api_key_is_missing() ) {
 				$result['status']  = 'critical';
 				$result['label']   = __( 'You need to provide the Site ID', 'wp-parsely' );
-				$result['actions'] = __( 'The site id can be provided in the <a href="/wp-admin/options-general.php?page=parsely">Parse.ly Settings Page</a>.', 'wp-parsely' );
+				$result['actions'] = __( 'The site ID can be set in the <a href="/wp-admin/options-general.php?page=parsely">Parse.ly Settings Page</a>.', 'wp-parsely' );
 			}
 
 			return $result;

--- a/src/UI/class-site-health.php
+++ b/src/UI/class-site-health.php
@@ -107,12 +107,10 @@ final class Site_Health {
 		);
 
 		foreach ( $options as $name => $value ) {
-			if ( $value ) {
-				$args['parsely']['fields'][ $name ] = array(
-					'label' => $name,
-					'value' => $value,
-				);
-			}
+			$args['parsely']['fields'][ $name ] = array(
+				'label' => $name,
+				'value' => $value,
+			);
 		}
 
 		return $args;

--- a/src/UI/class-site-health.php
+++ b/src/UI/class-site-health.php
@@ -74,7 +74,7 @@ final class Site_Health {
 			if ( $this->parsely->api_key_is_missing() ) {
 				$result['status']  = 'critical';
 				$result['label']   = __( 'You need to provide the Site ID', 'wp-parsely' );
-				$result['actions'] = __( 'The site id can be provided in the <a href="/wp-admin/options-general.php?page=parsely">Parse.ly Settings Page</a>', 'wp-parsely' );
+				$result['actions'] = __( 'The site id can be provided in the <a href="/wp-admin/options-general.php?page=parsely">Parse.ly Settings Page</a>.', 'wp-parsely' );
 			}
 
 			return $result;

--- a/src/UI/class-site-health.php
+++ b/src/UI/class-site-health.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * UI: Site Health
+ *
+ * Extends WordPress Core's site health with the plugin's debug information.
+ *
+ * @package Parsely
+ * @since 3.4.0
+ */
+
+declare(strict_types=1);
+
+namespace Parsely\UI;
+
+use Parsely\Parsely;
+
+/**
+ * Provides debug information about the plugin.
+ *
+ * @since 3.4.0
+ */
+final class Site_Health {
+	/**
+	 * Instance of Parsely class.
+	 *
+	 * @var Parsely
+	 */
+	private $parsely;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Parsely $parsely Instance of Parsely class.
+	 */
+	public function __construct( Parsely $parsely ) {
+		$this->parsely = $parsely;
+	}
+
+	/**
+	 * Registers the site health methods.
+	 *
+	 * @since 3.4.0
+	 */
+	public function run(): void {
+		add_filter( 'site_status_tests', array( $this, 'check_api_key' ) );
+		add_filter( 'debug_information', array( $this, 'options_debug_info' ) );
+	}
+
+	/**
+	 * Adds a healthcheck function that tests whether the Site ID is set or not.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param array<string, mixed> $tests An associative array of direct and asynchronous tests.
+	 *
+	 * @return array
+	 */
+	public function check_api_key( array $tests ): array {
+		$check = function() {
+			$result = array(
+				'label'       => __( 'The Site ID is correctly set up', 'wp-parsely' ),
+				'status'      => 'good',
+				'badge'       => array(
+					'label' => 'Parse.ly',
+					'color' => 'green',
+				),
+				'description' => sprintf(
+					'<p>%s</p>',
+					__( 'Your Site ID uniquely represents your site within Parse.ly. It is required for the tracking to work correctly.', 'wp-parsely' )
+				),
+				'test'        => 'loopback_requests',
+			);
+
+			if ( $this->parsely->api_key_is_missing() ) {
+				$result['status']  = 'critical';
+				$result['label']   = __( 'You need to provide the Site ID', 'wp-parsely' );
+				$result['actions'] = __( 'The site id can be provided in the <a href="/wp-admin/options-general.php?page=parsely">Parse.ly Settings Page</a>', 'wp-parsely' );
+			}
+
+			return $result;
+		};
+
+		$tests['direct']['parsely'] = array(
+			'label' => __( 'Parse.ly Site ID', 'wp-parsely' ),
+			'test'  => $check,
+		);
+
+		return $tests;
+	}
+
+	/**
+	 * Adds the Parse.ly options to core's debug information array.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param array<string, mixed> $args The debug information to be added to the core information page.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function options_debug_info( array $args ): array {
+		$options = $this->parsely->get_options();
+
+		$args['parsely'] = array(
+			'label'       => __( 'Parse.ly Options', 'wp-parsely' ),
+			'description' => __( 'Shows the options stored in the database used by the wp-parsely plugin.', 'wp-parsely' ),
+			'show_count'  => true,
+		);
+
+		foreach ( $options as $name => $value ) {
+			if ( $value ) {
+				$args['parsely']['fields'][ $name ] = array(
+					'label' => $name,
+					'value' => $value,
+				);
+			}
+		}
+
+		return $args;
+	}
+}

--- a/src/UI/class-site-health.php
+++ b/src/UI/class-site-health.php
@@ -56,7 +56,7 @@ final class Site_Health {
 	 * @return array
 	 */
 	public function check_api_key( array $tests ): array {
-		$check = function() {
+		$test = function() {
 			$result = array(
 				'label'       => __( 'The Site ID is correctly set up', 'wp-parsely' ),
 				'status'      => 'good',
@@ -82,7 +82,7 @@ final class Site_Health {
 
 		$tests['direct']['parsely'] = array(
 			'label' => __( 'Parse.ly Site ID', 'wp-parsely' ),
-			'test'  => $check,
+			'test'  => $test,
 		);
 
 		return $tests;

--- a/tests/Integration/UI/SiteHealthTest.php
+++ b/tests/Integration/UI/SiteHealthTest.php
@@ -47,4 +47,20 @@ final class SiteHealthTest extends TestCase {
 		self::assertEquals( 10, has_filter( 'site_status_tests', array( self::$site_health, 'check_api_key' ) ) );
 		self::assertEquals( 10, has_filter( 'debug_information', array( self::$site_health, 'options_debug_info' ) ) );
 	}
+
+	/**
+	 * Test if options_debug_info can populate the args array to be consumed by WordPress.
+	 *
+	 * @covers \Parsely\UI\Site_Health::__construct
+	 * @covers \Parsely\UI\Site_Health::options_debug_info
+	 */
+	public function test_options_debug_info(): void {
+		$args = self::$site_health->options_debug_info( array() );
+
+		self::assertArrayHasKey( 'parsely', $args );
+		self::assertEquals( 'Parse.ly Options', $args['parsely']['label'] );
+		self::assertEquals( 'Shows the options stored in the database used by the wp-parsely plugin.', $args['parsely']['description'] );
+		self::assertTrue( $args['parsely']['show_count'] );
+		self::assertArrayHasKey( 'fields', $args['parsely'] );
+	}
 }

--- a/tests/Integration/UI/SiteHealthTest.php
+++ b/tests/Integration/UI/SiteHealthTest.php
@@ -27,7 +27,7 @@ final class SiteHealthTest extends TestCase {
 	private static $site_health;
 
 	/**
-	 * The setUp run before each test
+	 * The setup run before each test.
 	 */
 	public function set_up(): void {
 		parent::set_up();

--- a/tests/Integration/UI/SiteHealthTest.php
+++ b/tests/Integration/UI/SiteHealthTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Site Health tools tests.
+ *
+ * @package Parsely\Tests
+ */
+
+declare(strict_types=1);
+
+namespace Parsely\Tests\Integration\UI;
+
+use Parsely\Parsely;
+use Parsely\Tests\Integration\TestCase;
+use Parsely\UI\Site_Health;
+
+/**
+ * Site Health extensions tests.
+ *
+ * @since 3.4.0
+ */
+final class SiteHealthTest extends TestCase {
+	/**
+	 * Internal variable.
+	 *
+	 * @var Site_Health $site_health Holds the Admin_Bar object
+	 */
+	private static $site_health;
+
+	/**
+	 * The setUp run before each test
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		self::$site_health = new Site_Health( new Parsely() );
+	}
+
+	/**
+	 * Check that the functions that extend the Site Health page are enqueued.
+	 *
+	 * @covers \Parsely\UI\Site_Health::__construct
+	 * @covers \Parsely\UI\Site_Health::run
+	 */
+	public function test_admin_bar_enqueued(): void {
+		self::$site_health->run();
+
+		self::assertEquals( 10, has_filter( 'site_status_tests', array( self::$site_health, 'check_api_key' ) ) );
+		self::assertEquals( 10, has_filter( 'debug_information', array( self::$site_health, 'options_debug_info' ) ) );
+	}
+}

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -44,6 +44,7 @@ use Parsely\UI\Network_Admin_Sites_List;
 use Parsely\UI\Recommended_Widget;
 use Parsely\UI\Row_Actions;
 use Parsely\UI\Settings_Page;
+use Parsely\UI\Site_Health;
 
 if ( class_exists( Parsely::class ) ) {
 	return;
@@ -97,6 +98,7 @@ function parsely_initialize_plugin(): void {
 require __DIR__ . '/src/UI/class-admin-warning.php';
 require __DIR__ . '/src/UI/class-plugins-actions.php';
 require __DIR__ . '/src/UI/class-row-actions.php';
+require __DIR__ . '/src/UI/class-site-health.php';
 
 add_action( 'admin_init', __NAMESPACE__ . '\\parsely_admin_init_register' );
 /**
@@ -111,6 +113,9 @@ function parsely_admin_init_register(): void {
 
 	$row_actions = new Row_Actions( $GLOBALS['parsely'] );
 	$row_actions->run();
+
+	$site_health = new Site_Health( $GLOBALS['parsely'] );
+	$site_health->run();
 }
 
 require __DIR__ . '/src/UI/class-settings-page.php';


### PR DESCRIPTION
## Description

This PR adds debugging tools into the Site Health page in wp-admin. In _Site Health Status_, it adds a check that passes if the Site ID is defined and fails critically otherwise. In _Site Health Info_, it provides a section that prints the plugin's options stored in the database (intended for support purposes).

## Motivation and Context

Closes #638

## How Has This Been Tested?

Remove the Site ID from your site and see the status check failing. See that it's not showing on the options printed in Info. Add it back again and see the check back to passing.

## Screenshots (if appropriate)

*Debug information*

<img width="818" alt="Screen Shot 2022-05-12 at 11 23 27 AM" src="https://user-images.githubusercontent.com/7188409/168038088-f9923278-af6d-4648-831b-502e823a1faa.png">

*Test passing*

<img width="850" alt="Screen Shot 2022-05-12 at 11 22 43 AM" src="https://user-images.githubusercontent.com/7188409/168037942-324be6ec-bd1e-488b-8c57-52e4f8821d35.png">

*Test failing* 

<img width="856" alt="Screen Shot 2022-05-12 at 11 24 03 AM" src="https://user-images.githubusercontent.com/7188409/168038240-cf270074-1e26-4d8e-b806-3c7b288b7df7.png">