### PR TITLE
Fix Fatal Error: switch `self` to `$this` since method is not static

### DIFF
--- a/src/Endpoints/class-analytics-post-detail-api-proxy.php
+++ b/src/Endpoints/class-analytics-post-detail-api-proxy.php
@@ -50,7 +50,7 @@ final class Analytics_Post_Detail_API_Proxy extends Base_API_Proxy {
 		return array_map(
 			static function( stdClass $item ) use ( $site_id ) {
 				return (object) array(
-					'avgEngaged' => self::get_duration( (float) $item->avg_engaged ),
+					'avgEngaged' => $this->get_duration( (float) $item->avg_engaged ),
 					'dashUrl'    => Parsely::get_dash_url( $site_id, $item->url ),
 					'url'        => $item->url,
 					'views'      => number_format_i18n( $item->metrics->views ),

--- a/src/Endpoints/class-analytics-post-detail-api-proxy.php
+++ b/src/Endpoints/class-analytics-post-detail-api-proxy.php
@@ -47,18 +47,19 @@ final class Analytics_Post_Detail_API_Proxy extends Base_API_Proxy {
 	protected function generate_data( $response ): array {
 		$site_id = $this->parsely->get_site_id();
 
-		return array_map(
-			static function( stdClass $item ) use ( $site_id ) {
-				return (object) array(
-					'avgEngaged' => $this->get_duration( (float) $item->avg_engaged ),
-					'dashUrl'    => Parsely::get_dash_url( $site_id, $item->url ),
-					'url'        => $item->url,
-					'views'      => number_format_i18n( $item->metrics->views ),
-					'visitors'   => number_format_i18n( $item->metrics->visitors ),
-				);
-			},
-			$response
-		);
+		$output = [];
+		
+		foreach ( $response as $item ) {
+			$output[] = (object) array(
+				'avgEngaged' => $this->get_duration( (float) $item->avg_engaged ),
+				'dashUrl'    => Parsely::get_dash_url( $site_id, $item->url ),
+				'url'        => $item->url,
+				'views'      => number_format_i18n( $item->metrics->views ),
+				'visitors'   => number_format_i18n( $item->metrics->visitors ),
+			);
+		}
+
+		return $output;
 	}
 
 	/**

--- a/src/Endpoints/class-analytics-post-detail-api-proxy.php
+++ b/src/Endpoints/class-analytics-post-detail-api-proxy.php
@@ -47,7 +47,7 @@ final class Analytics_Post_Detail_API_Proxy extends Base_API_Proxy {
 	protected function generate_data( $response ): array {
 		$site_id = $this->parsely->get_site_id();
 
-		$output = [];
+		$output = array();
 		
 		foreach ( $response as $item ) {
 			$output[] = (object) array(


### PR DESCRIPTION
I spotted this on our test site:

```
Uncaught Error: Non-static method Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::get_duration() cannot be called statically in /var/www/wp-content/plugins/wp-parsely/src/Endpoints/class-analytics-post-detail-api-proxy.php:53
```

Looks like we are incorrectly calling the `get_duration` method using `self::` rather than `$this->`.

This PR fixes that.