### PR TITLE
Add shell script for updating the wp-parsely version number

### DIFF
--- a/bin/uvn.sh
+++ b/bin/uvn.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-# Script to update version numbers (uvn) in the code.
+# Script to update version numbers (uvn) in the code. It will create a new
+# branch and commit the changes. After inspecting the results, it can be pushed
+# to GitHub as a PR.
+#
 # Usage: Specify the new version as an argument. (e.g. bin/uvn.sh 3.7.0)
-# Note: Has only been tested with macOS sed.
+# Note: This has only been tested with macOS sed.
 
 git checkout -b update/wp-parsely-version-to-$1
 
@@ -13,3 +16,5 @@ sed -i '' "s/ \* Version:           .*$/ \* Version:           $1/" wp-parsely.p
 sed -i '' "s/const PARSELY_VERSION = '.*'/const PARSELY_VERSION = '$1'/" wp-parsely.php
 
 npm install # Update version numbers in package.lock.json.
+
+git add -A && git commit -m "Update wp-parsely version to $1"

--- a/bin/uvn.sh
+++ b/bin/uvn.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Script to update version numbers (uvn) in the code.
+# Usage: Specify the new version as an argument. (e.g. bin/uvn.sh 3.7.0)
+# Note: Has only been tested with macOS sed.
+
+git checkout -b update/wp-parsely-version-to-$1
+
+sed -i '' "s/Stable tag: .*  $/Stable tag: $1  /" README.md
+sed -i '' "s/\"version\": \".*\"/\"version\": \"$1\"/" package.json
+sed -i '' "s/export const PLUGIN_VERSION = '.*'/export const PLUGIN_VERSION = '$1'/" tests/e2e/utils.ts
+sed -i '' "s/ \* Version:           .*$/ \* Version:           $1/" wp-parsely.php
+sed -i '' "s/const PARSELY_VERSION = '.*'/const PARSELY_VERSION = '$1'/" wp-parsely.php
+
+npm install # Update version numbers in package.lock.json.


### PR DESCRIPTION
## Description
With this PR we're adding a shell script that updates wp-parsely's version number strings in all our codebase easily.

The script will create a new branch and commit the changes there. The only thing after that is inspect the correctness of the changes, and push the branch to GitHub.

## How to run
While being in the plugin directory, run `bin/uvn.sh <version>` (e.g. `bin/uvn.sh 3.7.0`).

## Motivation and context
Update version numbers in our code faster.

## How has this been tested?
Local testing, only tested on macOS sed which requires the `''` after `sed -i`.