### PR TITLE
Update the wp-parsely version to 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1](https://github.com/Parsely/wp-parsely/compare/3.6.0...3.6.1) - 2022-12-20
+
+### Fixed
+
+- Revert composer autoloader PR that resulted in fatal errors ([#1259](https://github.com/Parsely/wp-parsely/pull/1259))
+
 ## [3.6.0](https://github.com/Parsely/wp-parsely/compare/3.5.2...3.6.0) - 2022-12-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.6.0  
+Stable tag: 3.6.1  
 Requires at least: 5.0  
 Tested up to: 6.1  
 Requires PHP: 7.1  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.6.0",
+			"version": "3.6.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/dom-ready": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, pauarge",

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -10,7 +10,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.6.0';
+export const PLUGIN_VERSION = '3.6.1';
 
 export const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://www.parse.ly/help/integration/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.6.0
+ * Version:           3.6.1
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -56,7 +56,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.6.0';
+const PARSELY_VERSION = '3.6.1';
 const PARSELY_FILE    = __FILE__;
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {


### PR DESCRIPTION
Updates wp-parsely to 3.6.1.
