### PR TITLE
Content Helper: Fix top referrers percentage displaying as "NaN"

### DIFF
--- a/src/Endpoints/class-referrers-post-detail-api-proxy.php
+++ b/src/Endpoints/class-referrers-post-detail-api-proxy.php
@@ -14,6 +14,8 @@ use stdClass;
 use WP_REST_Request;
 use WP_Error;
 
+use function Parsely\Utils\convert_to_positive_integer;
+
 /**
  * Configures the `/referrers/post/detail` REST API endpoint.
  *
@@ -46,7 +48,7 @@ final class Referrers_Post_Detail_API_Proxy extends Base_API_Proxy {
 	 * @return stdClass|WP_Error stdClass containing the data or a WP_Error object on failure.
 	 */
 	public function get_items( WP_REST_Request $request ) {
-		$this->total_views = $this->convert_to_positive_integer(
+		$this->total_views = convert_to_positive_integer(
 			strval( $request->get_param( 'total_views' ) )
 		);
 		$request->offsetUnset( 'total_views' ); // Remove param from request.
@@ -64,7 +66,7 @@ final class Referrers_Post_Detail_API_Proxy extends Base_API_Proxy {
 	 */
 	protected function generate_data( $response ): array {
 		$referrers_types = $this->generate_referrer_types_data( $response );
-		$direct_views    = $this->convert_to_positive_integer(
+		$direct_views    = convert_to_positive_integer(
 			$referrers_types->direct->views
 		);
 		$referrers_top   = $this->generate_referrers_data( 5, $response, $direct_views );
@@ -214,17 +216,6 @@ final class Referrers_Post_Detail_API_Proxy extends Base_API_Proxy {
 		}
 
 		return $result;
-	}
-
-	/**
-	 * Converts a string to a positive integer, removing any non-numeric
-	 * characters.
-	 *
-	 * @param string $string The string to be converted to an integer.
-	 * @return int The integer resulting from the conversion.
-	 */
-	private function convert_to_positive_integer( string $string ): int {
-		return (int) preg_replace( '/\D/', '', $string );
 	}
 
 	/**

--- a/src/Endpoints/class-referrers-post-detail-api-proxy.php
+++ b/src/Endpoints/class-referrers-post-detail-api-proxy.php
@@ -46,7 +46,9 @@ final class Referrers_Post_Detail_API_Proxy extends Base_API_Proxy {
 	 * @return stdClass|WP_Error stdClass containing the data or a WP_Error object on failure.
 	 */
 	public function get_items( WP_REST_Request $request ) {
-		$this->total_views = absint( $request->get_param( 'total_views' ) );
+		$this->total_views = $this->convert_to_positive_integer(
+			strval( $request->get_param( 'total_views' ) )
+		);
 		$request->offsetUnset( 'total_views' ); // Remove param from request.
 		return $this->get_data( $request );
 	}
@@ -62,7 +64,9 @@ final class Referrers_Post_Detail_API_Proxy extends Base_API_Proxy {
 	 */
 	protected function generate_data( $response ): array {
 		$referrers_types = $this->generate_referrer_types_data( $response );
-		$direct_views    = absint( preg_replace( '/\D/', '', $referrers_types->direct->views ) );
+		$direct_views    = $this->convert_to_positive_integer(
+			$referrers_types->direct->views
+		);
 		$referrers_top   = $this->generate_referrers_data( 5, $response, $direct_views );
 
 		return array(
@@ -210,6 +214,17 @@ final class Referrers_Post_Detail_API_Proxy extends Base_API_Proxy {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Converts a string to a positive integer, removing any non-numeric
+	 * characters.
+	 *
+	 * @param string $string The string to be converted to an integer.
+	 * @return int The integer resulting from the conversion.
+	 */
+	private function convert_to_positive_integer( string $string ): int {
+		return (int) preg_replace( '/\D/', '', $string );
 	}
 
 	/**

--- a/src/Utils/utils.php
+++ b/src/Utils/utils.php
@@ -221,3 +221,14 @@ function convert_to_associative_array( $obj ) {
 	 */
 	return json_decode( $encoded, true );
 }
+
+/**
+ * Converts a string to a positive integer, removing any non-numeric
+ * characters.
+ *
+ * @param string $string The string to be converted to an integer.
+ * @return int The integer resulting from the conversion.
+ */
+function convert_to_positive_integer( string $string ): int {
+	return (int) preg_replace( '/\D/', '', $string );
+}

--- a/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
@@ -83,7 +83,10 @@ final class ReferrersPostDetailProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 */
 	public function test_get_items_fails_when_site_id_is_not_set(): void {
-		parent::run_test_get_items_fails_without_site_id_set();
+		$request = new WP_REST_Request( 'GET', self::$route );
+		$request->set_param( 'total_views', '2,500' );
+
+		parent::run_test_get_items_fails_without_site_id_set( $request );
 	}
 
 	/**
@@ -104,7 +107,10 @@ final class ReferrersPostDetailProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 */
 	public function test_get_items_fails_when_api_secret_is_not_set(): void {
-		parent::run_test_get_items_fails_without_api_secret_set();
+		$request = new WP_REST_Request( 'GET', self::$route );
+		$request->set_param( 'total_views', '2,500' );
+
+		parent::run_test_get_items_fails_without_api_secret_set( $request );
 	}
 
 	/**
@@ -127,7 +133,7 @@ final class ReferrersPostDetailProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_api_url
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_items
 	 */
-	public function test_get_items() {
+	public function test_get_items(): void {
 		TestCase::set_options(
 			array(
 				'apikey'     => 'example.com',
@@ -144,52 +150,52 @@ final class ReferrersPostDetailProxyEndpointTest extends ProxyEndpointTest {
 				return array(
 					'body' => '{"data":[
 						{
-							"metrics": {"referrers_views": 1768},
+							"metrics": {"referrers_views": 1500},
 							"name": "google",
 							"type": "search"
 						},
 						{
-							"metrics": {"referrers_views": 65},
+							"metrics": {"referrers_views": 100},
 							"name": "blog.parse.ly",
 							"type": "internal"
 						},
 						{
-							"metrics": {"referrers_views": 12},
+							"metrics": {"referrers_views": 50},
 							"name": "bing",
 							"type": "search"
 						},
 						{
-							"metrics": {"referrers_views": 5},
+							"metrics": {"referrers_views": 30},
 							"name": "facebook.com",
 							"type": "social"
 						},
 						{
-							"metrics": {"referrers_views": 4},
+							"metrics": {"referrers_views": 10},
 							"name": "okt.to",
 							"type": "other"
 						},
 						{
-							"metrics": {"referrers_views": 4},
+							"metrics": {"referrers_views": 10},
 							"name": "yandex",
 							"type": "search"
 						},
 						{
-							"metrics": {"referrers_views": 3},
+							"metrics": {"referrers_views": 10},
 							"name": "parse.ly",
 							"type": "internal"
 						},
 						{
-							"metrics": {"referrers_views": 3},
+							"metrics": {"referrers_views": 10},
 							"name": "yahoo!",
 							"type": "search"
 						},
 						{
-							"metrics": {"referrers_views": 1},
+							"metrics": {"referrers_views": 5},
 							"name": "site1.com",
 							"type": "other"
 						},
 						{
-							"metrics": {"referrers_views": 1},
+							"metrics": {"referrers_views": 5},
 							"name": "link.site2.com",
 							"type": "other"
 						}
@@ -200,65 +206,68 @@ final class ReferrersPostDetailProxyEndpointTest extends ProxyEndpointTest {
 
 		$expected_top = (object) array(
 			'direct'        => (object) array(
-				'views'                  => '1,866',
-				'viewsPercentage'        => false,
-				'datasetViewsPercentage' => '50.22',
+				'views'                  => '770',
+				'viewsPercentage'        => '30.80',
+				'datasetViewsPercentage' => '31.43',
 			),
 			'google'        => (object) array(
-				'views'                  => '1,768',
-				'viewsPercentage'        => false,
-				'datasetViewsPercentage' => '47.58',
+				'views'                  => '1,500',
+				'viewsPercentage'        => '60.00',
+				'datasetViewsPercentage' => '61.22',
 			),
 			'blog.parse.ly' => (object) array(
-				'views'                  => '65',
-				'viewsPercentage'        => false,
-				'datasetViewsPercentage' => '1.75',
+				'views'                  => '100',
+				'viewsPercentage'        => '4.00',
+				'datasetViewsPercentage' => '4.08',
 			),
 			'bing'          => (object) array(
-				'views'                  => '12',
-				'viewsPercentage'        => false,
-				'datasetViewsPercentage' => '0.32',
+				'views'                  => '50',
+				'viewsPercentage'        => '2.00',
+				'datasetViewsPercentage' => '2.04',
 			),
 			'facebook.com'  => (object) array(
-				'views'                  => '5',
-				'viewsPercentage'        => false,
-				'datasetViewsPercentage' => '0.13',
+				'views'                  => '30',
+				'viewsPercentage'        => '1.20',
+				'datasetViewsPercentage' => '1.22',
 			),
 			'totals'        => (object) array(
-				'views'                  => '3,716',
-				'viewsPercentage'        => false,
+				'views'                  => '2,450',
+				'viewsPercentage'        => '98.00',
 				'datasetViewsPercentage' => '100.00',
 			),
 		);
 
 		$expected_types = (object) array(
 			'social'   => (object) array(
-				'views'           => '5',
-				'viewsPercentage' => false,
+				'views'           => '30',
+				'viewsPercentage' => '1.20',
 			),
 			'search'   => (object) array(
-				'views'           => '1,787',
-				'viewsPercentage' => false,
+				'views'           => '1,570',
+				'viewsPercentage' => '62.80',
 			),
 			'other'    => (object) array(
-				'views'           => '6',
-				'viewsPercentage' => false,
+				'views'           => '20',
+				'viewsPercentage' => '0.80',
 			),
 			'internal' => (object) array(
-				'views'           => '68',
-				'viewsPercentage' => false,
+				'views'           => '110',
+				'viewsPercentage' => '4.40',
 			),
 			'direct'   => (object) array(
-				'views'           => '-1,866',
-				'viewsPercentage' => false,
+				'views'           => '770',
+				'viewsPercentage' => '30.80',
 			),
 			'totals'   => (object) array(
-				'views'           => '0',
-				'viewsPercentage' => false,
+				'views'           => '2,500',
+				'viewsPercentage' => '100.00',
 			),
 		);
 
-		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/wp-parsely/v1/referrers/post/detail' ) );
+		$request = new WP_REST_Request( 'GET', self::$route );
+		$request->set_param( 'total_views', '2,500' );
+
+		$response = rest_get_server()->dispatch( $request );
 
 		self::assertSame( 1, $dispatched );
 		self::assertSame( 200, $response->get_status() );

--- a/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
@@ -83,10 +83,7 @@ final class ReferrersPostDetailProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 */
 	public function test_get_items_fails_when_site_id_is_not_set(): void {
-		$request = new WP_REST_Request( 'GET', self::$route );
-		$request->set_param( 'total_views', '2,500' );
-
-		parent::run_test_get_items_fails_without_site_id_set( $request );
+		parent::run_test_get_items_fails_without_site_id_set();
 	}
 
 	/**
@@ -107,10 +104,7 @@ final class ReferrersPostDetailProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 */
 	public function test_get_items_fails_when_api_secret_is_not_set(): void {
-		$request = new WP_REST_Request( 'GET', self::$route );
-		$request->set_param( 'total_views', '2,500' );
-
-		parent::run_test_get_items_fails_without_api_secret_set( $request );
+		parent::run_test_get_items_fails_without_api_secret_set();
 	}
 
 	/**

--- a/tests/Integration/ProxyEndpointTest.php
+++ b/tests/Integration/ProxyEndpointTest.php
@@ -137,27 +137,11 @@ abstract class ProxyEndpointTest extends TestCase {
 	 * @param WP_REST_Request|null $request The request object to be used.
 	 */
 	public function run_test_get_items_fails_without_site_id_set( $request = null ): void {
-		TestCase::set_options( array( 'apikey' => '' ) );
-		if ( null === $request ) {
-			$request = new WP_REST_Request( 'GET', self::$route );
-		}
-
-		$dispatched = 0;
-		add_filter(
-			'pre_http_request',
-			function () use ( &$dispatched ) {
-				$dispatched++;
-				return null;
-			}
-		);
-
-		$response = rest_get_server()->dispatch( $request );
-		$error    = $response->as_error();
-		self::assertSame( 403, $response->get_status() );
-		self::assertSame( 'parsely_site_id_not_set', $error->get_error_code() );
-		self::assertSame(
+		$this->run_test_get_items_fails(
+			array( 'apikey' => '' ),
+			'parsely_site_id_not_set',
 			'A Parse.ly Site ID must be set in site options to use this endpoint',
-			$error->get_error_message()
+			$request
 		);
 	}
 
@@ -168,12 +152,34 @@ abstract class ProxyEndpointTest extends TestCase {
 	 * @param WP_REST_Request|null $request The request object to be used.
 	 */
 	public function run_test_get_items_fails_without_api_secret_set( $request = null ): void {
-		TestCase::set_options(
+		$this->run_test_get_items_fails(
 			array(
 				'apikey'     => 'example.com',
 				'api_secret' => '',
-			)
+			),
+			'parsely_api_secret_not_set',
+			'A Parse.ly API Secret must be set in site options to use this endpoint',
+			$request
 		);
+	}
+
+	/**
+	 * Verifies that attempting to get items under the given conditions will
+	 * fail.
+	 *
+	 * @param array                $options The WordPress options to be set.
+	 * @param string               $expected_error_code The expected error code.
+	 * @param string               $expected_error_message The expected error message.
+	 * @param WP_REST_Request|null $request The request object to be used.
+	 * @return void
+	 */
+	private function run_test_get_items_fails(
+		array $options,
+		string $expected_error_code,
+		string $expected_error_message,
+		$request = null
+	) {
+		TestCase::set_options( $options );
 		if ( null === $request ) {
 			$request = new WP_REST_Request( 'GET', self::$route );
 		}
@@ -190,10 +196,7 @@ abstract class ProxyEndpointTest extends TestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$error    = $response->as_error();
 		self::assertSame( 403, $response->get_status() );
-		self::assertSame( 'parsely_api_secret_not_set', $error->get_error_code() );
-		self::assertSame(
-			'A Parse.ly API Secret must be set in site options to use this endpoint',
-			$error->get_error_message()
-		);
+		self::assertSame( $expected_error_code, $error->get_error_code() );
+		self::assertSame( $expected_error_message, $error->get_error_message() );
 	}
 }

--- a/tests/Integration/ProxyEndpointTest.php
+++ b/tests/Integration/ProxyEndpointTest.php
@@ -133,9 +133,14 @@ abstract class ProxyEndpointTest extends TestCase {
 	/**
 	 * Verifies that calls return an error and do not perform a remote call when
 	 * the Site ID is not populated in site options.
+	 *
+	 * @param WP_REST_Request|null $request The request object to be used.
 	 */
-	public function run_test_get_items_fails_without_site_id_set() {
+	public function run_test_get_items_fails_without_site_id_set( $request = null ): void {
 		TestCase::set_options( array( 'apikey' => '' ) );
+		if ( null === $request ) {
+			$request = new WP_REST_Request( 'GET', self::$route );
+		}
 
 		$dispatched = 0;
 		add_filter(
@@ -146,7 +151,7 @@ abstract class ProxyEndpointTest extends TestCase {
 			}
 		);
 
-		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', self::$route ) );
+		$response = rest_get_server()->dispatch( $request );
 		$error    = $response->as_error();
 		self::assertSame( 403, $response->get_status() );
 		self::assertSame( 'parsely_site_id_not_set', $error->get_error_code() );
@@ -159,14 +164,19 @@ abstract class ProxyEndpointTest extends TestCase {
 	/**
 	 * Verifies that calls return an error and do not perform a remote call when
 	 * the API Secret is not populated in site options.
+	 *
+	 * @param WP_REST_Request|null $request The request object to be used.
 	 */
-	public function run_test_get_items_fails_without_api_secret_set() {
+	public function run_test_get_items_fails_without_api_secret_set( $request = null ): void {
 		TestCase::set_options(
 			array(
 				'apikey'     => 'example.com',
 				'api_secret' => '',
 			)
 		);
+		if ( null === $request ) {
+			$request = new WP_REST_Request( 'GET', self::$route );
+		}
 
 		$dispatched = 0;
 		add_filter(
@@ -177,7 +187,7 @@ abstract class ProxyEndpointTest extends TestCase {
 			}
 		);
 
-		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', self::$route ) );
+		$response = rest_get_server()->dispatch( $request );
 		$error    = $response->as_error();
 		self::assertSame( 403, $response->get_status() );
 		self::assertSame( 'parsely_api_secret_not_set', $error->get_error_code() );


### PR DESCRIPTION
## Description
In certain cases, the top referrers percentage in the Content Helper would display as `NaN`. This was not a problem in the JS side, but rather an erroneous calculation in PHP which resulted in this.

## Motivation and context
Fix bugs!

## How has this been tested?
1. We first introduced integration tests that expose the issue.
2. We committed the fix that solves the issue.
3. The tests passed.