### PR TITLE
Integration Tests: Replace the deprecated this->factory with self::factory()

### DIFF
--- a/tests/Integration/Metadata/SinglePostTest.php
+++ b/tests/Integration/Metadata/SinglePostTest.php
@@ -663,7 +663,7 @@ final class SinglePostTest extends TestCase {
 		$parsely = new Parsely();
 
 		// Create a single post.
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
 		unset( $post->post_date );
@@ -717,7 +717,7 @@ final class SinglePostTest extends TestCase {
 		$parsely = new Parsely();
 
 		// Create the post.
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
 		// Annotate it with the timestamps to test against.
@@ -777,7 +777,7 @@ final class SinglePostTest extends TestCase {
 		$parsely = new Parsely();
 
 		// Create the post.
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
 		// Annotate it with the timestamps to test against.
@@ -837,7 +837,7 @@ final class SinglePostTest extends TestCase {
 		$parsely = new Parsely();
 
 		// Create the post.
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
 		// Annotate it with the timestamps to test against.

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -92,7 +92,7 @@ final class OtherTest extends TestCase {
 		$parsely = new Parsely();
 
 		// Create a single post.
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
 		// Apply page filtering.
@@ -236,7 +236,7 @@ final class OtherTest extends TestCase {
 	 * @covers \Parsely\Parsely::post_has_trackable_status
 	 */
 	public function test_post_has_trackable_status_password_protected(): void {
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
 		$post->post_password = 'somepassword';
@@ -256,7 +256,7 @@ final class OtherTest extends TestCase {
 	public function test_post_has_trackable_status_password_protected_with_filter(): void {
 		add_filter( 'wp_parsely_skip_post_password_check', '__return_true' );
 
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
 		$post->post_password = 'somepassword';

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -89,7 +89,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 *                        WP_Error otherwise.
 	 */
 	public function create_test_category( string $name ) {
-		return $this->factory->category->create(
+		return self::factory()->category->create(
 			array(
 				'name'                 => $name,
 				'category_description' => $name,
@@ -107,7 +107,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 *                      if the user could not be created.
 	 */
 	public function create_test_user( string $user_login ) {
-		return $this->factory->user->create( array( 'user_login' => $user_login ) );
+		return self::factory()->user->create( array( 'user_login' => $user_login ) );
 	}
 
 	/**
@@ -119,7 +119,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * @return int|WP_Error The site ID on success, WP_Error object on failure.
 	 */
 	public function create_test_blog( string $domain, int $user_id ) {
-		return $this->factory->blog->create(
+		return self::factory()->blog->create(
 			array(
 				'domain'  => 'https://' . $domain . 'com',
 				'user_id' => $user_id,
@@ -145,7 +145,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 			)
 		);
 
-		return $this->factory->term->create(
+		return self::factory()->term->create(
 			array(
 				'name'     => $term_name,
 				'taxonomy' => $taxonomy_key,
@@ -160,7 +160,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 */
 	public function go_to_new_post(): int {
 		$post_data = $this->create_test_post_array();
-		$post_id   = $this->factory->post->create( $post_data );
+		$post_id   = self::factory()->post->create( $post_data );
 		$this->go_to( '/?p=' . $post_id );
 
 		return $post_id;

--- a/tests/Integration/UI/NetworkAdminSitesListTest.php
+++ b/tests/Integration/UI/NetworkAdminSitesListTest.php
@@ -77,10 +77,10 @@ final class NetworkAdminSitesListTest extends TestCase {
 	 * @uses \Parsely\UI\Network_Admin_Sites_List::__construct
 	 */
 	public function test_api_key_column_is_correctly_printed(): void {
-		$blog_id_with_api_key = $this->factory->blog->create();
+		$blog_id_with_api_key = self::factory()->blog->create();
 
 		// Create a blog without a Site ID.
-		$this->factory->blog->create();
+		self::factory()->blog->create();
 
 		self::$sites_list->run();
 

--- a/tests/Integration/UI/SettingsPageTest.php
+++ b/tests/Integration/UI/SettingsPageTest.php
@@ -209,7 +209,7 @@ final class SettingsPageTest extends TestCase {
 			return;
 		}
 
-		$subsite_blog_id = $this->factory->blog->create(
+		$subsite_blog_id = self::factory()->blog->create(
 			array(
 				'domain' => 'parselyrocks.example.org',
 				'path'   => '/vipvipvip',


### PR DESCRIPTION
## Description
Closes: #1121 

The use of the non-static property of `$this->factory->`... in integration tests is deprecated. See https://core.trac.wordpress.org/changeset/54087. The use of the static method `self::factory()->`... is the correct approach.

## How Has This Been Tested?
- Replaced the method and verified that after changes all tests are passing successfully.