### PR TITLE
Update wordpress/scripts to 23.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
 				"@wordpress/hooks": "^3.10.0",
 				"@wordpress/i18n": "^4.5.0",
 				"@wordpress/plugins": "^4.12.0",
-				"@wordpress/scripts": "^23.6.0",
+				"@wordpress/scripts": "^23.7.1",
 				"@wordpress/url": "^3.15.0",
 				"concurrently": "^7.3.0",
 				"eslint-plugin-jest": "^26.8.2",
@@ -5372,9 +5372,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "6.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-6.16.0.tgz",
-			"integrity": "sha512-QtDjThHAwMvHWL+PvK/MeB0gEvPEWJKRf24sOPv+/ccyirzYXxs3VnXMrNLmAB2YxIdplMerLoT56YSKEXTFpA==",
+			"version": "6.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-6.17.0.tgz",
+			"integrity": "sha512-mBB1KHWT2vN+maKIPYLQSxhhAzW6CNwYiJNRSNaNBALie9TULe7etrnwoZ1eqPVsuYvBlXB4XKcPaSm3/FW+qQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.16.0",
@@ -5385,8 +5385,8 @@
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/babel-plugin-import-jsx-pragma": "^3.2.0",
 				"@wordpress/browserslist-config": "^4.1.2",
-				"@wordpress/element": "^4.12.0",
-				"@wordpress/warning": "^2.14.0",
+				"@wordpress/element": "^4.13.0",
+				"@wordpress/warning": "^2.15.0",
 				"browserslist": "^4.17.6",
 				"core-js": "^3.19.1"
 			},
@@ -5894,21 +5894,34 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.12.0.tgz",
-			"integrity": "sha512-QdpqJpdspuqV5qLmoETjZB/kTVqL/wIRJrvfEXJ4ozgIrf9zQaxgiFxwImJ35oXH7HR1iRBd/YBRer/fC93oYw==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.13.0.tgz",
+			"integrity": "sha512-oxTEiK7y0bLva9SMbt/xrp90VgDMFcLSOSPz1lS8wSrC+Hy8NyN0v5rku3DdIUf07kYtcOfiQ1jmsmwDWNvodg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"@types/react": "^17.0.37",
 				"@types/react-dom": "^17.0.11",
