### PR TITLE
E2E tests: Improve getContentHelperMessage() timeouts

### DIFF
--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -110,14 +110,13 @@ export const getContentHelperMessage = async ( category = null, tag = null, offl
 	await createNewPost();
 	await page.setOfflineMode( offline );
 	await ensureSidebarOpened();
-	await page.waitForTimeout( 1500 );
+	await page.waitForTimeout( 1000 );
 
 	// Select/add category in the Post Editor.
 	if ( category !== null ) {
 		const categoryToggleButton = await findSidebarPanelToggleButtonWithTitle( 'Categories' );
 		await categoryToggleButton.click();
 		await page.waitForSelector( addCategoryButton, { visible: true } );
-		await page.waitForTimeout( 250 );
 		await page.click( addCategoryButton );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.type( category );
@@ -128,7 +127,6 @@ export const getContentHelperMessage = async ( category = null, tag = null, offl
 	// Select/add tag in the Post Editor.
 	if ( tag !== null ) {
 		const tagToggleButton = await findSidebarPanelToggleButtonWithTitle( 'Tags' );
-		await page.waitForTimeout( 500 );
 		await tagToggleButton.click();
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.type( tag );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -114,8 +114,7 @@ export const getContentHelperMessage = async ( category = null, tag = null, offl
 	// Select/add category in the Post Editor.
 	if ( category !== null ) {
 		await page.waitForTimeout( 250 );
-		const categoryToggleButton = await findSidebarPanelToggleButtonWithTitle( 'Categories' );
-		await page.waitForTimeout( 1000 );
+		const [ categoryToggleButton ] = await page.$x( "//button[contains(., 'Categories')]" );
 		await categoryToggleButton.click();
 		await page.waitForSelector( addCategoryButton, { visible: true } );
 		await page.waitForTimeout( 250 );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -111,10 +111,6 @@ export const getContentHelperMessage = async ( category = null, tag = null, offl
 	await page.setOfflineMode( offline );
 	await ensureSidebarOpened();
 
-	await page.waitForNavigation( {
-		waitUntil: 'networkidle0',
-	} );
-
 	// Select/add category in the Post Editor.
 	if ( category !== null ) {
 		await page.waitForTimeout( 250 );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -116,7 +116,7 @@ export const getContentHelperMessage = async ( category = null, tag = null, offl
 	if ( category !== null ) {
 		const categoryToggleButton = await findSidebarPanelToggleButtonWithTitle( 'Categories' );
 		await categoryToggleButton.click();
-		await page.waitForSelector( addCategoryButton, { visible: true } );
+		await page.waitForTimeout( 500 );
 		await page.click( addCategoryButton );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.type( category );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -110,11 +110,11 @@ export const getContentHelperMessage = async ( category = null, tag = null, offl
 	await createNewPost();
 	await page.setOfflineMode( offline );
 	await ensureSidebarOpened();
+	await page.waitForTimeout( 1500 );
 
 	// Select/add category in the Post Editor.
 	if ( category !== null ) {
-		await page.waitForTimeout( 250 );
-		const [ categoryToggleButton ] = await page.$x( "//button[contains(., 'Categories')]" );
+		const categoryToggleButton = await findSidebarPanelToggleButtonWithTitle( 'Categories' );
 		await categoryToggleButton.click();
 		await page.waitForSelector( addCategoryButton, { visible: true } );
 		await page.waitForTimeout( 250 );
@@ -127,7 +127,6 @@ export const getContentHelperMessage = async ( category = null, tag = null, offl
 
 	// Select/add tag in the Post Editor.
 	if ( tag !== null ) {
-		await page.waitForTimeout( 250 );
 		const tagToggleButton = await findSidebarPanelToggleButtonWithTitle( 'Tags' );
 		await page.waitForTimeout( 500 );
 		await tagToggleButton.click();

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -111,6 +111,10 @@ export const getContentHelperMessage = async ( category = null, tag = null, offl
 	await page.setOfflineMode( offline );
 	await ensureSidebarOpened();
 
+	await page.waitForNavigation( {
+		waitUntil: 'networkidle0',
+	} );
+
 	// Select/add category in the Post Editor.
 	if ( category !== null ) {
 		await page.waitForTimeout( 250 );


### PR DESCRIPTION
## Description
The `getContentHelperMessage()` function was often causing E2e tests to fail on GitHub. This PR adjusts some timeouts in order to prevent that.

## Motivation and Context
Having as few unnecessary E2E test failures as possible.

## How Has This Been Tested?
Repeated runs on Github suggest that the modifications work.