### PR TITLE
Fix referral distribution in Performance Details panel

### DIFF
--- a/src/RemoteAPI/class-remote-api-base.php
+++ b/src/RemoteAPI/class-remote-api-base.php
@@ -52,6 +52,17 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	}
 
 	/**
+	 * Gets Parse.ly API endpoint.
+	 *
+	 * @since 3.6.2
+	 *
+	 * @return string
+	 */
+	public function get_endpoint(): string {
+		return static::ENDPOINT;
+	}
+
+	/**
 	 * Gets the URL for a particular Parse.ly API endpoint.
 	 *
 	 * @since 3.2.0

--- a/src/RemoteAPI/class-remote-api-cache.php
+++ b/src/RemoteAPI/class-remote-api-cache.php
@@ -54,7 +54,11 @@ class Remote_API_Cache implements Remote_API_Interface {
 	 *                                             response is empty.
 	 */
 	public function get_items( $query, $associative = false ) {
-		$cache_key = 'parsely_api_' . wp_hash( (string) wp_json_encode( $this->remote_api ) ) . '_' . wp_hash( (string) wp_json_encode( $query ) );
+		$cache_key = (
+			'parsely_api_' .
+			wp_hash( $this->remote_api->get_endpoint() ) . '_' .
+			wp_hash( (string) wp_json_encode( $query ) )
+		);
 
 		/**
 		 * Variable.

--- a/tests/Integration/RemoteAPITest.php
+++ b/tests/Integration/RemoteAPITest.php
@@ -76,11 +76,11 @@ abstract class RemoteAPITest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		// If this method is called, that means our cache did not hit as
-		// expected.
+		// If this method is called, that means our cache did not hit as expected.
 		$api_mock->expects( self::never() )->method( 'get_items' );
+		$api_mock->method( 'get_endpoint' )->willReturn( self::$remote_api->get_endpoint() ); // Passing call to non-mock method.
 
-		$cache_key = 'parsely_api_' . wp_hash( $this->wp_json_encode( $api_mock ) ) . '_' . wp_hash( $this->wp_json_encode( array() ) );
+		$cache_key = 'parsely_api_' . wp_hash( self::$remote_api->get_endpoint() ) . '_' . wp_hash( $this->wp_json_encode( array() ) );
 
 		$object_cache = $this->createMock( Cache::class );
 		$object_cache->method( 'get' )
@@ -123,11 +123,11 @@ abstract class RemoteAPITest extends TestCase {
 		$api_mock->method( 'get_items' )
 			->willReturn( (object) array( 'cache_hit' => false ) );
 
-		// If this method is _NOT_ called, that means our cache did not miss as
-		// expected.
+		// If this method is _NOT_ called, that means our cache did not miss as expected.
 		$api_mock->expects( self::once() )->method( 'get_items' );
+		$api_mock->method( 'get_endpoint' )->willReturn( self::$remote_api->get_endpoint() ); // Passing call to non-mock method.
 
-		$cache_key = 'parsely_api_' . wp_hash( $this->wp_json_encode( $api_mock ) ) . '_' . wp_hash( $this->wp_json_encode( array() ) );
+		$cache_key = 'parsely_api_' . wp_hash( self::$remote_api->get_endpoint() ) . '_' . wp_hash( $this->wp_json_encode( array() ) );
 
 		$object_cache = $this->createMock( Cache::class );
 		$object_cache->method( 'get' )


### PR DESCRIPTION
## Description
In Performance Details panel we are calling two API's which under the hood manages same cache. The root cause of the issue was the cache collision means when we request 1st API then it populates the cache and on 2nd API call instead of requesting data from API it serves the results from cache which are wrong.

Fixes: #1367

## How this PR addresses the issue?
- Updated the cache key logic to avoid cache collisions.

## How has this been tested?
- Ran existing tests.

## Screenshots 

Before
![image](https://user-images.githubusercontent.com/31419912/218094727-a63531d9-c5b2-4305-a2d8-2a0a938c0f2d.png)

After
![image](https://user-images.githubusercontent.com/31419912/218094789-1c54241b-321e-4eb2-8545-0c4f1fbb1672.png)
