### PR TITLE
Add composer phpcbf script for automatically fixing PHPCS errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,12 @@ To check your code with our code standards:
 composer cs
 ```
 
+To fix automatically fixable code based on our coding standards:
+
+```
+composer cbf
+```
+
 #### Testing
 
 **Note:** For the tests to install, the `svn` command is needed. To get it, you can install subversion (`brew install subversion` if you're using brew).

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,9 @@
 		"cs": [
 			"@php ./vendor/bin/phpcs --severity=1"
 		],
+		"cbf": [
+			"@php ./vendor/bin/phpcbf"
+		],
 		"lint": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
 		],
@@ -101,6 +104,7 @@
 		"coveragewp": "Run integration tests with code coverage for the Parse.ly plugin, send results to stdout, and generate local HTML output.",
 		"coveragewp-ci": "Run integration tests with code coverage for the Parse.ly plugin and send results to stdout.",
 		"cs": "Run PHPCS to checking coding standards for the Parse.ly plugin.",
+		"cbf": "Run PHPCBF to fix code based on coding standards for the Parse.ly plugin.",
 		"lint": "Run PHP linting on the Parse.ly plugin.",
 		"lint-ci": "Run PHP linting on the Parse.ly plugin with checkstyle output for CI.",
 		"prepare-ci": "Install the files and setup a database needed to run tests for the Parse.ly plugin for CI.",


### PR DESCRIPTION
## Description
Adds `composer cbf` script which uses PHPCBF to fix the auto fixable errors reported by PHPCS

## Motivation and Context
- We do have `composer cs` script but none for auto fixing the reported errors so added one.

## How Has This Been Tested?
- Just introduces some phpcs error and then run the `composer cbf` script manually
