### PR TITLE
Refactoring: Add helper methods to check script statuses

### DIFF
--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -487,7 +487,7 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
-	 * Assert that a passed script is not registered.
+	 * Asserts that a passed script is not registered.
 	 *
 	 * @param string $handle Script handle to test.
 	 */
@@ -496,7 +496,7 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
-	 * Assert that a passed script is registered.
+	 * Asserts that a passed script is registered.
 	 *
 	 * @param string $handle Script handle to test.
 	 */
@@ -505,7 +505,7 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
-	 * Assert that a passed script is not enqueued.
+	 * Asserts that a passed script is not enqueued.
 	 *
 	 * @param string $handle Script handle to test.
 	 */
@@ -514,7 +514,7 @@ final class ScriptsTest extends TestCase {
 	}
 
 	/**
-	 * Assert that a passed script is enqueued.
+	 * Asserts that a passed script is enqueued.
 	 *
 	 * @param string $handle Script handle to test.
 	 */

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -116,34 +116,16 @@ final class ScriptsTest extends TestCase {
 	 * @group scripts
 	 */
 	public function test_parsely_register_scripts(): void {
+		$this->assert_is_script_not_registered( 'wp-parsely-loader' );
+		$this->assert_is_script_not_registered( 'wp-parsely-tracker' );
 
-		// Verify that API and tracker scripts are not registered.
-		$this->assert_script_statuses(
-			'wp-parsely-loader',
-			array(),
-			array( 'registered' )
-		);
-		$this->assert_script_statuses(
-			'wp-parsely-tracker',
-			array(),
-			array( 'registered' )
-		);
-
-		// Attempt to register API and tracker scripts.
 		self::$scripts->register_scripts();
 
-		// Verify that API and tracker scripts are now registered (but not yet
-		// enqueued).
-		$this->assert_script_statuses(
-			'wp-parsely-loader',
-			array( 'registered' ),
-			array( 'enqueued' )
-		);
-		$this->assert_script_statuses(
-			'wp-parsely-tracker',
-			array( 'registered' ),
-			array( 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-loader' );
+		$this->assert_is_script_not_enqueued( 'wp-parsely-loader' );
+
+		$this->assert_is_script_registered( 'wp-parsely-tracker' );
+		$this->assert_is_script_not_enqueued( 'wp-parsely-tracker' );
 	}
 
 	/**
@@ -169,17 +151,11 @@ final class ScriptsTest extends TestCase {
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 
-		// Verify that tracker script is registered and enqueued.
-		$this->assert_script_statuses(
-			'wp-parsely-tracker',
-			array( 'registered', 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-tracker' );
+		$this->assert_is_script_enqueued( 'wp-parsely-tracker' );
 
-		// Verify that loader script is registered and enqueued.
-		$this->assert_script_statuses(
-			'wp-parsely-loader',
-			array( 'registered', 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-loader' );
+		$this->assert_is_script_enqueued( 'wp-parsely-loader' );
 
 		// Since no secret is provided, the extra fields (inline scripts) on the
 		// loader should not be populated.
@@ -207,17 +183,11 @@ final class ScriptsTest extends TestCase {
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 
-		$this->assert_script_statuses(
-			'wp-parsely-tracker',
-			array( 'registered' ),
-			array( 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-tracker' );
+		$this->assert_is_script_not_enqueued( 'wp-parsely-tracker' );
 
-		$this->assert_script_statuses(
-			'wp-parsely-loader',
-			array( 'registered' ),
-			array( 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-loader' );
+		$this->assert_is_script_not_enqueued( 'wp-parsely-loader' );
 	}
 
 	/**
@@ -243,17 +213,11 @@ final class ScriptsTest extends TestCase {
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 
-		$this->assert_script_statuses(
-			'wp-parsely-tracker',
-			array( 'registered' ),
-			array( 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-tracker' );
+		$this->assert_is_script_not_enqueued( 'wp-parsely-tracker' );
 
-		$this->assert_script_statuses(
-			'wp-parsely-loader',
-			array( 'registered' ),
-			array( 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-loader' );
+		$this->assert_is_script_not_enqueued( 'wp-parsely-loader' );
 	}
 
 	/**
@@ -282,17 +246,11 @@ final class ScriptsTest extends TestCase {
 		self::$scripts->register_scripts();
 		self::$scripts->enqueue_js_tracker();
 
-		// Verify that tracker script is registered and enqueued.
-		$this->assert_script_statuses(
-			'wp-parsely-tracker',
-			array( 'registered', 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-tracker' );
+		$this->assert_is_script_enqueued( 'wp-parsely-tracker' );
 
-		// Verify that loader script is registered and enqueued.
-		$this->assert_script_statuses(
-			'wp-parsely-loader',
-			array( 'registered', 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-loader' );
+		$this->assert_is_script_enqueued( 'wp-parsely-loader' );
 
 		// Since no secret is provided, the extra fields (inline scripts) on the
 		// loader should not be populated.
@@ -325,19 +283,13 @@ final class ScriptsTest extends TestCase {
 
 		// Since wp_parsely_load_js_tracker is set to false, enqueuing should
 		// fail. Verify that tracker script is registered but not enqueued.
-		$this->assert_script_statuses(
-			'wp-parsely-tracker',
-			array( 'registered' ),
-			array( 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-tracker' );
+		$this->assert_is_script_not_enqueued( 'wp-parsely-tracker' );
 
 		// Since no secret is provided, enqueuing should fail. Verify that API
 		// script is registered but not enqueued.
-		$this->assert_script_statuses(
-			'wp-parsely-loader',
-			array( 'registered' ),
-			array( 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-loader' );
+		$this->assert_is_script_not_enqueued( 'wp-parsely-loader' );
 
 		// Since no secret is provided, the extra fields (inline scripts) on the
 		// loader should not be populated.
@@ -369,11 +321,8 @@ final class ScriptsTest extends TestCase {
 		self::set_options( array( 'api_secret' => 'hunter2' ) );
 		self::$scripts->enqueue_js_tracker();
 
-		// Verify that API script is registered and enqueued.
-		$this->assert_script_statuses(
-			'wp-parsely-tracker',
-			array( 'registered', 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-tracker' );
+		$this->assert_is_script_enqueued( 'wp-parsely-tracker' );
 
 		// The variable should be inlined before the script.
 		self::assertEquals( "window.wpParselyApiKey = 'blog.parsely.com';", $wp_scripts->registered['wp-parsely-loader']->extra['before'][1] );
@@ -410,18 +359,12 @@ final class ScriptsTest extends TestCase {
 
 		// As track_authenticated_users options is false, enqueuing should fail.
 		// Verify that tracker script is registered but not enqueued.
-		$this->assert_script_statuses(
-			'wp-parsely-tracker',
-			array( 'registered' ),
-			array( 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-tracker' );
+		$this->assert_is_script_not_enqueued( 'wp-parsely-tracker' );
 
 		// Verify that API script is registered but not enqueued.
-		$this->assert_script_statuses(
-			'wp-parsely-loader',
-			array( 'registered' ),
-			array( 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-loader' );
+		$this->assert_is_script_not_enqueued( 'wp-parsely-loader' );
 	}
 
 	/**
@@ -481,11 +424,8 @@ final class ScriptsTest extends TestCase {
 		// Current user is logged-in and track_authenticated_users is false so
 		// enqueuing should fail. Verify that tracker script is registered but
 		// not enqueued.
-		$this->assert_script_statuses(
-			'wp-parsely-tracker',
-			array( 'registered' ),
-			array( 'enqueued' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-tracker' );
+		$this->assert_is_script_not_enqueued( 'wp-parsely-tracker' );
 
 		// -- Test second blog.
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
@@ -505,10 +445,8 @@ final class ScriptsTest extends TestCase {
 		// First user is not logged-in to the second blog, so
 		// track_authenticated_users value is irrelevant. Verify that tracker
 		// script is registered and enqueued.
-		$this->assert_script_statuses(
-			'wp-parsely-tracker',
-			array( 'enqueued', 'registered' )
-		);
+		$this->assert_is_script_registered( 'wp-parsely-tracker' );
+		$this->assert_is_script_enqueued( 'wp-parsely-tracker' );
 	}
 
 	/**
@@ -546,6 +484,42 @@ final class ScriptsTest extends TestCase {
 		self::assertStringContainsString( "<script data-cfasync=\"false\" type='text/javascript' src='http://example.org/wp-content/plugins/wp-parsely/tests/Integration/../../build/loader.js?ver=" . $loader_asset['version'] . "' id='wp-parsely-loader-js'></script>", $output );
 		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		self::assertStringContainsString( "<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=123456.78.9' id=\"parsely-cfg\"></script>", $output );
+	}
+
+	/**
+	 * Assert that a passed script is not registered.
+	 *
+	 * @param string $handle Script handle to test.
+	 */
+	private function assert_is_script_not_registered( string $handle ): void {
+		$this->assert_script_statuses( $handle, array(), array( 'registered' ) );
+	}
+
+	/**
+	 * Assert that a passed script is registered.
+	 *
+	 * @param string $handle Script handle to test.
+	 */
+	private function assert_is_script_registered( string $handle ): void {
+		$this->assert_script_statuses( $handle, array( 'registered' ) );
+	}
+
+	/**
+	 * Assert that a passed script is not enqueued.
+	 *
+	 * @param string $handle Script handle to test.
+	 */
+	private function assert_is_script_not_enqueued( string $handle ): void {
+		$this->assert_script_statuses( $handle, array(), array( 'enqueued' ) );
+	}
+
+	/**
+	 * Assert that a passed script is enqueued.
+	 *
+	 * @param string $handle Script handle to test.
+	 */
+	private function assert_is_script_enqueued( string $handle ): void {
+		$this->assert_script_statuses( $handle, array( 'enqueued' ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Got feedback [in PR](https://github.com/Parsely/wp-parsely/pull/1195/files/c58c2bfb4e8997b5512db34b74fe15b995de5c6b#diff-46257bda62fcf99c7041d9c0f9e3ad1d678d0ea6e1644e0754f2732d263655d1R214) that the current usage of `assert_script_statuses` function in tests seems confusing and readability is also hard so refactors the method by adding helper methods which are easy to read and understand.

## How Has This Been Tested?
- Ran current unit tests after refactoring.
