### PR TITLE
Fix missing require of class-date-builder.php

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -67,6 +67,7 @@ require __DIR__ . '/src/class-metadata.php';
 require __DIR__ . '/src/Metadata/class-metadata-builder.php';
 require __DIR__ . '/src/Metadata/class-author-archive-builder.php';
 require __DIR__ . '/src/Metadata/class-category-builder.php';
+require __DIR__ . '/src/Metadata/class-date-builder.php';
 require __DIR__ . '/src/Metadata/class-front-page-builder.php';
 require __DIR__ . '/src/Metadata/class-page-builder.php';
 require __DIR__ . '/src/Metadata/class-page-for-posts-builder.php';


### PR DESCRIPTION
## Description
This PR fixes the missing `require` of `/src/Metadata/class-date-builder.php`.

## Motivation and Context
Some users started experiencing fatal errors due to the missing `require`.