### PR TITLE
Endpoint integration tests: Improve function name

### DIFF
--- a/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
@@ -64,8 +64,8 @@ final class AnalyticsPostsProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\Endpoints\Base_API_Proxy::register_endpoint
 	 * @uses \Parsely\RemoteAPI\Base_Proxy::__construct
 	 */
-	public function test_do_not_register_routes_when_related_proxy_is_disabled(): void {
-		parent::test_do_not_register_routes_when_related_proxy_is_disabled();
+	public function test_do_not_register_route_when_proxy_is_disabled(): void {
+		parent::test_do_not_register_route_when_proxy_is_disabled();
 	}
 
 	/**

--- a/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
@@ -63,8 +63,8 @@ final class RelatedProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\Endpoints\Related_API_Proxy::__construct
 	 * @uses \Parsely\RemoteAPI\Base_Proxy::__construct
 	 */
-	public function test_do_not_register_routes_when_related_proxy_is_disabled(): void {
-		parent::test_do_not_register_routes_when_related_proxy_is_disabled();
+	public function test_do_not_register_route_when_proxy_is_disabled(): void {
+		parent::test_do_not_register_route_when_proxy_is_disabled();
 	}
 
 	/**

--- a/tests/Integration/ProxyEndpointTest.php
+++ b/tests/Integration/ProxyEndpointTest.php
@@ -114,12 +114,11 @@ abstract class ProxyEndpointTest extends TestCase {
 	}
 
 	/**
-	 * Verifies that the route is not registered when the
-	 * wp_parsely_enable_related_api_proxy filter is set to false.
+	 * Verifies that the route is not registered when the respective filter is
+	 * set to false.
 	 */
-	public function test_do_not_register_routes_when_related_proxy_is_disabled(): void {
-		// Override some setup steps in order to set the
-		// wp_parsely_enable_related_api_proxy filter to false.
+	public function test_do_not_register_route_when_proxy_is_disabled(): void {
+		// Override some setup steps in order to set the filter to false.
 		remove_action( 'rest_api_init', $this->rest_api_init_proxy );
 		$endpoint                  = $this->get_endpoint();
 		$this->rest_api_init_proxy = static function () use ( $endpoint ) {


### PR DESCRIPTION
## Description
In our integration tests, this PR Changes the name of the `test_do_not_register_routes_when_related_proxy_is_disabled()` function to `test_do_not_register_route_when_proxy_is_disabled()` as this is now a generic function that does not refer specifically to the Related Proxy.

## Motivation and Context
Remove confusing function names, increase coherence.

## How Has This Been Tested?
Tests still pass 😃