### PR TITLE
Add init_content_helper() action

### DIFF
--- a/src/blocks/content-helper/class-content-helper.php
+++ b/src/blocks/content-helper/class-content-helper.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Parse.ly Content Helper class
+ *
+ * @package Parsely
+ * @since 3.5.0
+ */
+
+declare(strict_types=1);
+
+namespace Parsely;
+
+/**
+ * Parse.ly Content Helper.
+ *
+ * @since 3.5.0
+ */
+class Content_Helper {
+
+	/**
+	 * Inserts the Content Helper into the WordPress Post Editor.
+	 *
+	 * @since 3.5.0
+	 */
+	public function run(): void {
+		$content_helper_asset = require plugin_dir_path( PARSELY_FILE ) . 'build/content-helper.asset.php';
+
+		wp_enqueue_script(
+			'wp-parsely-block-content-helper',
+			plugin_dir_url( PARSELY_FILE ) . 'build/content-helper.js',
+			$content_helper_asset['dependencies'],
+			$content_helper_asset['version'],
+			true
+		);
+
+		wp_enqueue_style(
+			'wp-parsely-block-content-helper',
+			plugin_dir_url( PARSELY_FILE ) . 'build/content-helper.css',
+			array(),
+			$content_helper_asset['version']
+		);
+	}
+
+}

--- a/src/class-scripts.php
+++ b/src/class-scripts.php
@@ -43,7 +43,6 @@ class Scripts {
 		if ( $this->parsely->api_key_is_set() && true !== $parsely_options['disable_javascript'] ) {
 			add_action( 'init', array( $this, 'register_scripts' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_js_tracker' ) );
-			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		}
 	}
 
@@ -69,22 +68,6 @@ class Scripts {
 			$loader_asset['dependencies'],
 			$loader_asset['version'],
 			true
-		);
-
-		$content_helper_asset = require plugin_dir_path( PARSELY_FILE ) . 'build/content-helper.asset.php';
-		wp_register_script(
-			'wp-parsely-block-content-helper',
-			plugin_dir_url( PARSELY_FILE ) . 'build/content-helper.js',
-			$content_helper_asset['dependencies'],
-			$loader_asset['version'],
-			true
-		);
-
-		wp_register_style(
-			'wp-parsely-block-content-helper',
-			plugin_dir_url( PARSELY_FILE ) . 'build/content-helper.css',
-			array(),
-			$content_helper_asset['version']
 		);
 	}
 
@@ -140,22 +123,6 @@ class Scripts {
 			$disable_autotrack = 'window.wpParselyDisableAutotrack = true;';
 			wp_add_inline_script( 'wp-parsely-loader', $disable_autotrack, 'before' );
 		}
-	}
-
-	/**
-	 * Loads the Block Editor / Gutenberg experience enhancements.
-	 * Hooked into the `enqueue_block_editor_assets` action in `$this->run()`
-	 *
-	 * @see: https://developer.wordpress.org/block-editor/how-to-guides/plugin-sidebar-0/
-	 * @return void
-	 */
-	public function enqueue_block_editor_assets(): void {
-		wp_enqueue_script( 'wp-parsely-block-content-helper' );
-		wp_enqueue_style( 'wp-parsely-block-content-helper' );
-
-		$prefix                = trailingslashit( 'https://dash.parsely.com/' . esc_js( $this->parsely->get_api_key() ) ) . 'find';
-		$analytics_link_prefix = 'window.wpParselyContentHelperPrefix = "' . $prefix . '";';
-		wp_add_inline_script( 'wp-parsely-block-content-helper', $analytics_link_prefix, 'before' );
 	}
 
 	/**

--- a/tests/Integration/Blocks/ContentHelperTest.php
+++ b/tests/Integration/Blocks/ContentHelperTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Integration Tests: Content Helper
+ *
+ * @package Parsely\Tests
+ */
+
+declare(strict_types=1);
+
+namespace Parsely\Tests\Blocks;
+
+use Parsely\Content_Helper;
+use Parsely\Tests\Integration\TestCase;
+
+/**
+ * Integration Tests for the Content Helper.
+ */
+final class ContentHelperTest extends TestCase {
+	private const BLOCK_NAME = 'wp-parsely-block-content-helper';
+
+	/**
+	 * Verifies that the Content Helper's run() method enqueues the required
+	 * files.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @covers \Parsely\Content_Helper::run
+	 *
+	 * @group blocks
+	 */
+	public function test_content_helper_files_get_enqueued_on_run(): void {
+		( new Content_Helper() )->run();
+		self::assertTrue( wp_script_is( self::BLOCK_NAME ) );
+		self::assertTrue( wp_style_is( self::BLOCK_NAME ) );
+	}
+}

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -182,6 +182,7 @@ function init_recommendations_block(): void {
 	$recommendations_block->run();
 }
 
