### PR TITLE
Avoid tracking page views when post is opened in preview mode

### DIFF
--- a/src/class-scripts.php
+++ b/src/class-scripts.php
@@ -78,6 +78,10 @@ class Scripts {
 	 * @since 3.0.0 Rename from load_js_tracker
 	 */
 	public function enqueue_js_tracker(): void {
+		if ( is_preview() ) {
+			return;
+		}
+
 		$parsely_options = $this->parsely->get_options();
 
 		global $post;

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -207,14 +207,12 @@ final class ScriptsTest extends TestCase {
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 
-		// Verify that tracker script is registered and enqueued.
 		$this->assert_script_statuses(
 			'wp-parsely-tracker',
 			array( 'registered' ),
 			array( 'enqueued' )
 		);
 
-		// Verify that loader script is registered and enqueued.
 		$this->assert_script_statuses(
 			'wp-parsely-loader',
 			array( 'registered' ),
@@ -245,14 +243,12 @@ final class ScriptsTest extends TestCase {
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 
-		// Verify that tracker script is registered and enqueued.
 		$this->assert_script_statuses(
 			'wp-parsely-tracker',
 			array( 'registered' ),
 			array( 'enqueued' )
 		);
 
-		// Verify that loader script is registered and enqueued.
 		$this->assert_script_statuses(
 			'wp-parsely-loader',
 			array( 'registered' ),

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -187,6 +187,80 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
+	 * Verifies that tracker scripts are not loading for drafted posts
+	 *
+	 * @covers \Parsely\Scripts::enqueue_js_tracker
+	 *
+	 * @uses Parsely\Parsely::api_key_is_set
+	 * @uses Parsely\Parsely::get_api_key
+	 * @uses Parsely\Parsely::get_options
+	 * @uses Parsely\Parsely::get_tracker_url
+	 * @uses Parsely\Scripts::__construct
+	 * @uses Parsely\Scripts::register_scripts
+	 *
+	 * @group scripts
+	 */
+	public function test_should_not_enqueue_tracker_scripts_for_drafted_posts(): void {
+		$this->set_admin_user();
+		$this->go_to_new_post( 'draft' );
+		
+		self::$scripts->register_scripts();
+		self::$scripts->enqueue_js_tracker();
+
+		// Verify that tracker script is registered and enqueued.
+		$this->assert_script_statuses(
+			'wp-parsely-tracker',
+			array( 'registered' ),
+			array( 'enqueued' )
+		);
+
+		// Verify that loader script is registered and enqueued.
+		$this->assert_script_statuses(
+			'wp-parsely-loader',
+			array( 'registered' ),
+			array( 'enqueued' )
+		);
+	}
+
+	/**
+	 * Verifies that tracker scripts are not loading for published posts in preview mode
+	 *
+	 * @covers \Parsely\Scripts::enqueue_js_tracker
+	 *
+	 * @uses Parsely\Parsely::api_key_is_set
+	 * @uses Parsely\Parsely::get_api_key
+	 * @uses Parsely\Parsely::get_options
+	 * @uses Parsely\Parsely::get_tracker_url
+	 * @uses Parsely\Scripts::__construct
+	 * @uses Parsely\Scripts::register_scripts
+	 *
+	 * @group scripts
+	 */
+	public function test_should_not_enqueue_tracker_scripts_for_published_posts_in_preview_mode(): void {
+		$post_id = $this->create_test_post();
+
+		$this->set_admin_user();
+		$this->go_to( "/?p={$post_id}&preview=true" );
+		
+		self::$scripts->register_scripts();
+		self::$scripts->enqueue_js_tracker();
+
+		// Verify that tracker script is registered and enqueued.
+		$this->assert_script_statuses(
+			'wp-parsely-tracker',
+			array( 'registered' ),
+			array( 'enqueued' )
+		);
+
+		// Verify that loader script is registered and enqueued.
+		$this->assert_script_statuses(
+			'wp-parsely-loader',
+			array( 'registered' ),
+			array( 'enqueued' )
+		);
+	}
+
+	/**
 	 * Verifies that tracker enqueuing functionality works as expected when the
 	 * autotrack option is disabled.
 	 *

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -187,7 +187,7 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
-	 * Verifies that tracker scripts are not loading for drafted posts
+	 * Verifies that tracker scripts are not loading for drafted posts.
 	 *
 	 * @covers \Parsely\Scripts::enqueue_js_tracker
 	 *
@@ -221,7 +221,7 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
-	 * Verifies that tracker scripts are not loading for published posts in preview mode
+	 * Verifies that tracker scripts are not loading for published posts in preview mode.
 	 *
 	 * @covers \Parsely\Scripts::enqueue_js_tracker
 	 *

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -155,7 +155,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 	}
 
 	/**
-	 * Creates a new post
+	 * Creates a new post.
 	 *
 	 * @param string $post_status Optional. The post's status. Default is 'publish'.
 	 *
@@ -183,7 +183,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 	}
 
 	/**
-	 * Set current user as admin
+	 * Sets current user as admin.
 	 *
 	 * @param int $admin_user_id User ID for the site administrator.
 	 *                           Default is 1 which is assigned to first admin user while creating the site.

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -68,15 +68,16 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * Creates a test post.
 	 *
 	 * @param string $post_type Optional. The post's type. Default is 'post'.
+	 * @param string $post_status Optional. The post's status. Default is 'publish'.
 	 *
 	 * @return array An array of WP_Post fields.
 	 */
-	public function create_test_post_array( string $post_type = 'post' ): array {
+	public function create_test_post_array( string $post_type = 'post', string $post_status = 'publish' ): array {
 		return array(
 			'post_title'   => 'Sample Parsely Post',
 			'post_author'  => 1,
 			'post_content' => 'Some sample content just to have here',
-			'post_status'  => 'publish',
+			'post_status'  => $post_status,
 			'post_type'    => $post_type,
 		);
 	}
@@ -154,15 +155,42 @@ abstract class TestCase extends WPIntegrationTestCase {
 	}
 
 	/**
-	 * Creates a new post and navigates to it.
+	 * Creates a new post
+	 *
+	 * @param string $post_status Optional. The post's status. Default is 'publish'.
 	 *
 	 * @return int The new post's ID.
 	 */
-	public function go_to_new_post(): int {
-		$post_data = $this->create_test_post_array();
+	public function create_test_post( string $post_status = 'publish' ): int {
+		$post_data = $this->create_test_post_array( 'post', $post_status );
 		$post_id   = self::factory()->post->create( $post_data );
+
+		return $post_id;
+	}
+
+	/**
+	 * Creates a new post and navigates to it.
+	 *
+	 * @param string $post_status Optional. The post's status. Default is 'publish'.
+	 *
+	 * @return int The new post's ID.
+	 */
+	public function go_to_new_post( string $post_status = 'publish' ): int {
+		$post_id = $this->create_test_post( $post_status );
 		$this->go_to( '/?p=' . $post_id );
 
 		return $post_id;
+	}
+
+	/**
+	 * Set current user as admin
+	 *
+	 * @param int $admin_user_id User ID for the site administrator.
+	 *                           Default is 1 which is assigned to first admin user while creating the site.
+	 *
+	 * @return void
+	 */
+	public function set_admin_user( $admin_user_id = 1 ): void {
+		wp_set_current_user( $admin_user_id );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When published post is opened in preview mode then we were counting it as page viewed on Parsely so now we fixed it and don't count the posts opened in preview mode.

Closes: #1155 

## How Has This Been Tested?
1. Added integration tests
2. Tested manually
