### PR TITLE
Metadata Author Archive Builder: Add support for the Co-Authors Plus plugin

### DIFF
--- a/src/Metadata/class-author-archive-builder.php
+++ b/src/Metadata/class-author-archive-builder.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace Parsely\Metadata;
 
+use WP_User;
+
 /**
  * Implements abstract Metadata Builder class to generate the metadata array
  * for an author archive page.
@@ -34,13 +36,54 @@ class Author_Archive_Builder extends Metadata_Builder {
 	}
 
 	/**
-	 * Populates the `headline` field in the metadata object.
+	 * Populates the `headline` field in the metadata object. Integrates with
+	 * the Co-Authors Plus plugin if it is installed and activated.
 	 *
 	 * @since 3.4.0
 	 */
 	private function build_headline(): void {
-		$author = ( get_query_var( 'author_name' ) ) ? get_user_by( 'slug', get_query_var( 'author_name' ) ) : get_userdata( get_query_var( 'author' ) );
-		/* translators: %s: Author name. */
-		$this->metadata['headline'] = $this->clean_value( sprintf( __( 'Author - %s', 'wp-parsely' ), $author->data->display_name ) );
+		// Use the author's username as a display name fallback.
+		$author_username     = get_query_var( 'author_name' );
+		$author_display_name = $author_username;
+
+		// Attempt to get the author from the Co-Authors Plus plugin or from
+		// WordPress core if this fails.
+		$author = $this->get_display_name_from_coauthors( $author_username );
+		if ( false === $author ) {
+			$author = get_user_by( 'slug', $author_username );
+			if ( false === $author ) {
+				$author = get_userdata( get_query_var( 'author' ) );
+			}
+		}
+
+		// Set the display name and populate the metadata.
+		if ( true === is_object( $author ) && isset( $author->display_name ) ) {
+			$author_display_name = $author->display_name;
+		}
+		$this->metadata['headline'] = $this->clean_value(
+			/* translators: %s: Author name. */
+			sprintf( __( 'Author - %s', 'wp-parsely' ), $author_display_name )
+		);
+	}
+
+	/**
+	 * Returns the author's display name using the Co-Authors Plus plugin when
+	 * it is installed and activated.
+	 *
+	 * Note: The object that gets returned for Guest Authors is not of the
+	 * `WP_User` type, but it contains a display_name property.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @param string $author_username The author's username.
+	 * @return WP_User|stdClass|false The object or false on failure.
+	 */
+	private function get_display_name_from_coauthors( string $author_username ) {
+		if ( class_exists( 'coauthors_plus' ) ) {
+			global $coauthors_plus;
+			return $coauthors_plus->get_coauthor_by( 'user_nicename', $author_username );
+		}
+
+		return false;
 	}
 }

--- a/tests/Integration/Metadata/AuthorArchiveTest.php
+++ b/tests/Integration/Metadata/AuthorArchiveTest.php
@@ -27,6 +27,7 @@ final class AuthorArchiveTest extends NonPostTestCase {
 	 * @covers \Parsely\Metadata::construct_metadata
 	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
 	 * @uses \Parsely\Metadata\Author_Archive_Builder::build_headline
+	 * @uses \Parsely\Metadata\Author_Archive_Builder::get_display_name_from_coauthors
 	 * @uses \Parsely\Metadata\Author_Archive_Builder::get_metadata
 	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
 	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic


### PR DESCRIPTION
## Description
We recently got a bug report about the plugin generating PHP 8 warnings, but from what I could tell this was probably due to our `Author_Archive_Builder` class not supporting the [Co-Authors Plus](https://github.com/Automattic/Co-Authors-Plus) plugin.

In this PR:
- We're adding support for the [Co-Authors Plus](https://github.com/Automattic/Co-Authors-Plus) plugin in our `Author_Archive_Builder` class.
- We make the class more resistant/flexible to things that could go wrong.
- If everything else fails, we use the author's username in the metadata. Previously, we would have an empty string, resulting in `Author -` metadata which was not helpful.

Credit: Thanks to @GaryJones for conducting the initial debugging investigation.

## Motivation and Context
- Support the Co-Authors Plus plugin properly.
- Improve problematic/incomplete metadata that can be an issue for our users.

## How Has This Been Tested?
Manual local testing was conducted, including:
- Testing with the Co-Authors Plus plugin disabled.
- Testing with the Co-Authors Plus plugin enabled:
  - Multiple authors (WP Users)
  - Multiple authors (Guest Authors)
  - `add_filter( 'coauthors_guest_authors_force', '__return_true' );`
  - `add_filter( 'coauthors_guest_authors_enabled', '__return_false' );`