### PR TITLE
Show/hide Parse.ly widget and stats column based on user capabilities

### DIFF
--- a/src/Endpoints/class-analytics-post-detail-api-proxy.php
+++ b/src/Endpoints/class-analytics-post-detail-api-proxy.php
@@ -24,7 +24,7 @@ final class Analytics_Post_Detail_API_Proxy extends Base_API_Proxy {
 	 * Registers the endpoint's WP REST route.
 	 */
 	public function run(): void {
-		$this->register_endpoint( '/stats/post/detail', 'publish_posts' );
+		$this->register_endpoint( '/stats/post/detail' );
 	}
 
 	/**

--- a/src/Endpoints/class-analytics-posts-api-proxy.php
+++ b/src/Endpoints/class-analytics-posts-api-proxy.php
@@ -26,7 +26,7 @@ final class Analytics_Posts_API_Proxy extends Base_API_Proxy {
 	 * Registers the endpoint's WP REST route.
 	 */
 	public function run(): void {
-		$this->register_endpoint( '/stats/posts', 'publish_posts' );
+		$this->register_endpoint( '/stats/posts' );
 	}
 
 	/**

--- a/src/Endpoints/class-base-api-proxy.php
+++ b/src/Endpoints/class-base-api-proxy.php
@@ -29,15 +29,6 @@ abstract class Base_API_Proxy {
 	protected $parsely;
 
 	/**
-	 * Capability of the user based on which we should allow access to endpoint.
-	 *
-	 * `null` should be used for all public endpoints.
-	 *
-	 * @var string|null
-	 */
-	protected $user_capability;
-
-	/**
 	 * Proxy object which does the actual calls to the Parse.ly API.
 	 *
 	 * @var Remote_API_Interface
@@ -72,17 +63,7 @@ abstract class Base_API_Proxy {
 	 * @return bool
 	 */
 	public function permission_callback(): bool {
-		// This endpoint does not require any capability checks.
-		if ( is_null( $this->user_capability ) ) {
-			return true;
-		}
-
-		// The user has the required capability to access this endpoint.
-		if ( current_user_can( $this->user_capability ) ) {
-			return true;
-		}
-
-		return false;
+		return $this->api->is_user_allowed_to_make_api_call();
 	}
 
 	/**
@@ -99,13 +80,9 @@ abstract class Base_API_Proxy {
 	/**
 	 * Registers the endpoint's WP REST route.
 	 *
-	 * @param string      $endpoint The endpoint's route (e.g. /stats/posts).
-	 * @param string|null $user_capability Capability of the user based on which we should allow access to endpoint.
-	 * @param bool        $show_in_index Show endpoint in /wp-json view if TRUE.
+	 * @param string $endpoint The endpoint's route (e.g. /stats/posts).
 	 */
-	protected function register_endpoint( string $endpoint, ?string $user_capability, $show_in_index = false ): void {
-		$this->user_capability = $user_capability;
-
+	protected function register_endpoint( string $endpoint ): void {
 		$filter_key = trim( str_replace( '/', '_', $endpoint ), '_' );
 		if ( ! apply_filters( 'wp_parsely_enable_' . $filter_key . '_api_proxy', true ) ) {
 			return;
@@ -131,7 +108,7 @@ abstract class Base_API_Proxy {
 				'callback'            => array( $this, 'get_items' ),
 				'permission_callback' => array( $this, 'permission_callback' ),
 				'args'                => $get_items_args,
-				'show_in_index'       => $show_in_index,
+				'show_in_index'       => $this->permission_callback(),
 			),
 		);
 

--- a/src/Endpoints/class-referrers-post-detail-api-proxy.php
+++ b/src/Endpoints/class-referrers-post-detail-api-proxy.php
@@ -35,7 +35,7 @@ final class Referrers_Post_Detail_API_Proxy extends Base_API_Proxy {
 	 * @since 3.6.0
 	 */
 	public function run(): void {
-		$this->register_endpoint( '/referrers/post/detail', 'publish_posts' );
+		$this->register_endpoint( '/referrers/post/detail' );
 	}
 
 	/**

--- a/src/Endpoints/class-related-api-proxy.php
+++ b/src/Endpoints/class-related-api-proxy.php
@@ -23,7 +23,7 @@ final class Related_API_Proxy extends Base_API_Proxy {
 	 * Registers the endpoint's WP REST route.
 	 */
 	public function run(): void {
-		$this->register_endpoint( '/related', null, true );
+		$this->register_endpoint( '/related' );
 	}
 
 	/**

--- a/src/RemoteAPI/class-analytics-post-detail-api.php
+++ b/src/RemoteAPI/class-analytics-post-detail-api.php
@@ -20,4 +20,13 @@ use Parsely\Parsely;
 class Analytics_Post_Detail_API extends Remote_API_Base {
 	protected const ENDPOINT     = Parsely::PUBLIC_API_BASE_URL . '/analytics/post/detail';
 	protected const QUERY_FILTER = 'wp_parsely_analytics_post_detail_endpoint_args';
+
+	/**
+	 * Indicates whether the endpoint is public or protected behind permissions.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @var bool
+	 */
+	protected $is_public_endpoint = false;
 }

--- a/src/RemoteAPI/class-analytics-posts-api.php
+++ b/src/RemoteAPI/class-analytics-posts-api.php
@@ -59,6 +59,15 @@ class Analytics_Posts_API extends Remote_API_Base {
 	protected const QUERY_FILTER = 'wp_parsely_analytics_posts_endpoint_args';
 
 	/**
+	 * Indicates whether the endpoint is public or protected behind permissions.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @var bool
+	 */
+	protected $is_public_endpoint = false;
+
+	/**
 	 * Calls Parse.ly Analytics API to get posts info.
 	 *
 	 * Main purpose of this function is to enforce typing.

--- a/src/RemoteAPI/class-referrers-post-detail-api.php
+++ b/src/RemoteAPI/class-referrers-post-detail-api.php
@@ -20,4 +20,13 @@ use Parsely\Parsely;
 class Referrers_Post_Detail_API extends Remote_API_Base {
 	protected const ENDPOINT     = Parsely::PUBLIC_API_BASE_URL . '/referrers/post/detail';
 	protected const QUERY_FILTER = 'wp_parsely_referrers_post_detail_endpoint_args';
+
+	/**
+	 * Indicates whether the endpoint is public or protected behind permissions.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @var bool
+	 */
+	protected $is_public_endpoint = false;
 }

--- a/src/RemoteAPI/class-related-api.php
+++ b/src/RemoteAPI/class-related-api.php
@@ -20,4 +20,13 @@ use Parsely\Parsely;
 class Related_API extends Remote_API_Base {
 	protected const ENDPOINT     = Parsely::PUBLIC_API_BASE_URL . '/related';
 	protected const QUERY_FILTER = 'wp_parsely_related_endpoint_args';
+
+	/**
+	 * Indicates whether the endpoint is public or protected behind permissions.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @var bool
+	 */
+	protected $is_public_endpoint = true;
 }

--- a/src/RemoteAPI/class-remote-api-base.php
+++ b/src/RemoteAPI/class-remote-api-base.php
@@ -35,11 +35,31 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	protected const QUERY_FILTER = '';
 
 	/**
+	 * Indicates whether the endpoint is public or protected behind permissions.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @var bool
+	 */
+	protected $is_public_endpoint = false;
+
+	/**
 	 * Parsely Instance.
 	 *
 	 * @var Parsely
 	 */
 	private $parsely;
+
+	/**
+	 * Capability of the user based on which we should allow access to endpoint.
+	 *
+	 * `null` should be used for all public endpoints.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @var string|null
+	 */
+	private $user_capability;
 
 	/**
 	 * Constructor.
@@ -48,7 +68,8 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	 * @since 3.2.0
 	 */
 	public function __construct( Parsely $parsely ) {
-		$this->parsely = $parsely;
+		$this->parsely         = $parsely;
+		$this->user_capability = $this->is_public_endpoint ? null : 'publish_posts';
 	}
 
 	/**
@@ -133,5 +154,26 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 		$response = $decoded->data;
 
 		return $associative ? convert_to_associative_array( $response ) : $response;
+	}
+
+	/**
+	 * Check if user is capable for making API call.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @return bool
+	 */
+	public function is_user_allowed_to_make_api_call(): bool {
+		// This endpoint does not require any capability checks.
+		if ( is_null( $this->user_capability ) ) {
+			return true;
+		}
+
+		// The user has the required capability to access this endpoint.
+		if ( current_user_can( $this->user_capability ) ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/RemoteAPI/class-remote-api-base.php
+++ b/src/RemoteAPI/class-remote-api-base.php
@@ -51,7 +51,7 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	private $parsely;
 
 	/**
-	 * Capability of the user based on which we should allow access to endpoint.
+	 * User capability based on which we should allow access to the endpoint.
 	 *
 	 * `null` should be used for all public endpoints.
 	 *
@@ -157,7 +157,7 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	}
 
 	/**
-	 * Check if user is capable for making API call.
+	 * Checks if the current user is allowed to make the API call.
 	 *
 	 * @since 3.7.0
 	 *

--- a/src/RemoteAPI/class-remote-api-cache.php
+++ b/src/RemoteAPI/class-remote-api-cache.php
@@ -74,7 +74,7 @@ class Remote_API_Cache implements Remote_API_Interface {
 	}
 
 	/**
-	 * Check if user is capable for making API call.
+	 * Checks if the current user is allowed to make the API call.
 	 *
 	 * @since 3.7.0
 	 *

--- a/src/RemoteAPI/class-remote-api-cache.php
+++ b/src/RemoteAPI/class-remote-api-cache.php
@@ -72,4 +72,15 @@ class Remote_API_Cache implements Remote_API_Interface {
 
 		return $items;
 	}
+
+	/**
+	 * Check if user is capable for making API call.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @return bool
+	 */
+	public function is_user_allowed_to_make_api_call(): bool {
+		return $this->remote_api->is_user_allowed_to_make_api_call();
+	}
 }

--- a/src/RemoteAPI/interface-remote-api.php
+++ b/src/RemoteAPI/interface-remote-api.php
@@ -25,4 +25,11 @@ interface Remote_API_Interface {
 	 * @return WP_Error|array<string, mixed>|false
 	 */
 	public function get_items( $query, $associative = false );
+
+	/**
+	 * Check if user is capable for making API call.
+	 *
+	 * @return bool
+	 */
+	public function is_user_allowed_to_make_api_call(): bool;
 }

--- a/src/RemoteAPI/interface-remote-api.php
+++ b/src/RemoteAPI/interface-remote-api.php
@@ -27,7 +27,7 @@ interface Remote_API_Interface {
 	public function get_items( $query, $associative = false );
 
 	/**
-	 * Check if user is capable for making API call.
+	 * Checks if the current user is allowed to make the API call.
 	 *
 	 * @return bool
 	 */

--- a/src/UI/class-admin-columns-parsely-stats.php
+++ b/src/UI/class-admin-columns-parsely-stats.php
@@ -96,7 +96,7 @@ class Admin_Columns_Parsely_Stats {
 
 		$this->analytics_api = new Analytics_Posts_API( $this->parsely );
 
-		// Avoid adding column if user is not allowed to make API call.
+		// Don't add the column if the user is not allowed to make the API call.
 		if ( ! $this->analytics_api->is_user_allowed_to_make_api_call() ) {
 			return;
 		}

--- a/src/UI/class-admin-columns-parsely-stats.php
+++ b/src/UI/class-admin-columns-parsely-stats.php
@@ -52,6 +52,13 @@ class Admin_Columns_Parsely_Stats {
 	private $parsely;
 
 	/**
+	 * Instance of Parsely Analytics Posts API.
+	 *
+	 * @var Analytics_Posts_API
+	 */
+	private $analytics_api;
+
+	/**
 	 * Internal Variable.
 	 *
 	 * @var WP_Screen|null
@@ -84,6 +91,13 @@ class Admin_Columns_Parsely_Stats {
 	 */
 	public function run(): void {
 		if ( ! $this->parsely->site_id_is_set() ) {
+			return;
+		}
+
+		$this->analytics_api = new Analytics_Posts_API( $this->parsely );
+
+		// Avoid adding column if user is not allowed to make API call.
+		if ( ! $this->analytics_api->is_user_allowed_to_make_api_call() ) {
 			return;
 		}
 
@@ -189,7 +203,7 @@ class Admin_Columns_Parsely_Stats {
 			return; // Avoid calling the API if column is hidden.
 		}
 
-		$parsely_stats_response = $this->get_parsely_stats_response( new Analytics_Posts_API( $this->parsely ) );
+		$parsely_stats_response = $this->get_parsely_stats_response( $this->analytics_api );
 
 		if ( null === $parsely_stats_response ) {
 			return;

--- a/src/content-helper/dashboard-widget/class-dashboard-widget.php
+++ b/src/content-helper/dashboard-widget/class-dashboard-widget.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Parsely\ContentHelper;
 
 use Parsely\Parsely;
+use Parsely\RemoteAPI\Analytics_Posts_API;
 
 use const Parsely\PARSELY_FILE;
 
@@ -28,6 +29,13 @@ class Dashboard_Widget {
 	 * @since 3.7.0
 	 */
 	public function run(): void {
+		$posts_api = new Analytics_Posts_API( $GLOBALS['parsely'] );
+
+		// Avoid adding widget if user is not allowed to make API call.
+		if ( ! $posts_api->is_user_allowed_to_make_api_call() ) {
+			return;
+		}
+
 		add_action( 'wp_dashboard_setup', array( $this, 'add_dashboard_widget' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 	}

--- a/src/content-helper/dashboard-widget/class-dashboard-widget.php
+++ b/src/content-helper/dashboard-widget/class-dashboard-widget.php
@@ -31,7 +31,7 @@ class Dashboard_Widget {
 	public function run(): void {
 		$posts_api = new Analytics_Posts_API( $GLOBALS['parsely'] );
 
-		// Avoid adding widget if user is not allowed to make API call.
+		// Don't add the widget if the user is not allowed to make the API call.
 		if ( ! $posts_api->is_user_allowed_to_make_api_call() ) {
 			return;
 		}

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Parsely\Tests\Integration;
 
+use DateInterval;
 use DateTime;
 use DateTimeZone;
 use ReflectionClass;
@@ -208,7 +209,20 @@ abstract class TestCase extends WPIntegrationTestCase {
 		 * @var int[]
 		 */
 		$post_ids = array();
-		$date     = new DateTime( '2009-12-31', new DateTimeZone( 'America/New_York' ) ); // Date with timezone to replicate real world scenarios.
+
+		/**
+		 * Variable.
+		 *
+		 * @var DateTime
+		 */
+		$date = new DateTime( '2009-12-31', new DateTimeZone( 'America/New_York' ) ); // Date with timezone to replicate real world scenarios.
+
+		/**
+		 * Variable.
+		 *
+		 * @var DateInterval
+		 */
+		$one_day_interval = date_interval_create_from_date_string( '1 days' );
 
 		for ( $i = 1; $i <= $num_of_posts; $i++ ) {
 			/**
@@ -216,7 +230,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 			 *
 			 * @var DateTime
 			 */
-			$post_date = date_add( $date, date_interval_create_from_date_string( '1 days' ) ); // Increment by 1 day like sequence.
+			$post_date = date_add( $date, $one_day_interval ); // Like sequence increment by 1 day.
 			$post_id   = self::factory()->post->create(
 				array(
 					'post_type'     => $post_type,

--- a/tests/Integration/UI/AdminColumnsParselyStatsTest.php
+++ b/tests/Integration/UI/AdminColumnsParselyStatsTest.php
@@ -54,6 +54,7 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 		parent::set_up();
 
 		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
+		$this->set_admin_user();
 	}
 
 	/**


### PR DESCRIPTION
## Description
Hides UI of Parsely Widget and Stats Column based on user capability.

Closes #1406

## What was causing the issue?
For _Widget_ the root cause of the issue is that we are performing checks on proxy endpoints which does this verification when the API is actually called not while including assets and due to this UI appears even when API responds with error.

For _Stats Column_ we don't use proxy endpoint which means no checks and due to this UI appears with data.

## How this issue is being fixed?
- Moved permission checks from proxy endpoints to actual remote endpoints.
  - Uses `$is_public_endpoint` attribute and based on this we will either make the endpoint public or use the default `publish_posts` capability check (can extend this more in future)
- Proxy endpoints can define permissions on REST endpoints by utilizing the checks from base remote endpoints.

## How has this been tested?
- Ran existing tests with some changes.
