### PR TITLE
Fix showing Parse.ly Stats on multiple columns

### DIFF
--- a/src/UI/class-admin-columns-parsely-stats.php
+++ b/src/UI/class-admin-columns-parsely-stats.php
@@ -153,9 +153,11 @@ class Admin_Columns_Parsely_Stats {
 	 * 3. Show data on each Admin Row using JS.
 	 *
 	 * @since 3.7.0
+	 *
+	 * @param string $column_name The name of the column to display.
 	 */
-	public function update_published_times_and_show_placeholder(): void {
-		if ( ! $this->is_tracked_as_post_type() ) {
+	public function update_published_times_and_show_placeholder( string $column_name ): void {
+		if ( 'parsely-stats' !== $column_name || ! $this->is_tracked_as_post_type() ) {
 			return;
 		}
 

--- a/tests/Integration/UI/AdminColumnsParselyStatsTest.php
+++ b/tests/Integration/UI/AdminColumnsParselyStatsTest.php
@@ -442,12 +442,13 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 
 		foreach ( $posts as $current_post ) {
 			global $post;
-			$post = $current_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$post        = $current_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$column_name = 'parsely-stats';
 
 			if ( $this->isPHPVersion7Dot2OrHigher() ) {
-				do_action( "manage_{$post_type}s_custom_column" ); // phpcs:ignore
+				do_action( "manage_{$post_type}s_custom_column", $column_name ); // phpcs:ignore
 			} else {
-				$obj->update_published_times_and_show_placeholder();
+				$obj->update_published_times_and_show_placeholder( $column_name );
 			}
 		}
 	}


### PR DESCRIPTION
## Description
Parse.ly Stats are visible on multiple columns so we need to add a check on `column_name` to solve this issue.

## How has this been tested?
- Made changes in existing test.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/31419912/214536857-4a4ac91d-5a23-41d9-9c21-8275403f096b.png)

