### PR TITLE
Fix metadata builder not defined warning

### DIFF
--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -84,7 +84,7 @@ class Metadata {
 			$builder = new Page_Builder( $this->parsely, $post );
 		}
 
-		if ( null !== $builder ) {
+		if ( isset( $builder ) ) {
 			$parsely_page = $builder->get_metadata();
 		} else {
 			$parsely_page = array();


### PR DESCRIPTION
## Description

This PR fixes a warning that would happen when the metadata builders were invoked and no builder was present. In that case, the `$builder` variable is not defined.

## Motivation and Context

Reduce risky code.

## How Has This Been Tested?

The warning no longer appears.

## Screenshots (if appropriate)

<img width="1920" alt="Screen Shot 2022-05-16 at 5 46 43 PM" src="https://user-images.githubusercontent.com/7188409/168632573-5e5da379-83b8-4908-b35a-43fccf0300d1.png">