### PR TITLE
Upgrade minimum PHP version to 7.2

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,7 +23,6 @@ jobs:
       WP_VERSION: ${{ matrix.wp }}
 
     strategy:
-      # PHP 7.1 uses PHPUnit 7.5.20
       # PHP 7.2 uses PHPUnit 8.5.21
       # PHP 7.3 uses PHPUnit 9.5.10
       # PHP 7.4 uses PHPUnit 9.5.10
@@ -39,10 +38,6 @@ jobs:
         coverage: [none]
         experimental: [false]
         include:
-          - php: '7.1'
-            wp: '5.8.3'
-            coverage: none
-            experimental: false
           - php: '8.0'
             coverage: pcov
             extensions: pcov

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,7 +25,6 @@ jobs:
       WP_VERSION: latest
 
     strategy:
-      # PHP 7.1 uses PHPUnit 7.5.20
       # PHP 7.2 uses PHPUnit 8.5.21
       # PHP 7.3 uses PHPUnit 9.5.10
       # PHP 7.4 uses PHPUnit 9.5.10
@@ -35,7 +34,7 @@ jobs:
       # - coverage: Whether to run the tests with code coverage.
       # - experimental: Whether the build is "allowed to fail".
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4']
         coverage: [none]
         experimental: [false]
         include:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.1",
+		"php": ">=7.2",
 		"composer/installers": "^1"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,19 +17,19 @@
 	},
 	"require-dev": {
 		"automattic/vipwpcs": "^2.2",
+		"axepress/wp-graphql-stubs": "^1.13",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
+		"php-stubs/wordpress-tests-stubs": "^6.1.1",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
-		"squizlabs/php_codesniffer": "^3.5",
-		"wp-coding-standards/wpcs": "^2.3.0",
-		"yoast/wp-test-utils": "^1",
-		"phpstan/phpstan": "^1.4",
 		"phpstan/extension-installer": "^1.1",
-		"phpstan/phpstan-strict-rules": "^1.1",
-		"szepeviktor/phpstan-wordpress": "^1.0",
-		"axepress/wp-graphql-stubs": "^1.13",
 		"phpstan/phpstan-mockery": "^1.0",
-		"php-stubs/wordpress-tests-stubs": "^6.1.1"
+		"phpstan/phpstan-strict-rules": "^1.1",
+		"phpstan/phpstan": "^1.4",
+		"squizlabs/php_codesniffer": "^3.5",
+		"szepeviktor/phpstan-wordpress": "^1.0",
+		"wp-coding-standards/wpcs": "^2.3.0",
+		"yoast/wp-test-utils": "^1"
 	},
 	"config": {
 		"allow-plugins": {

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -18,7 +18,7 @@
  * License:           GPL-2.0-or-later
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * GitHub Plugin URI: https://github.com/Parsely/wp-parsely
- * Requires PHP:      7.1
+ * Requires PHP:      7.2
  * Requires WP:       5.0.0
  */
 


### PR DESCRIPTION
## Description
After internal discussion (@mjangda, @mehmoodak, @acicovic), we have decided to upgrade the plugin's minimum PHP version to 7.2.

## Impact and compatibility

As this PR does not update any code to PHP 7.2 syntax, this change is backwards-compatible (thus we include it in a minor version upgrade). However, sites using PHP 7.1 will not be able to update to wp-parsely 3.8 automatically. The recommended solution is to upgrade to PHP 7.2 or newer.

## Motivation and context
Merge PRs	#1269 and #1270 into our codebase.

## How has this been tested?
Existing tests should pass.