### PR TITLE
Fix PHP Notice on Settings page: "Undefined index: title"

### DIFF
--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -377,7 +377,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 		// Metadata Format.
 		$field_id   = 'meta_type';
 		$field_args = array(
-			'title' => __( 'Metadata Format', 'wp-parsely' ),
+			'title'         => __( 'Metadata Format', 'wp-parsely' ),
 			'option_key'    => $field_id,
 			'help_text'     => __( 'Choose the metadata format for our crawlers to access. Most publishers are fine with <a href="https://www.parse.ly/help/integration/jsonld/">JSON-LD</a>, but if you prefer to use our proprietary metadata format then you can do so here.', 'wp-parsely' ),
 			'radio_options' => array(

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -377,6 +377,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 		// Metadata Format.
 		$field_id   = 'meta_type';
 		$field_args = array(
+			'title' => __( 'Metadata Format', 'wp-parsely' ),
 			'option_key'    => $field_id,
 			'help_text'     => __( 'Choose the metadata format for our crawlers to access. Most publishers are fine with <a href="https://www.parse.ly/help/integration/jsonld/">JSON-LD</a>, but if you prefer to use our proprietary metadata format then you can do so here.', 'wp-parsely' ),
 			'radio_options' => array(


### PR DESCRIPTION
## Description

The `meta_type` radio list does not set a `title` arg which is used for the `legend` / screen reader text when rendering the radio button list. This leads to a PHP Notice:

```
Undefined index: title
wp-content/mu-plugins/wp-parsely-3.6/src/UI/class-settings-page.php:784
Parsely\UI\Settings_Page->print_radio_tags()
wp-admin/includes/template.php:1785
do_settings_fields()
wp-admin/includes/template.php:1739
do_settings_sections()
wp-content/mu-plugins/wp-parsely-3.6/views/parsely-settings.php:33
Parsely\UI\Settings_Page->display_settings()
wp-includes/class-wp-hook.php:308
do_action('settings_page_parsely')
wp-admin/admin.php:259
```

This adds the title arg to get rid of the Notice.

## Motivation and context

- PHP Notices are annoying. We should not create them :)
- Fixes #1344

## How has this been tested?

Without the fix:

1. Goto Settings > Parse.ly
2. In Query Monitor you should see the notice

Apply the fix:

1. Goto Settings > Parse.ly
2. In Query Monitor, the notice will no longer be there.