-				"@wordpress/escape-html": "^2.14.0",
-				"lodash": "^4.17.21",
+				"@wordpress/escape-html": "^2.15.0",
+				"change-case": "^4.1.2",
+				"is-plain-obj": "^4.1.0",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2"
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/element/node_modules/is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@wordpress/env": {
@@ -6005,9 +6018,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.14.0.tgz",
-			"integrity": "sha512-y8wlJuT2ze6bf6a/vW6T1hnUxm8WD8CERYU133NpiNeQV3GJffw2tGimhasHwhN7hCfH1iPkY4od5RkclHxnRw==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.15.0.tgz",
+			"integrity": "sha512-eW655uSjCK835/eBt1lgCBtLFfgxSX4MiMTe7Dxo8pqZmP5cwh9zNJuirEnVnaamjAjfIVRel4awNGZebflJeg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -6017,15 +6030,15 @@
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "12.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-12.8.0.tgz",
-			"integrity": "sha512-Evb7ro3PzJ5hBgFLQo9GhSRYJz31AnhBelhVMr1GzNfUxqoXC34lEjx4NXjbpOfZIDboDeDL0NtbHoumkc6TVA==",
+			"version": "12.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-12.9.0.tgz",
+			"integrity": "sha512-R6dTvD4uFYeoUJFZNUhm1CSwthC0Pl0RIY057Y9oUvGSqjjm7RqRIwKrMlw3dO0P9KoBGGHUox8NUj6EciRXww==",
 			"dev": true,
 			"dependencies": {
 				"@babel/eslint-parser": "^7.16.0",
 				"@typescript-eslint/eslint-plugin": "^5.3.0",
 				"@typescript-eslint/parser": "^5.3.0",
-				"@wordpress/babel-preset-default": "^6.16.0",
+				"@wordpress/babel-preset-default": "^6.17.0",
 				"@wordpress/prettier-config": "^1.4.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
@@ -6225,9 +6238,9 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-8.5.0.tgz",
-			"integrity": "sha512-b4o82oZfHCuS0XEDrN0A/Nf2U1AIYPaqwYbkud8UEPZomxMOdtaivnZMMlo/CxW6hB9/pr75N03Lu5GZYEEzhw==",
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-8.5.1.tgz",
+			"integrity": "sha512-p84ILJvXxoLr6mAJra3tCtMYNCqcscU+XyuoDy3pro9zVDGFLbWLc6nw0TCQRPvRD5HvK3VGmcLB74ZsiYM0Bg==",
 			"dev": true,
 			"dependencies": {
 				"@wojtekmaj/enzyme-adapter-react-17": "^0.6.1",
@@ -6489,19 +6502,19 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-23.6.0.tgz",
-			"integrity": "sha512-Phcr4E4OjerLJG2eEa6zrBrX9vm3W/qmAZOEKDHmNzJFdWGnGljTLv+Or6C4yKCLJWo1wd3cslfgFct5nOWgPg==",
+			"version": "23.7.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-23.7.1.tgz",
+			"integrity": "sha512-KllePk/QAJo0X6Vp5pkXv2CzCRjo1fIJ60mdd28gP0W7iG+ncw+SGSEWbXOjSInQHzq/FnZf2RkkKWsu//2c8A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.16.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
 				"@svgr/webpack": "^6.2.1",
-				"@wordpress/babel-preset-default": "^6.16.0",
+				"@wordpress/babel-preset-default": "^6.17.0",
 				"@wordpress/browserslist-config": "^4.1.2",
 				"@wordpress/dependency-extraction-webpack-plugin": "^3.7.0",
-				"@wordpress/eslint-plugin": "^12.8.0",
-				"@wordpress/jest-preset-default": "^8.5.0",
+				"@wordpress/eslint-plugin": "^12.9.0",
+				"@wordpress/jest-preset-default": "^8.5.1",
 				"@wordpress/npm-package-json-lint-config": "^4.1.2",
 				"@wordpress/postcss-plugins-preset": "^3.10.0",
 				"@wordpress/prettier-config": "^1.4.0",
@@ -6760,9 +6773,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.14.0.tgz",
-			"integrity": "sha512-qlfSTGkS6ei366OEPNe54DG0O3D/Ta1d4Xalx8Crgxm8xygncuxuuefWKAnnwgXfzsO4d4gs29hnTEzIMIaGcA==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.15.0.tgz",
+			"integrity": "sha512-EXYraHE0g/w5ECWDmHQcUsvUhs+ksH44Ts67SWXDCLe8Rbz+Fwoeqkuq+nhpI+NnCWUbCpYGAAO3QRkgrL7TFQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -27044,9 +27057,9 @@
 			"requires": {}
 		},
 		"@wordpress/babel-preset-default": {
-			"version": "6.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-6.16.0.tgz",
-			"integrity": "sha512-QtDjThHAwMvHWL+PvK/MeB0gEvPEWJKRf24sOPv+/ccyirzYXxs3VnXMrNLmAB2YxIdplMerLoT56YSKEXTFpA==",
+			"version": "6.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-6.17.0.tgz",
+			"integrity": "sha512-mBB1KHWT2vN+maKIPYLQSxhhAzW6CNwYiJNRSNaNBALie9TULe7etrnwoZ1eqPVsuYvBlXB4XKcPaSm3/FW+qQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.16.0",
@@ -27057,8 +27070,8 @@
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/babel-plugin-import-jsx-pragma": "^3.2.0",
 				"@wordpress/browserslist-config": "^4.1.2",
-				"@wordpress/element": "^4.12.0",
-				"@wordpress/warning": "^2.14.0",
+				"@wordpress/element": "^4.13.0",
+				"@wordpress/warning": "^2.15.0",
 				"browserslist": "^4.17.6",
 				"core-js": "^3.19.1"
 			}
@@ -27470,18 +27483,27 @@
 			}
 		},
 		"@wordpress/element": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.12.0.tgz",
-			"integrity": "sha512-QdpqJpdspuqV5qLmoETjZB/kTVqL/wIRJrvfEXJ4ozgIrf9zQaxgiFxwImJ35oXH7HR1iRBd/YBRer/fC93oYw==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.13.0.tgz",
+			"integrity": "sha512-oxTEiK7y0bLva9SMbt/xrp90VgDMFcLSOSPz1lS8wSrC+Hy8NyN0v5rku3DdIUf07kYtcOfiQ1jmsmwDWNvodg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0",
 				"@types/react": "^17.0.37",
 				"@types/react-dom": "^17.0.11",
-				"@wordpress/escape-html": "^2.14.0",
-				"lodash": "^4.17.21",
+				"@wordpress/escape-html": "^2.15.0",
+				"change-case": "^4.1.2",
+				"is-plain-obj": "^4.1.0",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2"
+			},
+			"dependencies": {
+				"is-plain-obj": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+					"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/env": {
@@ -27556,24 +27578,24 @@
 			}
 		},
 		"@wordpress/escape-html": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.14.0.tgz",