+require __DIR__ . '/src/blocks/content-helper/class-content-helper.php';
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\init_content_helper' );
 /**
  * Inserts the Content Helper into the WordPress Post Editor.
@@ -189,22 +190,7 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\init_content_helper
  * @since 3.5.0 Moved from Parsely\Scripts\enqueue_block_editor_assets()
  */
 function init_content_helper(): void {
-	$content_helper_asset = require plugin_dir_path( PARSELY_FILE ) . 'build/content-helper.asset.php';
-
-	wp_enqueue_script(
-		'wp-parsely-block-content-helper',
-		plugin_dir_url( PARSELY_FILE ) . 'build/content-helper.js',
-		$content_helper_asset['dependencies'],
-		$content_helper_asset['version'],
-		true
-	);
-
-	wp_enqueue_style(
-		'wp-parsely-block-content-helper',
-		plugin_dir_url( PARSELY_FILE ) . 'build/content-helper.css',
-		array(),
-		$content_helper_asset['version']
-	);
+	( new Content_Helper() )->run();
 }
 
 require __DIR__ . '/src/UI/class-recommended-widget.php';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -182,6 +182,31 @@ function init_recommendations_block(): void {
 	$recommendations_block->run();
 }
 
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\init_content_helper' );
+/**
+ * Inserts the Content Helper into the WordPress Post Editor.
+ *
+ * @since 3.5.0 Moved from Parsely\Scripts\enqueue_block_editor_assets()
+ */
+function init_content_helper(): void {
+	$content_helper_asset = require plugin_dir_path( PARSELY_FILE ) . 'build/content-helper.asset.php';
+
+	wp_enqueue_script(
+		'wp-parsely-block-content-helper',
+		plugin_dir_url( PARSELY_FILE ) . 'build/content-helper.js',
+		$content_helper_asset['dependencies'],
+		$content_helper_asset['version'],
+		true
+	);
+
+	wp_enqueue_style(
+		'wp-parsely-block-content-helper',
+		plugin_dir_url( PARSELY_FILE ) . 'build/content-helper.css',
+		array(),
+		$content_helper_asset['version']
+	);
+}
+
 require __DIR__ . '/src/UI/class-recommended-widget.php';
 
 add_action( 'widgets_init', __NAMESPACE__ . '\\parsely_recommended_widget_register' );


### PR DESCRIPTION
## Description
This PR adds an `init_content_helper()` action, allowing to disable the Content Helper by invoking `remove_action()`.

I'm aware that this could be considered a breaking change. However:
- The Content Helper has been out only for a short time.
- The previous action was not adequately named and it was located in the `Script` class (which made it all that harder to use and possibly having to write bad code to access it). Someone would have to go out of their way to find the action and try to use it.
- To my knowledge, 99.99% of cases don't have a reason to disable the Content Helper.
- We needed to introduce this feature as soon as possible, and creating a major release for this would be expensive but with minimal actual user impact.

As such, I've decided to integrate it into 3.5 which will be released very soon.

## Motivation and Context
We have a specific use case where it is desirable to disable the Content Helper.

## How Has This Been Tested?
Tests pass, and an integration test has also been added as part of this PR.