### PR TITLE
Use $parsed_post in render_metadata()

### DIFF
--- a/src/UI/class-metadata-renderer.php
+++ b/src/UI/class-metadata-renderer.php
@@ -104,7 +104,7 @@ final class Metadata_Renderer {
 
 		// Assign default values for LD+JSON
 		// TODO: Mapping of an install's post types to Parse.ly post types (namely page/post).
-		$metadata = ( new Metadata( $this->parsely ) )->construct_metadata( $post );
+		$metadata = ( new Metadata( $this->parsely ) )->construct_metadata( $parsed_post );
 
 		// Something went wrong - abort.
 		if ( 0 === count( $metadata ) || ! isset( $metadata['headline'] ) ) {


### PR DESCRIPTION
## Description
This PR fixes the issue of passing a wrong parameter to the `construct_metadata()` function within `render_metadata()`. More information can be found in #868.

## Motivation and Context
Fixes #868.

## How Has This Been Tested?
Manually verified that the correct parameter is being passed.