### PR TITLE
UI: Fix typo in Disable JavaScript option

### DIFF
--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -446,7 +446,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 				'option_key'    => 'disable_javascript',
 				'radio_options' => array(
 					'true'  => __( 'Yes, disable JavaScript tracking. I want to use a separate system for tracking instead of the Parse.ly plugin.', 'wp-parsely' ),
-					'false' => __( 'No, do not disable JavaScript tracking. I want to the Parse.ly plugin to load the tracker.', 'wp-parsely' ),
+					'false' => __( 'No, do not disable JavaScript tracking. I want the Parse.ly plugin to load the tracker.', 'wp-parsely' ),
 				),
 				'help_text'     => __( '<span style="color:#d63638">WARNING:</span> We highly recommend choosing "No." Disabling the JavaScript tracker will also disable the "Personalize Results" section of the recommendation widget.', 'wp-parsely' ),
 				'filter'        => 'wp_parsely_load_js_tracker',


### PR DESCRIPTION
## Description
Fix a typo.

## Motivation and context
Nobody likes ~typoes~ typos.