### PR TITLE
Fix referral distribution in Performance Details panel v3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix PHP 8 Incompatibilities ([#1362](https://github.com/Parsely/wp-parsely/pull/1362))
+- Fix referral distribution in Performance Details panel ([#1382](https://github.com/Parsely/wp-parsely/pull/1382))
 
 ## [3.6.1](https://github.com/Parsely/wp-parsely/compare/3.6.0...3.6.1) - 2022-12-20
 

--- a/src/RemoteAPI/class-base-proxy.php
+++ b/src/RemoteAPI/class-base-proxy.php
@@ -44,6 +44,17 @@ abstract class Base_Proxy implements Proxy {
 	}
 
 	/**
+	 * Gets Parse.ly API endpoint.
+	 *
+	 * @since 3.6.2
+	 *
+	 * @return string
+	 */
+	public function get_endpoint(): string {
+		return static::ENDPOINT;
+	}
+
+	/**
 	 * Gets the URL for a particular Parse.ly API endpoint.
 	 *
 	 * @since 3.2.0

--- a/src/RemoteAPI/class-cached-proxy.php
+++ b/src/RemoteAPI/class-cached-proxy.php
@@ -50,8 +50,13 @@ class Cached_Proxy implements Proxy {
 	 *                                    response is empty.
 	 */
 	public function get_items( array $query ) {
-		$cache_key = 'parsely_api_' . wp_hash( (string) wp_json_encode( $this->proxy ) ) . '_' . wp_hash( (string) wp_json_encode( $query ) );
-		$items     = $this->cache->get( $cache_key, self::CACHE_GROUP );
+		$cache_key = (
+			'parsely_api_' .
+			wp_hash( $this->remote_api->get_endpoint() ) . '_' .
+			wp_hash( (string) wp_json_encode( $query ) )
+		);
+
+		$items = $this->cache->get( $cache_key, self::CACHE_GROUP );
 
 		if ( false === $items ) {
 			$items = $this->proxy->get_items( $query );

--- a/src/RemoteAPI/class-cached-proxy.php
+++ b/src/RemoteAPI/class-cached-proxy.php
@@ -52,7 +52,7 @@ class Cached_Proxy implements Proxy {
 	public function get_items( array $query ) {
 		$cache_key = (
 			'parsely_api_' .
-			wp_hash( $this->remote_api->get_endpoint() ) . '_' .
+			wp_hash( $this->proxy->get_endpoint() ) . '_' .
 			wp_hash( (string) wp_json_encode( $query ) )
 		);
 

--- a/tests/Integration/RemoteAPITest.php
+++ b/tests/Integration/RemoteAPITest.php
@@ -79,8 +79,9 @@ abstract class RemoteAPITest extends TestCase {
 		// If this method is called, that means our cache did not hit as
 		// expected.
 		$proxy_mock->expects( self::never() )->method( 'get_items' );
+		$proxy_mock->method( 'get_endpoint' )->willReturn( self::$proxy->get_endpoint() ); // Passing call to non-mock method.
 
-		$cache_key = 'parsely_api_' . wp_hash( wp_json_encode( $proxy_mock ) ) . '_' . wp_hash( wp_json_encode( array() ) );
+		$cache_key = 'parsely_api_' . wp_hash( self::$proxy->get_endpoint() ) . '_' . wp_hash( wp_json_encode( array() ) );
 
 		$object_cache = $this->createMock( Cache::class );
 		$object_cache->method( 'get' )
@@ -121,8 +122,9 @@ abstract class RemoteAPITest extends TestCase {
 		// If this method is _NOT_ called, that means our cache did not miss as
 		// expected.
 		$proxy_mock->expects( self::once() )->method( 'get_items' );
+		$proxy_mock->method( 'get_endpoint' )->willReturn( self::$proxy->get_endpoint() ); // Passing call to non-mock method.
 
-		$cache_key = 'parsely_api_' . wp_hash( wp_json_encode( $proxy_mock ) ) . '_' . wp_hash( wp_json_encode( array() ) );
+		$cache_key = 'parsely_api_' . wp_hash( self::$proxy->get_endpoint() ) . '_' . wp_hash( wp_json_encode( array() ) );
 
 		$object_cache = $this->createMock( Cache::class );
 		$object_cache->method( 'get' )


### PR DESCRIPTION
## Description
In Performance Details panel we are calling two API's which under the hood manages same cache. The root cause of the issue was the cache collision means when we request 1st API then it populates the cache and on 2nd API call instead of requesting data from API it serves the results from cache which are wrong.

Fixes: #1367

## How this PR addresses the issue?
- Updated the cache key logic to avoid cache collisions.

## How has this been tested?
- Ran existing tests.

## Screenshots 

Before
![image](https://user-images.githubusercontent.com/31419912/218094727-a63531d9-c5b2-4305-a2d8-2a0a938c0f2d.png)

After
![image](https://user-images.githubusercontent.com/31419912/218094789-1c54241b-321e-4eb2-8545-0c4f1fbb1672.png)
