### PR TITLE
Fix PHP 8 incompatibilities

### DIFF
--- a/src/Endpoints/class-analytics-post-detail-api-proxy.php
+++ b/src/Endpoints/class-analytics-post-detail-api-proxy.php
@@ -74,7 +74,7 @@ final class Analytics_Post_Detail_API_Proxy extends Base_API_Proxy {
 	 * @param float $time The time as a float number.
 	 * @return string The resulting formatted time duration.
 	 */
-	private function get_duration( float $time ): string {
+	private static function get_duration( float $time ): string {
 		$minutes = absint( $time );
 		$seconds = absint( round( fmod( $time, 1 ) * 60 ) );
 

--- a/src/Endpoints/class-referrers-post-detail-api-proxy.php
+++ b/src/Endpoints/class-referrers-post-detail-api-proxy.php
@@ -97,7 +97,7 @@ final class Referrers_Post_Detail_API_Proxy extends Base_API_Proxy {
 		// Set referrer type order as it is displayed in the Parse.ly dashboard.
 		$referrer_type_keys = array( 'social', 'search', 'other', 'internal', 'direct' );
 		foreach ( $referrer_type_keys as $key ) {
-			$result->$key->views = 0;
+			$result->$key = (object) array( 'views' => 0 );
 		}
 
 		// Set views and views totals.
@@ -116,7 +116,7 @@ final class Referrers_Post_Detail_API_Proxy extends Base_API_Proxy {
 
 		// Add direct and total views to the object.
 		$result->direct->views = $this->total_views - $total_referrer_views;
-		$result->totals->views = $this->total_views;
+		$result->totals        = (object) array( 'views' => $this->total_views );
 
 		// Remove referrer types without views.
 		foreach ( $referrer_type_keys as $key ) {
@@ -188,9 +188,9 @@ final class Referrers_Post_Detail_API_Proxy extends Base_API_Proxy {
 		// Convert temporary array to result object and add totals.
 		$result = new stdClass();
 		foreach ( $temp_views as $key => $value ) {
-			$result->$key->views = $value;
+			$result->$key = (object) array( 'views' => $value );
 		}
-		$result->totals->views = $totals;
+		$result->totals = (object) array( 'views' => $totals );
 
 		// Set percentages values and format numbers.
 		// @phpstan-ignore-next-line.

--- a/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
@@ -4,8 +4,6 @@
  *
  * @package Parsely\Tests
  * @since   3.5.0
- *
- * phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
  */
 
 declare(strict_types=1);
@@ -54,7 +52,7 @@ final class AnalyticsPostsProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 */
 	public function test_register_routes_by_default(): void {
-		parent::test_register_routes_by_default();
+		parent::run_test_register_routes_by_default();
 	}
 
 	/**
@@ -67,7 +65,7 @@ final class AnalyticsPostsProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 */
 	public function test_verify_that_route_is_not_registered_when_proxy_is_disabled(): void {
-		parent::test_do_not_register_route_when_proxy_is_disabled();
+		parent::run_test_do_not_register_route_when_proxy_is_disabled();
 	}
 
 	/**
@@ -87,7 +85,28 @@ final class AnalyticsPostsProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\Endpoints\Base_API_Proxy::register_endpoint
 	 */
 	public function test_get_items_fails_when_site_id_is_not_set(): void {
-		parent::test_get_items_fails_without_site_id_set();
+		parent::run_test_get_items_fails_without_site_id_set();
+	}
+
+	/**
+	 * Verifies that calling `GET /wp-parsely/v1/stats/posts` returns an
+	 * error and does not perform a remote call when the API Secret is not
+	 * populated in site options.
+	 *
+	 * @covers \Parsely\Endpoints\Analytics_Posts_API_Proxy::get_items
+	 * @uses \Parsely\Endpoints\Analytics_Posts_API_Proxy::__construct
+	 * @uses \Parsely\Endpoints\Analytics_Posts_API_Proxy::permission_callback
+	 * @uses \Parsely\Endpoints\Analytics_Posts_API_Proxy::run
+	 * @uses \Parsely\Parsely::site_id_is_missing
+	 * @uses \Parsely\Parsely::site_id_is_set
+	 * @uses \Parsely\Parsely::api_secret_is_set
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::get_data
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::register_endpoint
+	 */
+	public function test_get_items_fails_when_api_secret_is_not_set(): void {
+		parent::run_test_get_items_fails_without_api_secret_set();
 	}
 
 	/**
@@ -112,8 +131,12 @@ final class AnalyticsPostsProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_items
 	 */
 	public function test_get_items(): void {
-		TestCase::set_options( array( 'apikey' => 'example.com' ) );
-		TestCase::set_options( array( 'api_secret' => 'test' ) );
+		TestCase::set_options(
+			array(
+				'apikey'     => 'example.com',
+				'api_secret' => 'test',
+			)
+		);
 
 		$dispatched  = 0;
 		$date_format = get_date_format();
@@ -123,7 +146,24 @@ final class AnalyticsPostsProxyEndpointTest extends ProxyEndpointTest {
 			function () use ( &$dispatched ) {
 				$dispatched++;
 				return array(
-					'body' => '{"data":[{"_hits": 142, "author": "Aakash Shah", "authors": ["Aakash Shah"], "full_content_word_count": 3624, "image_url": "https://blog.parse.ly/wp-content/uploads/2021/06/Web-Analytics-Tool.png?w=150&h=150&crop=1", "link": "https://blog.parse.ly/web-analytics-software-tools/?itm_source=parsely-api", "metadata": "", "metrics": {"views": 142}, "pub_date": "2020-04-06T13:30:58", "section": "Analytics That Matter", "tags": ["animalz", "parsely_smart:entity:Bounce rate", "parsely_smart:entity:Customer analytics", "parsely_smart:entity:Digital marketing", "parsely_smart:entity:Google Analytics", "parsely_smart:entity:Marketing strategy", "parsely_smart:entity:Multivariate testing in marketing", "parsely_smart:entity:Open source", "parsely_smart:entity:Pageview", "parsely_smart:entity:Search engine optimization", "parsely_smart:entity:Social media", "parsely_smart:entity:Social media analytics", "parsely_smart:entity:Usability", "parsely_smart:entity:User experience design", "parsely_smart:entity:Web analytics", "parsely_smart:entity:Web traffic", "parsely_smart:entity:Website", "parsely_smart:entity:World Wide Web", "parsely_smart:iab:Business", "parsely_smart:iab:Graphics", "parsely_smart:iab:Software", "parsely_smart:iab:Technology"], "thumb_url_medium": "https://images.parsely.com/XCmTXuOf8yVbUYTxj2abQ4RSDkM=/85x85/smart/https%3A//blog.parse.ly/wp-content/uploads/2021/06/Web-Analytics-Tool.png%3Fw%3D150%26h%3D150%26crop%3D1", "title": "9 Types of Web Analytics Tools \u2014 And How to Know Which Ones You Really Need", "url": "https://blog.parse.ly/web-analytics-software-tools/?itm_source=parsely-api"}, {"_hits": 40, "author": "Stephanie Schwartz and Andrew Butler", "authors": ["Stephanie Schwartz and Andrew Butler"], "full_content_word_count": 1785, "image_url": "https://blog.parse.ly/wp-content/uploads/2021/05/pexels-brett-jordan-998501-1024x768-2.jpeg?w=150&h=150&crop=1", "link": "https://blog.parse.ly/5-tagging-best-practices-content-strategy/?itm_source=parsely-api", "metadata": "", "metrics": {"views": 40}, "pub_date": "2021-04-30T20:30:24", "section": "Analytics That Matter", "tags": ["parsely_smart:entity:Analytics", "parsely_smart:entity:Best practice", "parsely_smart:entity:Hashtag", "parsely_smart:entity:Metadata", "parsely_smart:entity:Search engine", "parsely_smart:entity:Search engine optimization", "parsely_smart:entity:Tag (metadata)", "parsely_smart:iab:Business", "parsely_smart:iab:Science", "parsely_smart:iab:Software", "parsely_smart:iab:Technology"], "thumb_url_medium": "https://images.parsely.com/ap3YSufqxnLpz6zzQshoks3snXI=/85x85/smart/https%3A//blog.parse.ly/wp-content/uploads/2021/05/pexels-brett-jordan-998501-1024x768-2.jpeg%3Fw%3D150%26h%3D150%26crop%3D1", "title": "5 Tagging Best Practices For Getting the Most Out of Your Content Strategy", "url": "https://blog.parse.ly/5-tagging-best-practices-content-strategy/?itm_source=parsely-api"}]}',
+					'body' => '{"data":[
+						{
+							"author": "Aakash Shah",
+							"metrics": {"views": 142},
+							"pub_date": "2020-04-06T13:30:58",
+							"thumb_url_medium": "https://images.parsely.com/XCmTXuOf8yVbUYTxj2abQ4RSDkM=/85x85/smart/https%3A//blog.parse.ly/wp-content/uploads/2021/06/Web-Analytics-Tool.png%3Fw%3D150%26h%3D150%26crop%3D1",
+							"title": "9 Types of Web Analytics Tools \u2014 And How to Know Which Ones You Really Need",
+							"url": "https://blog.parse.ly/web-analytics-software-tools/?itm_source=parsely-api"
+						},
+						{
+							"author": "Stephanie Schwartz and Andrew Butler",
+							"metrics": {"views": 40},
+							"pub_date": "2021-04-30T20:30:24",
+							"thumb_url_medium": "https://images.parsely.com/ap3YSufqxnLpz6zzQshoks3snXI=/85x85/smart/https%3A//blog.parse.ly/wp-content/uploads/2021/05/pexels-brett-jordan-998501-1024x768-2.jpeg%3Fw%3D150%26h%3D150%26crop%3D1",
+							"title": "5 Tagging Best Practices For Getting the Most Out of Your Content Strategy",
+							"url": "https://blog.parse.ly/5-tagging-best-practices-content-strategy/?itm_source=parsely-api"
+						}
+					]}',
 				);
 			}
 		);
@@ -139,7 +179,7 @@ final class AnalyticsPostsProxyEndpointTest extends ProxyEndpointTest {
 						'author'         => 'Aakash Shah',
 						'date'           => wp_date( $date_format, strtotime( '2020-04-06T13:30:58' ) ),
 						'id'             => 'https://blog.parse.ly/web-analytics-software-tools/?itm_source=parsely-api',
-						'dashUrl'        => PARSELY::DASHBOARD_BASE_URL . '/blog.parsely.com/find?url=https%3A%2F%2Fblog.parse.ly%2Fweb-analytics-software-tools%2F%3Fitm_source%3Dparsely-api',
+						'dashUrl'        => PARSELY::DASHBOARD_BASE_URL . '/example.com/find?url=https%3A%2F%2Fblog.parse.ly%2Fweb-analytics-software-tools%2F%3Fitm_source%3Dparsely-api',
 						'thumbUrlMedium' => 'https://images.parsely.com/XCmTXuOf8yVbUYTxj2abQ4RSDkM=/85x85/smart/https%3A//blog.parse.ly/wp-content/uploads/2021/06/Web-Analytics-Tool.png%3Fw%3D150%26h%3D150%26crop%3D1',
 						'title'          => '9 Types of Web Analytics Tools — And How to Know Which Ones You Really Need',
 						'url'            => 'https://blog.parse.ly/web-analytics-software-tools/?itm_source=parsely-api',
@@ -150,7 +190,7 @@ final class AnalyticsPostsProxyEndpointTest extends ProxyEndpointTest {
 						'author'         => 'Stephanie Schwartz and Andrew Butler',
 						'date'           => wp_date( $date_format, strtotime( '2021-04-30T20:30:24' ) ),
 						'id'             => 'https://blog.parse.ly/5-tagging-best-practices-content-strategy/?itm_source=parsely-api',
-						'dashUrl'        => PARSELY::DASHBOARD_BASE_URL . '/blog.parsely.com/find?url=https%3A%2F%2Fblog.parse.ly%2F5-tagging-best-practices-content-strategy%2F%3Fitm_source%3Dparsely-api',
+						'dashUrl'        => PARSELY::DASHBOARD_BASE_URL . '/example.com/find?url=https%3A%2F%2Fblog.parse.ly%2F5-tagging-best-practices-content-strategy%2F%3Fitm_source%3Dparsely-api',
 						'thumbUrlMedium' => 'https://images.parsely.com/ap3YSufqxnLpz6zzQshoks3snXI=/85x85/smart/https%3A//blog.parse.ly/wp-content/uploads/2021/05/pexels-brett-jordan-998501-1024x768-2.jpeg%3Fw%3D150%26h%3D150%26crop%3D1',
 						'title'          => '5 Tagging Best Practices For Getting the Most Out of Your Content Strategy',
 						'url'            => 'https://blog.parse.ly/5-tagging-best-practices-content-strategy/?itm_source=parsely-api',

--- a/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Integration Tests: Referrers Post Detail API Proxy Endpoint
+ *
+ * @package Parsely\Tests
+ * @since   3.7.0
+ */
+
+declare(strict_types=1);
+
+namespace Parsely\Tests\Integration;
+
+use Parsely\Endpoints\Base_API_Proxy;
+use Parsely\Endpoints\Referrers_Post_Detail_API_Proxy;
+use Parsely\Parsely;
+use Parsely\RemoteAPI\Referrers_Post_Detail_API;
+use WP_REST_Request;
+
+/**
+ * Integration Tests for the Referrers Post Detail API Proxy Endpoint.
+ */
+final class ReferrersPostDetailProxyEndpointTest extends ProxyEndpointTest {
+
+	/**
+	 * Initializes all required values for the test.
+	 */
+	public static function initialize(): void {
+		self::$route      = '/wp-parsely/v1/referrers/post/detail';
+		self::$filter_key = 'referrers_post_detail';
+	}
+
+	/**
+	 * Returns the endpoint to be used in tests.
+	 *
+	 * @return Base_API_Proxy
+	 */
+	public function get_endpoint(): Base_API_Proxy {
+		return new Referrers_Post_Detail_API_Proxy(
+			new Parsely(),
+			new Referrers_Post_Detail_API( new Parsely() )
+		);
+	}
+
+	/**
+	 * Verifies that the route is registered.
+	 *
+	 * @covers \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::run
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::register_endpoint
+	 * @uses \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::__construct
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 */
+	public function test_register_routes_by_default(): void {
+		parent::run_test_register_routes_by_default();
+	}
+
+	/**
+	 * Verifies that the route is not registered when the
+	 * wp_parsely_enable_referrers_post_details_api_proxy filter is set to false.
+	 *
+	 * @covers \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::run
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::register_endpoint
+	 * @uses \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::__construct
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 */
+	public function test_verify_that_route_is_not_registered_when_proxy_is_disabled(): void {
+		parent::run_test_do_not_register_route_when_proxy_is_disabled();
+	}
+
+	/**
+	 * Verifies that calling `GET /wp-parsely/v1/referrers/post/detail` returns
+	 * an error and does not perform a remote call when the Site ID is not
+	 * populated in site options.
+	 *
+	 * @covers \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::get_items
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::get_data
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::register_endpoint
+	 * @uses \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::__construct
+	 * @uses \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::permission_callback
+	 * @uses \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::run
+	 * @uses \Parsely\Parsely::site_id_is_missing
+	 * @uses \Parsely\Parsely::site_id_is_set
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 */
+	public function test_get_items_fails_when_site_id_is_not_set(): void {
+		parent::run_test_get_items_fails_without_site_id_set();
+	}
+
+	/**
+	 * Verifies that calling `GET /wp-parsely/v1/referrers/post/detail` returns
+	 * an error and does not perform a remote call when the Site ID is not
+	 * populated in site options.
+	 *
+	 * @covers \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::get_items
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::get_data
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::register_endpoint
+	 * @uses \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::__construct
+	 * @uses \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::permission_callback
+	 * @uses \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::run
+	 * @uses \Parsely\Parsely::site_id_is_missing
+	 * @uses \Parsely\Parsely::site_id_is_set
+	 * @uses \Parsely\Parsely::api_secret_is_set
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 */
+	public function test_get_items_fails_when_api_secret_is_not_set(): void {
+		parent::run_test_get_items_fails_without_api_secret_set();
+	}
+
+	/**
+	 * Verifies that calls to `GET /wp-parsely/v1/referrers/post/detail` return
+	 * results in the expected format.
+	 *
+	 * @covers \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::get_items
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::get_data
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::register_endpoint
+	 * @uses \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::__construct
+	 * @uses \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::generate_data
+	 * @uses \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::permission_callback
+	 * @uses \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::run
+	 * @uses \Parsely\Parsely::site_id_is_missing
+	 * @uses \Parsely\Parsely::site_id_is_set
+	 * @uses \Parsely\Parsely::api_secret_is_set
+	 * @uses \Parsely\Parsely::get_site_id
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_api_url
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_items
+	 */
+	public function test_get_items() {
+		TestCase::set_options(
+			array(
+				'apikey'     => 'example.com',
+				'api_secret' => 'test',
+			)
+		);
+
+		$dispatched = 0;
+
+		add_filter(
+			'pre_http_request',
+			function () use ( &$dispatched ) {
+				$dispatched++;
+				return array(
+					'body' => '{"data":[
+						{
+							"metrics": {"referrers_views": 1768},
+							"name": "google",
+							"type": "search"
+						},
+						{
+							"metrics": {"referrers_views": 65},
+							"name": "blog.parse.ly",
+							"type": "internal"
+						},
+						{
+							"metrics": {"referrers_views": 12},
+							"name": "bing",
+							"type": "search"
+						},
+						{
+							"metrics": {"referrers_views": 5},
+							"name": "facebook.com",
+							"type": "social"
+						},
+						{
+							"metrics": {"referrers_views": 4},
+							"name": "okt.to",
+							"type": "other"
+						},
+						{
+							"metrics": {"referrers_views": 4},
+							"name": "yandex",
+							"type": "search"
+						},
+						{
+							"metrics": {"referrers_views": 3},
+							"name": "parse.ly",
+							"type": "internal"
+						},
+						{
+							"metrics": {"referrers_views": 3},
+							"name": "yahoo!",
+							"type": "search"
+						},
+						{
+							"metrics": {"referrers_views": 1},
+							"name": "site1.com",
+							"type": "other"
+						},
+						{
+							"metrics": {"referrers_views": 1},
+							"name": "link.site2.com",
+							"type": "other"
+						}
+					]}',
+				);
+			}
+		);
+
+		$expected_top = (object) array(
+			'direct'        => (object) array(
+				'views'                  => '1,866',
+				'viewsPercentage'        => false,
+				'datasetViewsPercentage' => '50.22',
+			),
+			'google'        => (object) array(
+				'views'                  => '1,768',
+				'viewsPercentage'        => false,
+				'datasetViewsPercentage' => '47.58',
+			),
+			'blog.parse.ly' => (object) array(
+				'views'                  => '65',
+				'viewsPercentage'        => false,
+				'datasetViewsPercentage' => '1.75',
+			),
+			'bing'          => (object) array(
+				'views'                  => '12',
+				'viewsPercentage'        => false,
+				'datasetViewsPercentage' => '0.32',
+			),
+			'facebook.com'  => (object) array(
+				'views'                  => '5',
+				'viewsPercentage'        => false,
+				'datasetViewsPercentage' => '0.13',
+			),
+			'totals'        => (object) array(
+				'views'                  => '3,716',
+				'viewsPercentage'        => false,
+				'datasetViewsPercentage' => '100.00',
+			),
+		);
+
+		$expected_types = (object) array(
+			'social'   => (object) array(
+				'views'           => '5',
+				'viewsPercentage' => false,
+			),
+			'search'   => (object) array(
+				'views'           => '1,787',
+				'viewsPercentage' => false,
+			),
+			'other'    => (object) array(
+				'views'           => '6',
+				'viewsPercentage' => false,
+			),
+			'internal' => (object) array(
+				'views'           => '68',
+				'viewsPercentage' => false,
+			),
+			'direct'   => (object) array(
+				'views'           => '-1,866',
+				'viewsPercentage' => false,
+			),
+			'totals'   => (object) array(
+				'views'           => '0',
+				'viewsPercentage' => false,
+			),
+		);
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/wp-parsely/v1/referrers/post/detail' ) );
+
+		self::assertSame( 1, $dispatched );
+		self::assertSame( 200, $response->get_status() );
+		self::assertEquals(
+			(object) array(
+				'data' => array(
+					'top'   => $expected_top,
+					'types' => $expected_types,
+				),
+			),
+			$response->get_data()
+		);
+	}
+}

--- a/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
@@ -3,8 +3,6 @@
  * Integration Tests: Related API Proxy Endpoint
  *
  * @package Parsely\Tests
- *
- * phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
  */
 
 declare(strict_types=1);
@@ -51,7 +49,7 @@ final class RelatedProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 */
 	public function test_register_routes_by_default(): void {
-		parent::test_register_routes_by_default();
+		parent::run_test_register_routes_by_default();
 	}
 
 	/**
@@ -64,7 +62,7 @@ final class RelatedProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 */
 	public function test_verify_that_route_is_not_registered_when_proxy_is_disabled(): void {
-		parent::test_do_not_register_route_when_proxy_is_disabled();
+		parent::run_test_do_not_register_route_when_proxy_is_disabled();
 	}
 
 	/**
@@ -84,7 +82,7 @@ final class RelatedProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 */
 	public function test_get_items_fails_when_site_id_is_not_set(): void {
-		parent::test_get_items_fails_without_site_id_set();
+		parent::run_test_get_items_fails_without_site_id_set();
 	}
 
 	/**
@@ -117,7 +115,20 @@ final class RelatedProxyEndpointTest extends ProxyEndpointTest {
 			function () use ( &$dispatched ) {
 				$dispatched++;
 				return array(
-					'body' => '{"data":[{"image_url":"https:\/\/example.com\/img.png","thumb_url_medium":"https:\/\/example.com\/thumb.png","title":"something","url":"https:\/\/example.com"},{"image_url":"https:\/\/example.com\/img2.png","thumb_url_medium":"https:\/\/example.com\/thumb2.png","title":"something2","url":"https:\/\/example.com\/2"}]}',
+					'body' => '{"data":[
+						{
+							"image_url":"https:\/\/example.com\/img.png",
+							"thumb_url_medium":"https:\/\/example.com\/thumb.png",
+							"title":"something",
+							"url":"https:\/\/example.com"
+						},
+						{
+							"image_url":"https:\/\/example.com\/img2.png",
+							"thumb_url_medium":"https:\/\/example.com\/thumb2.png",
+							"title":"something2",
+							"url":"https:\/\/example.com\/2"
+						}
+					]}',
 				);
 			}
 		);

--- a/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
@@ -165,7 +165,7 @@ final class StatsPostDetailProxyEndpointTest extends ProxyEndpointTest {
 				'data' => array(
 					(object) array(
 						'avgEngaged' => ' 1:55',
-						'dashUrl'    => 'https://dash.parsely.com/example.com/find?url=https%3A%2F%2Fexample.com',
+						'dashUrl'    => Parsely::DASHBOARD_BASE_URL . '/example.com/find?url=https%3A%2F%2Fexample.com',
 						'url'        => 'https://example.com',
 						'views'      => '2,158',
 						'visitors'   => '1,537',

--- a/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Integration Tests: Stats Post Detail API Proxy Endpoint
+ *
+ * @package Parsely\Tests
+ * @since   3.7.0
+ */
+
+declare(strict_types=1);
+
+namespace Parsely\Tests\Integration;
+
+use Parsely\Endpoints\Base_API_Proxy;
+use Parsely\Endpoints\Analytics_Post_Detail_API_Proxy;
+use Parsely\Parsely;
+use Parsely\RemoteAPI\Analytics_Post_Detail_API;
+use WP_REST_Request;
+
+/**
+ * Integration Tests for the Stats Post Detail API Proxy Endpoint.
+ */
+final class StatsPostDetailProxyEndpointTest extends ProxyEndpointTest {
+
+	/**
+	 * Initializes all required values for the test.
+	 */
+	public static function initialize(): void {
+		self::$route      = '/wp-parsely/v1/stats/post/detail';
+		self::$filter_key = 'stats_post_detail';
+	}
+
+	/**
+	 * Returns the endpoint to be used in tests.
+	 *
+	 * @return Base_API_Proxy
+	 */
+	public function get_endpoint(): Base_API_Proxy {
+		return new Analytics_Post_Detail_API_Proxy(
+			new Parsely(),
+			new Analytics_Post_Detail_API( new Parsely() )
+		);
+	}
+
+	/**
+	 * Verifies that the route is registered.
+	 *
+	 * @covers \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::run
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::register_endpoint
+	 * @uses \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::__construct
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 */
+	public function test_register_routes_by_default(): void {
+		parent::run_test_register_routes_by_default();
+	}
+
+	/**
+	 * Verifies that the route is not registered when the
+	 * wp_parsely_enable_analytics_post_details_api_proxy filter is set to false.
+	 *
+	 * @covers \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::run
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::register_endpoint
+	 * @uses \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::__construct
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 */
+	public function test_verify_that_route_is_not_registered_when_proxy_is_disabled(): void {
+		parent::run_test_do_not_register_route_when_proxy_is_disabled();
+	}
+
+	/**
+	 * Verifies that calling `GET /wp-parsely/v1/analytics/post/detail` returns
+	 * an error and does not perform a remote call when the Site ID is not
+	 * populated in site options.
+	 *
+	 * @covers \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::get_items
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::get_data
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::register_endpoint
+	 * @uses \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::__construct
+	 * @uses \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::permission_callback
+	 * @uses \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::run
+	 * @uses \Parsely\Parsely::site_id_is_missing
+	 * @uses \Parsely\Parsely::site_id_is_set
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 */
+	public function test_get_items_fails_when_site_id_is_not_set(): void {
+		parent::run_test_get_items_fails_without_site_id_set();
+	}
+
+	/**
+	 * Verifies that calling `GET /wp-parsely/v1/analytics/post/detail` returns
+	 * an error and does not perform a remote call when the Site ID is not
+	 * populated in site options.
+	 *
+	 * @covers \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::get_items
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::get_data
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::register_endpoint
+	 * @uses \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::__construct
+	 * @uses \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::permission_callback
+	 * @uses \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::run
+	 * @uses \Parsely\Parsely::site_id_is_missing
+	 * @uses \Parsely\Parsely::site_id_is_set
+	 * @uses \Parsely\Parsely::api_secret_is_set
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 */
+	public function test_get_items_fails_when_api_secret_is_not_set(): void {
+		parent::run_test_get_items_fails_without_api_secret_set();
+	}
+
+	/**
+	 * Verifies that calls to `GET /wp-parsely/v1/analytics/post/detail` return
+	 * results in the expected format.
+	 *
+	 * @covers \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::get_items
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::get_data
+	 * @uses \Parsely\Endpoints\Base_API_Proxy::register_endpoint
+	 * @uses \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::__construct
+	 * @uses \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::generate_data
+	 * @uses \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::permission_callback
+	 * @uses \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::run
+	 * @uses \Parsely\Parsely::site_id_is_missing
+	 * @uses \Parsely\Parsely::site_id_is_set
+	 * @uses \Parsely\Parsely::api_secret_is_set
+	 * @uses \Parsely\Parsely::get_site_id
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_api_url
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_items
+	 */
+	public function test_get_items() {
+		TestCase::set_options(
+			array(
+				'apikey'     => 'example.com',
+				'api_secret' => 'test',
+			)
+		);
+
+		$dispatched = 0;
+
+		add_filter(
+			'pre_http_request',
+			function () use ( &$dispatched ) {
+				$dispatched++;
+				return array(
+					'body' => '
+						{"data":[{
+							"avg_engaged": 1.911,
+							"metrics": {
+								"views": 2158,
+								"visitors": 1537
+							},
+							"url": "https://example.com"
+						}]}
+					',
+				);
+			}
+		);
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/wp-parsely/v1/stats/post/detail' ) );
+
+		self::assertSame( 1, $dispatched );
+		self::assertSame( 200, $response->get_status() );
+		self::assertEquals(
+			(object) array(
+				'data' => array(
+					(object) array(
+						'avgEngaged' => ' 1:55',
+						'dashUrl'    => 'https://dash.parsely.com/example.com/find?url=https%3A%2F%2Fexample.com',
+						'url'        => 'https://example.com',
+						'views'      => '2,158',
+						'visitors'   => '1,537',
+					),
+				),
+			),
+			$response->get_data()
+		);
+	}
+}


### PR DESCRIPTION
## Description
We have found parts of our code which are incompatible with PHP 8.x.

## Motivation and context
- Closes #1361.
- More context is available in that issue.

## How has this been tested?
1. We first introduced integration tests that would expose the incompatibilities and let GitHub run them.
2. As expected, the tests failed.
3. We committed the fixes that solve the issue.
4. The tests then passed.