### PR TITLE
README.md: Remove minor version from "Tested up to"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Stable tag: 3.5.2  
 Requires at least: 5.0  
-Tested up to: 6.1.0  
+Tested up to: 6.1  
 Requires PHP: 7.1  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  


### PR DESCRIPTION
## Description
This PR removes the minor version from the "Tested up to" field within the README.md, as it is not needed and only introduces complexity. This is recommended by the [Plugin Readmes Documentation](https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/).

Thanks to @GaryJones for bringing this to my attention.

## Motivation and Context
- Reduce unneeded PRs.
- Follow best practices.

## How Has This Been Tested?
No code changes.
