### PR TITLE
Settings Page: Rename "Track as Page" to "Track as Non-Post"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Some notable features of the wp-parsely plugin are:
 - Provides a settings page to customize your integration. Some of the options include:
   - Output metadata as [JSON-LD](https://www.parse.ly/help/integration/jsonld) or [repeated meta tags](https://www.parse.ly/help/integration/metatags).
   - Choose whether logged-in users should be tracked.
-  - Define how to track every Post Type (as Page, as Post or no tracking).
+  - Define how to track every Post Type (as Post, Non-Post or no tracking).
 - Offers a wide range of hooks to customize the plugin's functionality even further.
 
 ### Documentation and resources

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -846,7 +846,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 					<tr>
 						<th scope="col"><?php echo esc_html__( 'Post Type', 'wp-parsely' ); ?></th>
 						<th id="track-post-types--post" scope="col"><?php echo esc_html__( 'Track as Post', 'wp-parsely' ); ?></th>
-						<th id="track-post-types--page" scope="col"><?php echo esc_html__( 'Track as Page', 'wp-parsely' ); ?></th>
+						<th id="track-post-types--page" scope="col"><?php echo esc_html__( 'Track as Non-Post', 'wp-parsely' ); ?></th>
 						<th id="track-post-types--none" scope="col"><?php echo esc_html__( 'Do not track', 'wp-parsely' ); ?></th>
 					</tr>
 				</thead>


### PR DESCRIPTION
## Description
This PR updates the "Track as Page" label to "Track as Non-Post" within the plugin's settings page.

## Motivation and Context
The "Track as Page" label could create confusion during integrations using the plugin, since the Parse.ly terminology for this is Non-Post, as outlined [here](https://docs.parse.ly/metadata-jsonld/#distinguishing-between-posts-and-non-posts-pages). This is a small but meaningful change to bring our terminologies in sync to avoid needless friction or misunderstandings.

## How Has This Been Tested?
Existing E2E tests pass.