### PR TITLE
Fix Metadata test coverage

### DIFF
--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -154,14 +154,28 @@ final class RestMetadataTest extends TestCase {
 	 * @uses \Parsely\Endpoints\Metadata_Endpoint::get_rendered_meta
 	 * @uses \Parsely\Metadata::__construct
 	 * @uses \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
-	 * @uses \Parsely\Metadata::get_tags
-	 * @uses \Parsely\Metadata::set_metadata_post_times
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_api_key
@@ -192,16 +206,32 @@ final class RestMetadataTest extends TestCase {
 	 *
 	 * @covers \Parsely\Endpoints\Rest_Metadata::get_callback
 	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::get_rendered_meta
 	 * @uses \Parsely\Metadata::__construct
 	 * @uses \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
-	 * @uses \Parsely\Metadata::get_tags
-	 * @uses \Parsely\Metadata::set_metadata_post_times
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
+	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_api_key
 	 * @uses \Parsely\Parsely::get_options
@@ -232,14 +262,28 @@ final class RestMetadataTest extends TestCase {
 	 * @uses \Parsely\Endpoints\Metadata_Endpoint::get_rendered_meta
 	 * @uses \Parsely\Metadata::__construct
 	 * @uses \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
-	 * @uses \Parsely\Metadata::get_tags
-	 * @uses \Parsely\Metadata::set_metadata_post_times
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
@@ -291,18 +335,33 @@ final class RestMetadataTest extends TestCase {
 	/**
 	 * Test that the rendered meta function returns the meta HTML string with json ld.
 	 *
-	 * @covers \Parsely\Endpoints\Rest_Metadata::get_rendered_meta
+	 * @covers \Parsely\Endpoints\Rest_Metadata::get_callback
 	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::get_rendered_meta
 	 * @uses \Parsely\Metadata::__construct
 	 * @uses \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
-	 * @uses \Parsely\Metadata::get_tags
-	 * @uses \Parsely\Metadata::set_metadata_post_times
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options
@@ -333,18 +392,33 @@ final class RestMetadataTest extends TestCase {
 	/**
 	 * Test that the rendered meta function returns the meta HTML string with json ld.
 	 *
-	 * @covers \Parsely\Endpoints\Rest_Metadata::get_rendered_meta
+	 * @covers \Parsely\Endpoints\Rest_Metadata::get_callback
 	 * @uses \Parsely\Endpoints\Metadata_Endpoint::__construct
+	 * @uses \Parsely\Endpoints\Metadata_Endpoint::get_rendered_meta
 	 * @uses \Parsely\Metadata::__construct
 	 * @uses \Parsely\Metadata::construct_metadata
-	 * @uses \Parsely\Metadata::get_author_names
-	 * @uses \Parsely\Metadata::get_bottom_level_term
-	 * @uses \Parsely\Metadata::get_category_name
-	 * @uses \Parsely\Metadata::get_clean_parsely_page_value
-	 * @uses \Parsely\Metadata::get_coauthor_names
-	 * @uses \Parsely\Metadata::get_current_url
-	 * @uses \Parsely\Metadata::get_tags
-	 * @uses \Parsely\Metadata::set_metadata_post_times
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::api_key_is_missing
 	 * @uses \Parsely\Parsely::api_key_is_set
 	 * @uses \Parsely\Parsely::get_options

--- a/tests/Integration/GetCurrentUrlTest.php
+++ b/tests/Integration/GetCurrentUrlTest.php
@@ -104,7 +104,8 @@ final class GetCurrentUrlTest extends TestCase {
 	 *
 	 * @testdox Given Force HTTPS is $force_https, when home is $home, then expect URLs starting with $expected.
 	 * @dataProvider data_for_test_get_current_url
-	 * @covers \Parsely\Metadata::get_current_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
 	 * @uses \Parsely\Metadata::__construct
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::update_metadata_endpoint

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -60,15 +60,28 @@ final class OtherTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::set_metadata_post_times
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -109,15 +122,29 @@ final class OtherTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::construct_metadata
 	 * @covers \Parsely\Metadata::__construct
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
-	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint

--- a/tests/Integration/StructuredData/AuthorArchiveTest.php
+++ b/tests/Integration/StructuredData/AuthorArchiveTest.php
@@ -24,14 +24,13 @@ final class AuthorArchiveTest extends NonPostTestCase {
 	 *
 	 * @covers \Parsely\Metadata::construct_metadata
 	 * @covers \Parsely\Metadata::__construct
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @uses \Parsely\Metadata\Author_Archive_Builder::build_headline
+	 * @uses \Parsely\Metadata\Author_Archive_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint

--- a/tests/Integration/StructuredData/BlogArchiveTest.php
+++ b/tests/Integration/StructuredData/BlogArchiveTest.php
@@ -24,14 +24,12 @@ final class BlogArchiveTest extends NonPostTestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_url
+	 * @uses \Parsely\Metadata\Page_For_Posts_Builder::build_headline
+	 * @uses \Parsely\Metadata\Page_For_Posts_Builder::get_metadata
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint

--- a/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomPostTypeArchiveTest.php
@@ -24,14 +24,13 @@ final class CustomPostTypeArchiveTest extends NonPostTestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Category_Builder::build_headline
+	 * @uses \Parsely\Metadata\Category_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint

--- a/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
+++ b/tests/Integration/StructuredData/CustomTaxonomyTermArchiveTest.php
@@ -24,14 +24,13 @@ class CustomTaxonomyTermArchiveTest extends NonPostTestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Category_Builder::build_headline
+	 * @uses \Parsely\Metadata\Category_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint

--- a/tests/Integration/StructuredData/HomePageTest.php
+++ b/tests/Integration/StructuredData/HomePageTest.php
@@ -35,14 +35,14 @@ final class HomePageTest extends NonPostTestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @covers \Parsely\Metadata\Paginated_Front_Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Front_Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Front_Page_Builder::build_headline
+	 * @uses \Parsely\Metadata\Front_Page_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -81,14 +81,14 @@ final class HomePageTest extends NonPostTestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @covers \Parsely\Metadata\Paginated_Front_Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Front_Page_Builder::build_headline
+	 * @uses \Parsely\Metadata\Front_Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Front_Page_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -132,14 +132,13 @@ final class HomePageTest extends NonPostTestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Front_Page_Builder::build_headline
+	 * @uses \Parsely\Metadata\Front_Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Front_Page_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -184,14 +183,13 @@ final class HomePageTest extends NonPostTestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Front_Page_Builder::build_headline
+	 * @uses \Parsely\Metadata\Front_Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Front_Page_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint

--- a/tests/Integration/StructuredData/SinglePageTest.php
+++ b/tests/Integration/StructuredData/SinglePageTest.php
@@ -25,14 +25,14 @@ final class SinglePageTest extends NonPostTestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Page_Builder::__construct
+	 * @uses \Parsely\Metadata\Page_Builder::build_headline
+	 * @uses \Parsely\Metadata\Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Page_Builder::get_metadata
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint

--- a/tests/Integration/StructuredData/SinglePostTest.php
+++ b/tests/Integration/StructuredData/SinglePostTest.php
@@ -35,15 +35,28 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
-	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -75,15 +88,28 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
-	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -111,15 +137,28 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
-	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -158,17 +197,30 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_categories
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_custom_taxonomy_values
-	 * @covers \Parsely\Metadata::get_tags
-	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
+	 * @uses \Parsely\Metadata\Post_Builder::get_categories
+	 * @uses \Parsely\Metadata\Post_Builder::get_custom_taxonomy_values
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -207,17 +259,30 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_categories
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_custom_taxonomy_values
-	 * @covers \Parsely\Metadata::get_tags
-	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
+	 * @uses \Parsely\Metadata\Post_Builder::get_categories
+	 * @uses \Parsely\Metadata\Post_Builder::get_custom_taxonomy_values
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -268,16 +333,29 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
-	 * @covers \Parsely\Metadata::get_top_level_term
-	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
+	 * @uses \Parsely\Metadata\Post_Builder::get_top_level_term
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -328,16 +406,29 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
-	 * @covers \Parsely\Metadata::get_top_level_term
-	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
+	 * @uses \Parsely\Metadata\Post_Builder::get_top_level_term
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -399,15 +490,28 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
-	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -453,15 +557,28 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
-	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
@@ -506,15 +623,28 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
-	 * @covers \Parsely\Metadata::set_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @group metadata
@@ -545,14 +675,28 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::set_metadata_post_times
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @group metadata
@@ -590,14 +734,28 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::set_metadata_post_times
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @group metadata
@@ -636,14 +794,28 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::set_metadata_post_times
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @group metadata
@@ -702,16 +874,30 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::set_metadata_post_times
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
-	 * @covers \Parsely\Metadata::get_categories
-	 * @covers \Parsely\Metadata::get_custom_taxonomy_values
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_categories
+	 * @uses \Parsely\Metadata\Post_Builder::get_custom_taxonomy_values
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @group metadata
@@ -746,14 +932,28 @@ final class SinglePostTest extends TestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::set_metadata_post_times
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Post_Builder::__construct
+	 * @uses \Parsely\Metadata\Post_Builder::build_article_section
+	 * @uses \Parsely\Metadata\Post_Builder::build_author
+	 * @uses \Parsely\Metadata\Post_Builder::build_headline
+	 * @uses \Parsely\Metadata\Post_Builder::build_image
+	 * @uses \Parsely\Metadata\Post_Builder::build_keywords
+	 * @uses \Parsely\Metadata\Post_Builder::build_main_entity
+	 * @uses \Parsely\Metadata\Post_Builder::build_metadata_post_times
+	 * @uses \Parsely\Metadata\Post_Builder::build_publisher
+	 * @uses \Parsely\Metadata\Post_Builder::build_thumbnail_url
+	 * @uses \Parsely\Metadata\Post_Builder::build_type
+	 * @uses \Parsely\Metadata\Post_Builder::build_url
+	 * @uses \Parsely\Metadata\Post_Builder::get_author_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_bottom_level_term
+	 * @uses \Parsely\Metadata\Post_Builder::get_category_name
+	 * @uses \Parsely\Metadata\Post_Builder::get_coauthor_names
+	 * @uses \Parsely\Metadata\Post_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Post_Builder::get_tags
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @group metadata

--- a/tests/Integration/StructuredData/TermArchiveTest.php
+++ b/tests/Integration/StructuredData/TermArchiveTest.php
@@ -24,14 +24,13 @@ final class TermArchiveTest extends NonPostTestCase {
 	 *
 	 * @covers \Parsely\Metadata::__construct
 	 * @covers \Parsely\Metadata::construct_metadata
-	 * @covers \Parsely\Metadata::get_author_name
-	 * @covers \Parsely\Metadata::get_author_names
-	 * @covers \Parsely\Metadata::get_bottom_level_term
-	 * @covers \Parsely\Metadata::get_category_name
-	 * @covers \Parsely\Metadata::get_clean_parsely_page_value
-	 * @covers \Parsely\Metadata::get_coauthor_names
-	 * @covers \Parsely\Metadata::get_current_url
-	 * @covers \Parsely\Metadata::get_tags
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @uses \Parsely\Metadata\Category_Builder::build_headline
+	 * @uses \Parsely\Metadata\Category_Builder::get_metadata
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_url
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
 	 * @uses \Parsely\Parsely::update_metadata_endpoint

--- a/tests/Integration/UI/SiteHealthTest.php
+++ b/tests/Integration/UI/SiteHealthTest.php
@@ -53,6 +53,7 @@ final class SiteHealthTest extends TestCase {
 	 *
 	 * @covers \Parsely\UI\Site_Health::__construct
 	 * @covers \Parsely\UI\Site_Health::options_debug_info
+	 * @uses \Parsely\Parsely::get_options
 	 */
 	public function test_options_debug_info(): void {
 		$args = self::$site_health->options_debug_info( array() );


### PR DESCRIPTION
## Description

After the metadata builder refactor, some coverage references in tests got broken. This PR fixes the references so we don't have warnings on the tests.

## Motivation and Context

Avoid warnings on tests.

## How Has This Been Tested?

See that no warnings on _PHP 8.0 Integration tests with coverage_ are present.