### PR TITLE
Add Analytics Proxy and Endpoint for Content Helper

### DIFF
--- a/src/Endpoints/class-analytics-api-proxy.php
+++ b/src/Endpoints/class-analytics-api-proxy.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Endpoints: Parse.ly `/analytics` API proxy endpoint class
+ *
+ * @package Parsely
+ * @since   3.4.0
+ */
+
+declare(strict_types=1);
+
+namespace Parsely\Endpoints;
+
+use Parsely\Parsely;
+use Parsely\RemoteAPI\Proxy;
+use stdClass;
+use WP_Error;
+use WP_REST_Server;
+use WP_REST_Request;
+
+/**
+ * Configures a REST API endpoint for use.
+ */
+final class Analytics_API_Proxy {
+	/**
+	 * Parsely object instance.
+	 *
+	 * @var Parsely
+	 */
+	private $parsely;
+
+	/**
+	 * Proxy object which does the actual calls to the Parse.ly API.
+	 *
+	 * @var Proxy
+	 */
+	private $proxy;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Parsely $parsely Instance of Parsely class.
+	 * @param Proxy   $proxy   Proxy object which does the actual calls to the
+	 *                         Parse.ly API.
+	 */
+	public function __construct( Parsely $parsely, Proxy $proxy ) {
+		$this->parsely = $parsely;
+		$this->proxy   = $proxy;
+	}
+
+	/**
+	 * Registers the endpoint and initializes this class.
+	 */
+	public function run(): void {
+		if ( ! apply_filters( 'wp_parsely_enable_analytics_api_proxy', true ) ) {
+			return;
+		}
+
+		$get_items_args = array(
+			'query' => array(
+				'default'           => array(),
+				'sanitize_callback' => function ( $query ) {
+					// question: how should we sanitize these?
+					return (array) $query;
+				},
+			),
+		);
+
+		$rest_route_args = array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+				'args'                => $get_items_args,
+			),
+		);
+
+		register_rest_route( 'wp-parsely/v1', '/analytics', $rest_route_args );
+	}
+
+	/**
+	 * Determines if the endpoint can be called.
+	 *
+	 * @return bool
+	 */
+	public function permission_callback(): bool {
+		// Unauthenticated.
+		return true;
+	}
+
+	/**
+	 * Cached "proxy" to the Parsely `/analytics` endpoint
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return stdClass
+	 */
+	public function get_items( WP_REST_Request $request ) {
+		$params = $request->get_params();
+
+		if ( false === $this->parsely->api_key_is_set() ) {
+			return (object) array(
+				'data'  => array(),
+				'error' => new WP_Error( 400, __( 'A Parse.ly API Key must be set in site options to use this endpoint', 'wp-parsely' ) ),
+			);
+		}
+
+		if ( false === $this->parsely->api_secret_is_set() ) {
+			return (object) array(
+				'data'  => array(),
+				'error' => new WP_Error( 400, __( 'A Parse.ly API Secret must be set in site options to use this endpoint', 'wp-parsely' ) ),
+			);
+		}
+
+		// A proxy with caching behaviour is used here.
+		$response = $this->proxy->get_items( $params['query'] );
+
+		if ( is_wp_error( $response ) ) {
+			return (object) array(
+				'data'  => array(),
+				'error' => $response,
+			);
+		}
+
+		$data = array_map(
+			static function( stdClass $item ) {
+				return (object) array(
+					'author'   => $item->author,
+					'pub_date' => $item->pub_date,
+					'title'    => $item->title,
+					'url'      => $item->url,
+				);
+			},
+			$response
+		);
+
+		return (object) array( 'data' => $data );
+	}
+}

--- a/src/RemoteAPI/class-analytics-proxy.php
+++ b/src/RemoteAPI/class-analytics-proxy.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Remote API: `/analytics` REST API Proxy class
+ *
+ * @package Parsely
+ * @since   3.4.0
+ */
+
+declare(strict_types=1);
+
+namespace Parsely\RemoteAPI;
+
+/**
+ * Proxy for the `/analytics` endpoint.
+ *
+ * @since 3.4.0
+ */
+class Analytics_Proxy extends Base_Proxy {
+	protected const ENDPOINT     = 'https://api.parsely.com/v2/analytics';
+	protected const QUERY_FILTER = 'wp_parsely_analytics_endpoint_args';
+}

--- a/src/RemoteAPI/class-base-proxy.php
+++ b/src/RemoteAPI/class-base-proxy.php
@@ -63,7 +63,10 @@ abstract class Base_Proxy implements Proxy {
 		}
 
 		$query['apikey'] = $this->parsely->get_api_key();
-		$query           = array_filter( $query );
+		if ( $this->parsely->api_secret_is_set() ) {
+			$query['api_secret'] = $this->parsely->get_api_secret();
+		}
+		$query = array_filter( $query );
 
 		// Sort by key so the query args are in alphabetical order.
 		ksort( $query );

