### PR TITLE
Integration Tests: Fix flaky tests related to Parse.ly metadata

### DIFF
--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -195,7 +195,7 @@ final class RestMetadataTest extends TestCase {
 		self::set_options( array( 'apikey' => 'testkey' ) );
 		$post_id = self::factory()->post->create();
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		$meta_object = self::$rest->get_callback( get_post( $post_id, 'ARRAY_A' ) );
@@ -307,7 +307,7 @@ final class RestMetadataTest extends TestCase {
 		self::set_options( array( 'apikey' => 'testkey' ) );
 		$post_id = self::factory()->post->create();
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		$meta_object = self::$rest->get_callback( get_post( $post_id, 'ARRAY_A' ) );
@@ -399,7 +399,7 @@ final class RestMetadataTest extends TestCase {
 		$post = get_post( $post_id );
 		$date = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		$meta_string = self::$rest->get_rendered_meta( 'json_ld' );
@@ -462,7 +462,7 @@ final class RestMetadataTest extends TestCase {
 		$post = get_post( $post_id );
 		$date = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		$meta_string = self::$rest->get_rendered_meta( 'repeated_metas' );

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -195,6 +195,9 @@ final class RestMetadataTest extends TestCase {
 		self::set_options( array( 'apikey' => 'testkey' ) );
 		$post_id = self::factory()->post->create();
 
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
+
 		$meta_object = self::$rest->get_callback( get_post( $post_id, 'ARRAY_A' ) );
 		$metadata    = new Metadata( self::$parsely );
 		$expected    = array(
@@ -304,6 +307,9 @@ final class RestMetadataTest extends TestCase {
 		self::set_options( array( 'apikey' => 'testkey' ) );
 		$post_id = self::factory()->post->create();
 
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
+
 		$meta_object = self::$rest->get_callback( get_post( $post_id, 'ARRAY_A' ) );
 		$metadata    = new Metadata( self::$parsely );
 		$expected    = array(
@@ -393,6 +399,9 @@ final class RestMetadataTest extends TestCase {
 		$post = get_post( $post_id );
 		$date = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );
 
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
+
 		$meta_string = self::$rest->get_rendered_meta( 'json_ld' );
 		$expected    = '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"NewsArticle","headline":"My test_get_rendered_meta_json_ld title","url":"http:\/\/example.org\/?p=' . $post_id . '","mainEntityOfPage":{"@type":"WebPage","@id":"http:\/\/example.org\/?p=' . $post_id . '"},"thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"articleSection":"Uncategorized","author":[],"creator":[],"publisher":{"@type":"Organization","name":"Test Blog","logo":""},"keywords":[],"dateCreated":"' . $date . '","datePublished":"' . $date . '","dateModified":"' . $date . '"}</script>';
 		self::assertEquals( $expected, $meta_string );
@@ -452,6 +461,9 @@ final class RestMetadataTest extends TestCase {
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$post = get_post( $post_id );
 		$date = gmdate( 'Y-m-d\TH:i:s\Z', get_post_time( 'U', true, $post ) );
+
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
 
 		$meta_string = self::$rest->get_rendered_meta( 'repeated_metas' );
 		$expected    = '<meta name="parsely-title" content="My test_get_rendered_repeated_metas title" />

--- a/tests/Integration/Metadata/SinglePostTest.php
+++ b/tests/Integration/Metadata/SinglePostTest.php
@@ -70,9 +70,8 @@ final class SinglePostTest extends TestCase {
 		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
-		// Make a request to the root of the site to set the global $wp_query
-		// object.
-		$this->go_to( get_permalink( $post ) );
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
@@ -125,6 +124,9 @@ final class SinglePostTest extends TestCase {
 		$category = self::factory()->category->create( array( 'name' => 'Test Category' ) );
 		$post_id  = self::factory()->post->create( array( 'post_category' => array( $category ) ) );
 		$post     = get_post( $post_id );
+
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
@@ -186,6 +188,9 @@ final class SinglePostTest extends TestCase {
 		$parsely_options['lowercase_tags'] = true;
 		update_option( 'parsely', $parsely_options );
 
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
+
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
 		$structured_data = $metadata->construct_metadata( $post );
@@ -246,6 +251,9 @@ final class SinglePostTest extends TestCase {
 		$cat3    = self::factory()->category->create( array( 'name' => 'Test Category 3' ) );
 		$post_id = self::factory()->post->create( array( 'post_category' => array( $cat1, $cat2, $cat3 ) ) );
 		$post    = get_post( $post_id );
+
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
@@ -322,6 +330,9 @@ final class SinglePostTest extends TestCase {
 		wp_set_object_terms( $post_id, array( $custom_tax_tag ), 'hockey' );
 		wp_set_object_terms( $post_id, array( $tag ), 'post_tag' );
 
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
+
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
 		$structured_data = $metadata->construct_metadata( $post );
@@ -386,6 +397,9 @@ final class SinglePostTest extends TestCase {
 		);
 		$post_id = self::factory()->post->create( array( 'post_category' => array( $cat1, $cat2 ) ) );
 		$post    = get_post( $post_id );
+
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
@@ -475,6 +489,9 @@ final class SinglePostTest extends TestCase {
 		$parsely_options['use_top_level_cats'] = false;
 		update_option( 'parsely', $parsely_options );
 
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
+
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
 		$structured_data = $metadata->construct_metadata( $post );
@@ -537,6 +554,9 @@ final class SinglePostTest extends TestCase {
 		// Set Parsely to not force https canonicals.
 		$parsely_options['force_https_canonicals'] = false;
 		update_option( 'parsely', $parsely_options );
+
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
@@ -607,12 +627,14 @@ final class SinglePostTest extends TestCase {
 				'post_date_gmt' => $date_created_gmt,
 			)
 		);
+		$post             = get_post( $post_id );
 
-		// In the metadata, check that the post's created date is correct and
-		// that the last modified date is identical.
-		$post     = get_post( $post_id );
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
+
 		$meta     = new Metadata( $parsely );
 		$metadata = $meta->construct_metadata( $post );
+
 		self::assertSame( $date_created, $metadata['dateCreated'] );
 		self::assertSame( $date_created, $metadata['dateModified'] );
 
@@ -727,6 +749,9 @@ final class SinglePostTest extends TestCase {
 		$post->post_modified     = $singular_datetime;
 		$post->post_modified_gmt = $singular_datetime;
 
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
+
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
 		$structured_data = $metadata->construct_metadata( $post );
@@ -788,6 +813,9 @@ final class SinglePostTest extends TestCase {
 		$post->post_modified     = $modified_datetime;
 		$post->post_modified_gmt = $modified_datetime;
 
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
+
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
 		$structured_data = $metadata->construct_metadata( $post );
@@ -847,6 +875,9 @@ final class SinglePostTest extends TestCase {
 		$post->post_date_gmt     = $created_datetime;
 		$post->post_modified     = $modified_datetime;
 		$post->post_modified_gmt = $modified_datetime;
+
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
 		$metadata        = new Metadata( $parsely );
@@ -931,6 +962,9 @@ final class SinglePostTest extends TestCase {
 		$default_category_slug = get_category( get_option( 'default_category' ) )->slug;
 		wp_remove_object_terms( $post_id, $default_category_slug, 'category' );
 
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post_id ) );
+
 		$expected        = array();
 		$metadata        = new Metadata( $parsely );
 		$structured_data = $metadata->construct_metadata( $post );
@@ -981,6 +1015,9 @@ final class SinglePostTest extends TestCase {
 		$attachment_path = dirname( __DIR__, 3 ) . '/.wordpress-org/banner-1544x500.png';
 		$attachment_id   = self::factory()->attachment->create_upload_object( $attachment_path, $post->ID );
 		set_post_thumbnail( $post, $attachment_id );
+
+		// Navigate to post which setup conditional functions that refers current post.
+		$this->go_to( get_permalink( $post->ID ) );
 
 		// Generate metadata and expected results.
 		$actual_metadata    = $metadata->construct_metadata( $post );

--- a/tests/Integration/Metadata/SinglePostTest.php
+++ b/tests/Integration/Metadata/SinglePostTest.php
@@ -70,7 +70,7 @@ final class SinglePostTest extends TestCase {
 		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
@@ -125,7 +125,7 @@ final class SinglePostTest extends TestCase {
 		$post_id  = self::factory()->post->create( array( 'post_category' => array( $category ) ) );
 		$post     = get_post( $post_id );
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
@@ -188,7 +188,7 @@ final class SinglePostTest extends TestCase {
 		$parsely_options['lowercase_tags'] = true;
 		update_option( 'parsely', $parsely_options );
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
@@ -252,7 +252,7 @@ final class SinglePostTest extends TestCase {
 		$post_id = self::factory()->post->create( array( 'post_category' => array( $cat1, $cat2, $cat3 ) ) );
 		$post    = get_post( $post_id );
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
@@ -330,7 +330,7 @@ final class SinglePostTest extends TestCase {
 		wp_set_object_terms( $post_id, array( $custom_tax_tag ), 'hockey' );
 		wp_set_object_terms( $post_id, array( $tag ), 'post_tag' );
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
@@ -398,7 +398,7 @@ final class SinglePostTest extends TestCase {
 		$post_id = self::factory()->post->create( array( 'post_category' => array( $cat1, $cat2 ) ) );
 		$post    = get_post( $post_id );
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
@@ -489,7 +489,7 @@ final class SinglePostTest extends TestCase {
 		$parsely_options['use_top_level_cats'] = false;
 		update_option( 'parsely', $parsely_options );
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
@@ -555,7 +555,7 @@ final class SinglePostTest extends TestCase {
 		$parsely_options['force_https_canonicals'] = false;
 		update_option( 'parsely', $parsely_options );
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
@@ -629,7 +629,7 @@ final class SinglePostTest extends TestCase {
 		);
 		$post             = get_post( $post_id );
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		$meta     = new Metadata( $parsely );
@@ -749,7 +749,7 @@ final class SinglePostTest extends TestCase {
 		$post->post_modified     = $singular_datetime;
 		$post->post_modified_gmt = $singular_datetime;
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
@@ -813,7 +813,7 @@ final class SinglePostTest extends TestCase {
 		$post->post_modified     = $modified_datetime;
 		$post->post_modified_gmt = $modified_datetime;
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
@@ -876,7 +876,7 @@ final class SinglePostTest extends TestCase {
 		$post->post_modified     = $modified_datetime;
 		$post->post_modified_gmt = $modified_datetime;
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		// Create the structured data for that post.
@@ -962,7 +962,7 @@ final class SinglePostTest extends TestCase {
 		$default_category_slug = get_category( get_option( 'default_category' ) )->slug;
 		wp_remove_object_terms( $post_id, $default_category_slug, 'category' );
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		$expected        = array();
@@ -1016,7 +1016,7 @@ final class SinglePostTest extends TestCase {
 		$attachment_id   = self::factory()->attachment->create_upload_object( $attachment_path, $post->ID );
 		set_post_thumbnail( $post, $attachment_id );
 
-		// Navigate to post which setup conditional functions that refers current post.
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post->ID ) );
 
 		// Generate metadata and expected results.

--- a/tests/Integration/UI/MetadataRendererTest.php
+++ b/tests/Integration/UI/MetadataRendererTest.php
@@ -224,9 +224,7 @@ final class MetadataRendererTest extends TestCase {
 
 		$post_id = self::factory()->post->create();
 
-		global $post;
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$post = $post_id;
+		$this->go_to( get_permalink( $post_id ) );
 
 		ob_start();
 		self::$metadata_renderer->render_metadata( 'repeated_metas' );

--- a/tests/Integration/UI/MetadataRendererTest.php
+++ b/tests/Integration/UI/MetadataRendererTest.php
@@ -224,6 +224,7 @@ final class MetadataRendererTest extends TestCase {
 
 		$post_id = self::factory()->post->create();
 
+		// Go to current post to update WP_Query with correct data.
 		$this->go_to( get_permalink( $post_id ) );
 
 		ob_start();


### PR DESCRIPTION
## Description
Our integeration tests fails rarely before but after merging #1179 the frequency increases but the tests usually pass on the second run.

In almost all cases the root cause of the function is the implementation of [construct_metadata function](https://github.com/Parsely/wp-parsely/blob/fixes/flaky-integeration-tests/src/class-metadata.php#L54) in which we were using the conditional functions which requires that right `WP_QUERY` is called but in our tests the value from last running test were interferring with the current running test and failing it. The thing to note here is that the tests in question were flaky and happens when only certain race coditions are met and due to this it took a lot of time to find the root cause.

Fixes: #1205 

## How does the PR addresses the issue?
In real scenario we navigate to the page and make sure that right metadata is present but the tests which were failing were not navigating to the post due to which `WP_QUERY` was not getting updated and conditional values from last tests are causing issues. To fix the tests we navigated to the post before comparing metadata values.

## How Has This Been Tested?
- Just fixes the tests and ran it `1000+` times to be sure that there is no flakiness now before fix the issue were appearing in almost every `25` tries.