### PR TITLE
README.md: Update contributor list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requires PHP: 7.1
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 Tags: analytics, content marketing, parse.ly, parsely, parsley  
-Contributors: parsely, acicovic, jblz, GaryJ, hbbtstar, mehmoodak
+Contributors: parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak
 
 The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.
 


### PR DESCRIPTION
## Description
After some recent changes to our README.md, we're reverting back to the original contributor list. The only difference is that since there is no wordpress.org account associated to Pau anymore (and thus he is not being listed in plugin contributors anyway), we have removed the associated string.

## Motivation and context
Keep things as they are until we figure out what approach we want to take concerning the contributor listing.

## How has this been tested?
No code changes