--- a/src/RemoteAPI/class-cached-proxy.php
+++ b/src/RemoteAPI/class-cached-proxy.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Remote API: `/related` REST API caching decorator class
+ * Remote API: REST API caching decorator class
  *
  * @package Parsely
  * @since   3.2.0
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace Parsely\RemoteAPI;
 
 /**
- * Caching Decorator for the remote /related endpoint.
+ * Caching Decorator for remote API endpoints.
  */
 class Cached_Proxy implements Proxy {
 	private const CACHE_GROUP      = 'wp-parsely';

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -443,4 +443,34 @@ class Parsely {
 
 		return $this->api_key_is_set() ? $options['apikey'] : '';
 	}
+
+	/**
+	 * Returns whether the API Secret is set in the plugin's options.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return bool True if the API Secret is set, false if not set.
+	 */
+	public function api_secret_is_set(): bool {
+		$options = $this->get_options();
+
+		return (
+				isset( $options['api_secret'] ) &&
+				is_string( $options['api_secret'] ) &&
+				'' !== $options['api_secret']
+		);
+	}
+
+	/**
+	 * Returns the API Secret stored in the plugin's options.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return string The API Secret, empty string if the API secret is not set.
+	 */
+	public function get_api_secret(): string {
+		$options = $this->get_options();
+
+		return $this->api_secret_is_set() ? $options['api_secret'] : '';
+	}
 }

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace Parsely;
 
 use Parsely\Endpoints\Related_API_Proxy;
+use Parsely\Endpoints\Analytics_API_Proxy;
 use Parsely\Endpoints\GraphQL_Metadata;
 use Parsely\Endpoints\Rest_Metadata;
 use Parsely\Integrations\Amp;
@@ -35,6 +36,7 @@ use Parsely\Integrations\Google_Web_Stories;
 use Parsely\Integrations\Integrations;
 use Parsely\RemoteAPI\Cached_Proxy;
 use Parsely\RemoteAPI\Related_Proxy;
+use Parsely\RemoteAPI\Analytics_Proxy;
 use Parsely\RemoteAPI\WordPress_Cache;
 use Parsely\UI\Admin_Bar;
 use Parsely\UI\Admin_Warning;
@@ -139,8 +141,10 @@ require __DIR__ . '/src/RemoteAPI/interface-proxy.php';
 require __DIR__ . '/src/RemoteAPI/class-base-proxy.php';
 require __DIR__ . '/src/RemoteAPI/class-cached-proxy.php';
 require __DIR__ . '/src/RemoteAPI/class-related-proxy.php';
+require __DIR__ . '/src/RemoteAPI/class-analytics-proxy.php';
 require __DIR__ . '/src/RemoteAPI/class-wordpress-cache.php';
 require __DIR__ . '/src/Endpoints/class-related-api-proxy.php';
+require __DIR__ . '/src/Endpoints/class-analytics-api-proxy.php';
 require __DIR__ . '/src/Endpoints/class-rest-metadata.php';
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\\parsely_rest_api_init' );
@@ -154,10 +158,15 @@ function parsely_rest_api_init(): void {
 	$rest = new Rest_Metadata( $GLOBALS['parsely'] );
 	$rest->run();
 
-	$proxy        = new Related_Proxy( $GLOBALS['parsely'] );
-	$cached_proxy = new Cached_Proxy( $proxy, new WordPress_Cache() );
-	$endpoint     = new Related_API_Proxy( $GLOBALS['parsely'], $cached_proxy );
-	$endpoint->run();
+	$related_proxy        = new Related_Proxy( $GLOBALS['parsely'] );
+	$related_cached_proxy = new Cached_Proxy( $related_proxy, new WordPress_Cache() );
+	$related_endpoint     = new Related_API_Proxy( $GLOBALS['parsely'], $related_cached_proxy );
+	$related_endpoint->run();
+
+	$analytics_proxy        = new Analytics_Proxy( $GLOBALS['parsely'] );
+	$analytics_cached_proxy = new Cached_Proxy( $analytics_proxy, new WordPress_Cache() );
+	$analytics_endpoint     = new Analytics_API_Proxy( $GLOBALS['parsely'], $analytics_cached_proxy );
+	$analytics_endpoint->run();
 }
 
 require __DIR__ . '/src/blocks/recommendations/class-recommendations-block.php';


### PR DESCRIPTION
## Description
This PR introduces an `Analytics` Proxy and Endpoint, which hits the Parsely `/analytics` API. It is based on our existing code for the Parse.ly `/related` API. It currently returns the following fields:

```
author
pub_date
title
url
```

## Motivation and Context
This is based on PR #876. It is posted as a separate PR to make its review easier, but should be merged into #876 as soon as the Content Helper can accept data so we can see it in action and perform any adjustments. We can then also refactor this to reduce code duplication if needed.

## How Has This Been Tested?
This code is in draft status and totally untested, waiting to be merged into #876.