### PR TITLE
GitHub templates: Add public repo notice

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,11 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-
 ---
+
+<!-- 
+Hello! Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!
+-->
 
 ## Describe the bug
 <!-- A clear and concise description of what the bug is. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 ---
 
-<!-- 
+<!--
 Hello! Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!
 -->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 ---
 
-<!-- 
+<!--
 Hello! Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!
 -->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,11 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
 ---
+
+<!-- 
+Hello! Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!
+-->
 
 ## Is your feature request related to a problem?
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,18 @@
-<!--- Provide a general summary of your changes in the Title above -->
+<!-- 
+Hello! Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!
+-->
 
 ## Description
-<!--- Describe your changes in detail -->
+<!-- Describe your changes in detail. -->
 
-## Motivation and Context
-<!--- Why is this change required? What problem does it solve? -->
-<!--- If it fixes an open issue, please link to the issue here. -->
+## Motivation and context
+<!-- Why is this change required? What problem does it solve? -->
+<!-- If it fixes an open issue, please link to the issue here. -->
 
-## How Has This Been Tested?
-<!--- Please describe in detail how you tested your changes. -->
-<!--- Include details of your testing environment, and the tests you ran to -->
-<!--- see how your change affects other areas of the code, etc. -->
+## How has this been tested?
+<!-- Please describe in detail how you tested your changes. -->
+<!-- Include details of your testing environment, and the tests you ran too. -->
+<!-- See how your change affects other areas of the code, etc. -->
 
 ## Screenshots (if appropriate)
+<!-- Any screenshot(s) demonstrating the result of this PR. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Hello! Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!
 -->
 


### PR DESCRIPTION
## Description
This PR adds a notice to most of our GitHub templates, which states that this is a public repo and that no PII or otherwise sensitive information should be posted here. The notice is added as a comment and is displayed on the top of the templates.

The notice is based on the text found [here](https://github.com/Automattic/vip-cli/blob/develop/.github/PULL_REQUEST_TEMPLATE.md#for-automatticians).

## Motivation and Context
Prevent accidental publication of sensitive information.

## How Has This Been Tested?
- No code changes.
- Verified that the comments don't appear by previewing the files.