-			"integrity": "sha512-y8wlJuT2ze6bf6a/vW6T1hnUxm8WD8CERYU133NpiNeQV3GJffw2tGimhasHwhN7hCfH1iPkY4od5RkclHxnRw==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.15.0.tgz",
+			"integrity": "sha512-eW655uSjCK835/eBt1lgCBtLFfgxSX4MiMTe7Dxo8pqZmP5cwh9zNJuirEnVnaamjAjfIVRel4awNGZebflJeg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0"
 			}
 		},
 		"@wordpress/eslint-plugin": {
-			"version": "12.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-12.8.0.tgz",
-			"integrity": "sha512-Evb7ro3PzJ5hBgFLQo9GhSRYJz31AnhBelhVMr1GzNfUxqoXC34lEjx4NXjbpOfZIDboDeDL0NtbHoumkc6TVA==",
+			"version": "12.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-12.9.0.tgz",
+			"integrity": "sha512-R6dTvD4uFYeoUJFZNUhm1CSwthC0Pl0RIY057Y9oUvGSqjjm7RqRIwKrMlw3dO0P9KoBGGHUox8NUj6EciRXww==",
 			"dev": true,
 			"requires": {
 				"@babel/eslint-parser": "^7.16.0",
 				"@typescript-eslint/eslint-plugin": "^5.3.0",
 				"@typescript-eslint/parser": "^5.3.0",
-				"@wordpress/babel-preset-default": "^6.16.0",
+				"@wordpress/babel-preset-default": "^6.17.0",
 				"@wordpress/prettier-config": "^1.4.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
@@ -27699,9 +27721,9 @@
 			}
 		},
 		"@wordpress/jest-preset-default": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-8.5.0.tgz",
-			"integrity": "sha512-b4o82oZfHCuS0XEDrN0A/Nf2U1AIYPaqwYbkud8UEPZomxMOdtaivnZMMlo/CxW6hB9/pr75N03Lu5GZYEEzhw==",
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-8.5.1.tgz",
+			"integrity": "sha512-p84ILJvXxoLr6mAJra3tCtMYNCqcscU+XyuoDy3pro9zVDGFLbWLc6nw0TCQRPvRD5HvK3VGmcLB74ZsiYM0Bg==",
 			"dev": true,
 			"requires": {
 				"@wojtekmaj/enzyme-adapter-react-17": "^0.6.1",
@@ -27882,19 +27904,19 @@
 			}
 		},
 		"@wordpress/scripts": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-23.6.0.tgz",
-			"integrity": "sha512-Phcr4E4OjerLJG2eEa6zrBrX9vm3W/qmAZOEKDHmNzJFdWGnGljTLv+Or6C4yKCLJWo1wd3cslfgFct5nOWgPg==",
+			"version": "23.7.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-23.7.1.tgz",
+			"integrity": "sha512-KllePk/QAJo0X6Vp5pkXv2CzCRjo1fIJ60mdd28gP0W7iG+ncw+SGSEWbXOjSInQHzq/FnZf2RkkKWsu//2c8A==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.16.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
 				"@svgr/webpack": "^6.2.1",
-				"@wordpress/babel-preset-default": "^6.16.0",
+				"@wordpress/babel-preset-default": "^6.17.0",
 				"@wordpress/browserslist-config": "^4.1.2",
 				"@wordpress/dependency-extraction-webpack-plugin": "^3.7.0",
-				"@wordpress/eslint-plugin": "^12.8.0",
-				"@wordpress/jest-preset-default": "^8.5.0",
+				"@wordpress/eslint-plugin": "^12.9.0",
+				"@wordpress/jest-preset-default": "^8.5.1",
 				"@wordpress/npm-package-json-lint-config": "^4.1.2",
 				"@wordpress/postcss-plugins-preset": "^3.10.0",
 				"@wordpress/prettier-config": "^1.4.0",
@@ -28082,9 +28104,9 @@
 			}
 		},
 		"@wordpress/warning": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.14.0.tgz",
-			"integrity": "sha512-qlfSTGkS6ei366OEPNe54DG0O3D/Ta1d4Xalx8Crgxm8xygncuxuuefWKAnnwgXfzsO4d4gs29hnTEzIMIaGcA==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.15.0.tgz",
+			"integrity": "sha512-EXYraHE0g/w5ECWDmHQcUsvUhs+ksH44Ts67SWXDCLe8Rbz+Fwoeqkuq+nhpI+NnCWUbCpYGAAO3QRkgrL7TFQ==",
 			"dev": true
 		},
 		"@wordpress/wordcount": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"@wordpress/hooks": "^3.10.0",
 		"@wordpress/i18n": "^4.5.0",
 		"@wordpress/plugins": "^4.12.0",
-		"@wordpress/scripts": "^23.6.0",
+		"@wordpress/scripts": "^23.7.1",
 		"@wordpress/url": "^3.15.0",
 		"concurrently": "^7.3.0",
 		"eslint-plugin-jest": "^26.8.2",


### PR DESCRIPTION
## Description
We've stumbled upon [this issue](https://github.com/WordPress/gutenberg/issues/43132), which results in failing tests in our PRs. This PR attempts to fix this by updating `wordpress/scripts` to 23.7.1.

## Motivation and Context


## How Has This Been Tested?

