### PR TITLE
Add filters to configure user capability on remote APIs

### DIFF
--- a/src/Endpoints/class-base-api-proxy.php
+++ b/src/Endpoints/class-base-api-proxy.php
@@ -17,6 +17,8 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;
 
+use function Parsely\Utils\convert_endpoint_to_filter_key;
+
 /**
  * Configures a REST API endpoint for use.
  */
@@ -83,8 +85,7 @@ abstract class Base_API_Proxy {
 	 * @param string $endpoint The endpoint's route (e.g. /stats/posts).
 	 */
 	protected function register_endpoint( string $endpoint ): void {
-		$filter_key = trim( str_replace( '/', '_', $endpoint ), '_' );
-		if ( ! apply_filters( 'wp_parsely_enable_' . $filter_key . '_api_proxy', true ) ) {
+		if ( ! apply_filters( 'wp_parsely_enable_' . convert_endpoint_to_filter_key( $endpoint ) . '_api_proxy', true ) ) {
 			return;
 		}
 

--- a/src/RemoteAPI/class-analytics-post-detail-api.php
+++ b/src/RemoteAPI/class-analytics-post-detail-api.php
@@ -18,7 +18,7 @@ use Parsely\Parsely;
  * @since 3.6.0
  */
 class Analytics_Post_Detail_API extends Remote_API_Base {
-	protected const ENDPOINT     = Parsely::PUBLIC_API_BASE_URL . '/analytics/post/detail';
+	protected const ENDPOINT     = '/analytics/post/detail';
 	protected const QUERY_FILTER = 'wp_parsely_analytics_post_detail_endpoint_args';
 
 	/**

--- a/src/RemoteAPI/class-analytics-posts-api.php
+++ b/src/RemoteAPI/class-analytics-posts-api.php
@@ -55,7 +55,7 @@ class Analytics_Posts_API extends Remote_API_Base {
 	public const MAX_RECORDS_LIMIT        = 2000;
 	public const ANALYTICS_API_DAYS_LIMIT = 7;
 
-	protected const ENDPOINT     = Parsely::PUBLIC_API_BASE_URL . '/analytics/posts';
+	protected const ENDPOINT     = '/analytics/posts';
 	protected const QUERY_FILTER = 'wp_parsely_analytics_posts_endpoint_args';
 
 	/**

--- a/src/RemoteAPI/class-referrers-post-detail-api.php
+++ b/src/RemoteAPI/class-referrers-post-detail-api.php
@@ -18,7 +18,7 @@ use Parsely\Parsely;
  * @since 3.6.0
  */
 class Referrers_Post_Detail_API extends Remote_API_Base {
-	protected const ENDPOINT     = Parsely::PUBLIC_API_BASE_URL . '/referrers/post/detail';
+	protected const ENDPOINT     = '/referrers/post/detail';
 	protected const QUERY_FILTER = 'wp_parsely_referrers_post_detail_endpoint_args';
 
 	/**

--- a/src/RemoteAPI/class-related-api.php
+++ b/src/RemoteAPI/class-related-api.php
@@ -18,7 +18,7 @@ use Parsely\Parsely;
  * @since 3.2.0
  */
 class Related_API extends Remote_API_Base {
-	protected const ENDPOINT     = Parsely::PUBLIC_API_BASE_URL . '/related';
+	protected const ENDPOINT     = '/related';
 	protected const QUERY_FILTER = 'wp_parsely_related_endpoint_args';
 
 	/**

--- a/src/RemoteAPI/class-remote-api-base.php
+++ b/src/RemoteAPI/class-remote-api-base.php
@@ -14,6 +14,7 @@ use Parsely\Parsely;
 use UnexpectedValueException;
 use WP_Error;
 
+use function Parsely\Utils\convert_endpoint_to_filter_key;
 use function Parsely\Utils\convert_to_associative_array;
 
 /**
@@ -68,8 +69,31 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	 * @since 3.2.0
 	 */
 	public function __construct( Parsely $parsely ) {
-		$this->parsely         = $parsely;
-		$this->user_capability = $this->is_public_endpoint ? null : 'publish_posts';
+		$this->parsely = $parsely;
+
+		if ( $this->is_public_endpoint ) {
+			$this->user_capability = null;
+		} else {
+			/**
+			 * Filter to change the default user capability on all private remote endpoints.
+			 *
+			 * @var string
+			 *
+			 * @since 3.7.0
+			 */
+			$default_user_capability = apply_filters( 'wp_parsely_user_capability_for_all_private_apis', 'publish_posts' );
+
+			/**
+			 * Filter to change the user capability on specific remote endpoint.
+			 *
+			 * @var string
+			 *
+			 * @since 3.7.0
+			 */
+			$endpoint_specific_user_capability = apply_filters( 'wp_parsely_user_capability_for_' . convert_endpoint_to_filter_key( static::ENDPOINT ) . '_api', $default_user_capability );
+
+			$this->user_capability = $endpoint_specific_user_capability;
+		}
 	}
 
 	/**
@@ -113,7 +137,7 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound -- Hook names are defined in child classes.
 		$query = apply_filters( static::QUERY_FILTER, $query );
-		return add_query_arg( $query, static::ENDPOINT );
+		return add_query_arg( $query, Parsely::PUBLIC_API_BASE_URL . static::ENDPOINT );
 	}
 
 	/**

--- a/src/RemoteAPI/class-remote-api-base.php
+++ b/src/RemoteAPI/class-remote-api-base.php
@@ -66,7 +66,9 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	 * Constructor.
 	 *
 	 * @param Parsely $parsely Parsely instance.
+	 *
 	 * @since 3.2.0
+	 * @since 3.7.0 Added user capability checks based on `is_public_endpoint` attribute.
 	 */
 	public function __construct( Parsely $parsely ) {
 		$this->parsely = $parsely;
@@ -75,20 +77,16 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 			$this->user_capability = null;
 		} else {
 			/**
-			 * Filter to change the default user capability on all private remote endpoints.
+			 * Filter to change the default user capability for all private remote apis.
 			 *
 			 * @var string
-			 *
-			 * @since 3.7.0
 			 */
 			$default_user_capability = apply_filters( 'wp_parsely_user_capability_for_all_private_apis', 'publish_posts' );
 
 			/**
-			 * Filter to change the user capability on specific remote endpoint.
+			 * Filter to change the user capability for specific remote api.
 			 *
 			 * @var string
-			 *
-			 * @since 3.7.0
 			 */
 			$endpoint_specific_user_capability = apply_filters( 'wp_parsely_user_capability_for_' . convert_endpoint_to_filter_key( static::ENDPOINT ) . '_api', $default_user_capability );
 

--- a/src/Utils/utils.php
+++ b/src/Utils/utils.php
@@ -238,6 +238,8 @@ function convert_to_positive_integer( string $string ): int {
  *
  * @param string $endpoint Route of the endpoint.
  *
+ * @since 3.7.0
+ *
  * @return string
  */
 function convert_endpoint_to_filter_key( string $endpoint ): string {

--- a/src/Utils/utils.php
+++ b/src/Utils/utils.php
@@ -234,7 +234,7 @@ function convert_to_positive_integer( string $string ): int {
 }
 
 /**
- * Convert endpoint to filter key by replacing `/` with `_`.
+ * Converts endpoint to filter key by replacing `/` with `_`.
  *
  * @param string $endpoint Route of the endpoint.
  *

--- a/src/Utils/utils.php
+++ b/src/Utils/utils.php
@@ -232,3 +232,14 @@ function convert_to_associative_array( $obj ) {
 function convert_to_positive_integer( string $string ): int {
 	return (int) preg_replace( '/\D/', '', $string );
 }
+
+/**
+ * Convert endpoint to filter key by replacing `/` with `_`.
+ *
+ * @param string $endpoint Route of the endpoint.
+ *
+ * @return string
+ */
+function convert_endpoint_to_filter_key( string $endpoint ): string {
+	return trim( str_replace( '/', '_', $endpoint ), '_' );
+}

--- a/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
@@ -141,6 +141,56 @@ final class AnalyticsPostsProxyEndpointTest extends ProxyEndpointTest {
 	}
 
 	/**
+	 * Verifies default user capability filter.
+	 *
+	 * @covers \Parsely\Endpoints\Analytics_Posts_API_Proxy::permission_callback
+	 *
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::is_user_allowed_to_make_api_call
+	 */
+	public function test_user_is_allowed_to_make_proxy_api_call_if_default_user_capability_is_changed(): void {
+		$this->login_as_contributor();
+		add_filter(
+			'wp_parsely_user_capability_for_all_private_apis',
+			function () {
+				return 'edit_posts';
+			}
+		);
+
+		$proxy_api = new Analytics_Posts_API_Proxy(
+			new Parsely(),
+			new Analytics_Posts_API( new Parsely() )
+		);
+
+		self::assertTrue( $proxy_api->permission_callback() );
+	}
+
+	/**
+	 * Verifies endpoint specific user capability filter.
+	 *
+	 * @covers \Parsely\Endpoints\Analytics_Posts_API_Proxy::permission_callback
+	 *
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::is_user_allowed_to_make_api_call
+	 */
+	public function test_user_is_allowed_to_make_proxy_api_call_if_endpoint_specific_user_capability_is_changed(): void {
+		$this->login_as_contributor();
+		add_filter(
+			'wp_parsely_user_capability_for_analytics_posts_api',
+			function () {
+				return 'edit_posts';
+			}
+		);
+
+		$proxy_api = new Analytics_Posts_API_Proxy(
+			new Parsely(),
+			new Analytics_Posts_API( new Parsely() )
+		);
+
+		self::assertTrue( $proxy_api->permission_callback() );
+	}
+
+	/**
 	 * Verifies that calls to `GET /wp-parsely/v1/stats/posts` return
 	 * results in the expected format.
 	 *

--- a/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
@@ -110,6 +110,56 @@ final class ReferrersPostDetailProxyEndpointTest extends ProxyEndpointTest {
 	}
 
 	/**
+	 * Verifies default user capability filter.
+	 *
+	 * @covers \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::permission_callback
+	 *
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::is_user_allowed_to_make_api_call
+	 */
+	public function test_user_is_allowed_to_make_proxy_api_call_if_default_user_capability_is_changed(): void {
+		$this->login_as_contributor();
+		add_filter(
+			'wp_parsely_user_capability_for_all_private_apis',
+			function () {
+				return 'edit_posts';
+			}
+		);
+
+		$proxy_api = new Referrers_Post_Detail_API_Proxy(
+			new Parsely(),
+			new Referrers_Post_Detail_API( new Parsely() )
+		);
+
+		self::assertTrue( $proxy_api->permission_callback() );
+	}
+
+	/**
+	 * Verifies endpoint specific user capability filter.
+	 *
+	 * @covers \Parsely\Endpoints\Referrers_Post_Detail_API_Proxy::permission_callback
+	 *
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::is_user_allowed_to_make_api_call
+	 */
+	public function test_user_is_allowed_to_make_proxy_api_call_if_endpoint_specific_user_capability_is_changed(): void {
+		$this->login_as_contributor();
+		add_filter(
+			'wp_parsely_user_capability_for_referrers_post_detail_api',
+			function () {
+				return 'edit_posts';
+			}
+		);
+
+		$proxy_api = new Referrers_Post_Detail_API_Proxy(
+			new Parsely(),
+			new Referrers_Post_Detail_API( new Parsely() )
+		);
+
+		self::assertTrue( $proxy_api->permission_callback() );
+	}
+
+	/**
 	 * Verifies that calls to `GET /wp-parsely/v1/referrers/post/detail` return
 	 * results in the expected format.
 	 *

--- a/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
@@ -110,6 +110,56 @@ final class StatsPostDetailProxyEndpointTest extends ProxyEndpointTest {
 	}
 
 	/**
+	 * Verifies default user capability filter.
+	 *
+	 * @covers \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::permission_callback
+	 *
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::is_user_allowed_to_make_api_call
+	 */
+	public function test_user_is_allowed_to_make_proxy_api_call_if_default_user_capability_is_changed(): void {
+		$this->login_as_contributor();
+		add_filter(
+			'wp_parsely_user_capability_for_all_private_apis',
+			function () {
+				return 'edit_posts';
+			}
+		);
+
+		$proxy_api = new Analytics_Post_Detail_API_Proxy(
+			new Parsely(),
+			new Analytics_Post_Detail_API( new Parsely() )
+		);
+
+		self::assertTrue( $proxy_api->permission_callback() );
+	}
+
+	/**
+	 * Verifies endpoint specific user capability filter.
+	 *
+	 * @covers \Parsely\Endpoints\Analytics_Post_Detail_API_Proxy::permission_callback
+	 *
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::is_user_allowed_to_make_api_call
+	 */
+	public function test_user_is_allowed_to_make_proxy_api_call_if_endpoint_specific_user_capability_is_changed(): void {
+		$this->login_as_contributor();
+		add_filter(
+			'wp_parsely_user_capability_for_analytics_post_detail_api',
+			function () {
+				return 'edit_posts';
+			}
+		);
+
+		$proxy_api = new Analytics_Post_Detail_API_Proxy(
+			new Parsely(),
+			new Analytics_Post_Detail_API( new Parsely() )
+		);
+
+		self::assertTrue( $proxy_api->permission_callback() );
+	}
+
+	/**
 	 * Verifies that calls to `GET /wp-parsely/v1/analytics/post/detail` return
 	 * results in the expected format.
 	 *

--- a/tests/Integration/RemoteAPI/AnalyticsPostsRemoteAPITest.php
+++ b/tests/Integration/RemoteAPI/AnalyticsPostsRemoteAPITest.php
@@ -81,4 +81,33 @@ final class AnalyticsPostsRemoteAPITest extends RemoteAPITest {
 
 		self::assertTrue( $api->is_user_allowed_to_make_api_call() );
 	}
+
+	/**
+	 * Verifies that endpoint specific user capability filter have more priority than default.
+	 *
+	 * @covers \Parsely\RemoteAPI\Remote_API_Base::is_user_allowed_to_make_api_call
+	 *
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 */
+	public function test_endpoint_specific_user_capability_filter_have_more_priority_than_default(): void {
+		$this->login_as_contributor();
+
+		add_filter(
+			'wp_parsely_user_capability_for_all_private_apis',
+			function () {
+				return 'publish_posts';
+			}
+		);
+
+		add_filter(
+			'wp_parsely_user_capability_for_analytics_posts_api',
+			function () {
+				return 'edit_posts';
+			}
+		);
+
+		$api = new Analytics_Posts_API( new Parsely() );
+
+		self::assertTrue( $api->is_user_allowed_to_make_api_call() );
+	}
 }

--- a/tests/Integration/RemoteAPI/AnalyticsPostsRemoteAPITest.php
+++ b/tests/Integration/RemoteAPI/AnalyticsPostsRemoteAPITest.php
@@ -83,7 +83,7 @@ final class AnalyticsPostsRemoteAPITest extends RemoteAPITest {
 	}
 
 	/**
-	 * Verifies that endpoint specific user capability filter have more priority than default.
+	 * Verifies that the endpoint specific user capability filter has more priority than the default capability filter.
 	 *
 	 * @covers \Parsely\RemoteAPI\Remote_API_Base::is_user_allowed_to_make_api_call
 	 *

--- a/tests/Integration/RemoteAPI/AnalyticsPostsRemoteAPITest.php
+++ b/tests/Integration/RemoteAPI/AnalyticsPostsRemoteAPITest.php
@@ -39,4 +39,46 @@ final class AnalyticsPostsRemoteAPITest extends RemoteAPITest {
 			Parsely::PUBLIC_API_BASE_URL . '/analytics/posts?apikey=my-key&limit=5',
 		);
 	}
+
+	/**
+	 * Verifies default user capability filter.
+	 *
+	 * @covers \Parsely\RemoteAPI\Remote_API_Base::is_user_allowed_to_make_api_call
+	 *
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 */
+	public function test_user_is_allowed_to_make_api_call_if_default_user_capability_is_changed(): void {
+		$this->login_as_contributor();
+		add_filter(
+			'wp_parsely_user_capability_for_all_private_apis',
+			function () {
+				return 'edit_posts';
+			}
+		);
+
+		$api = new Analytics_Posts_API( new Parsely() );
+
+		self::assertTrue( $api->is_user_allowed_to_make_api_call() );
+	}
+
+	/**
+	 * Verifies endpoint specific user capability filter.
+	 *
+	 * @covers \Parsely\RemoteAPI\Remote_API_Base::is_user_allowed_to_make_api_call
+	 *
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 */
+	public function test_user_is_allowed_to_make_api_call_if_endpoint_specific_user_capability_is_changed(): void {
+		$this->login_as_contributor();
+		add_filter(
+			'wp_parsely_user_capability_for_analytics_posts_api',
+			function () {
+				return 'edit_posts';
+			}
+		);
+
+		$api = new Analytics_Posts_API( new Parsely() );
+
+		self::assertTrue( $api->is_user_allowed_to_make_api_call() );
+	}
 }

--- a/tests/Integration/RemoteAPI/RelatedRemoteAPITest.php
+++ b/tests/Integration/RemoteAPI/RelatedRemoteAPITest.php
@@ -71,13 +71,13 @@ final class RelatedRemoteAPITest extends RemoteAPITest {
 	}
 
 	/**
-	 * Verifies that public apis does not have filter which checks user capability.
+	 * Verifies that the endpoint does not have filters that check user capability.
 	 *
 	 * @covers \Parsely\RemoteAPI\Remote_API_Base::is_user_allowed_to_make_api_call
 	 *
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 */
-	public function test_public_endpoint_does_not_have_user_capability_checks(): void {
+	public function test_related_endpoint_does_not_have_user_capability_filters(): void {
 		$api = new Related_API( new Parsely() );
 
 		self::assertTrue( $api->is_user_allowed_to_make_api_call() );

--- a/tests/Integration/RemoteAPI/RelatedRemoteAPITest.php
+++ b/tests/Integration/RemoteAPI/RelatedRemoteAPITest.php
@@ -69,4 +69,24 @@ final class RelatedRemoteAPITest extends RemoteAPITest {
 			Parsely::PUBLIC_API_BASE_URL . '/related?apikey=my-key&limit=5&sort=score',
 		);
 	}
+
+	/**
+	 * Verifies that public apis does not have filter which checks user capability.
+	 *
+	 * @covers \Parsely\RemoteAPI\Remote_API_Base::is_user_allowed_to_make_api_call
+	 *
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
+	 */
+	public function test_public_endpoint_does_not_have_user_capability_checks(): void {
+		$api = new Related_API( new Parsely() );
+
+		self::assertTrue( $api->is_user_allowed_to_make_api_call() );
+		$this->assert_wp_hooks_availablility(
+			array(
+				'wp_parsely_user_capability_for_all_private_apis',
+				'wp_parsely_user_capability_for_related_api',
+			),
+			false
+		);
+	}
 }

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -452,7 +452,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 	}
 
 	/**
-	 * Create a user with role `contributor` and login.
+	 * Creates a user with role `contributor` and login.
 	 */
 	public function login_as_contributor(): void {
 		$user_id = $this->create_test_user( 'test_contributor', 'contributor' );

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -114,11 +114,17 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * Creates a test user.
 	 *
 	 * @param string $user_login The user's login username.
+	 * @param string $user_role The user's role. Default is subscriber.
 	 *
 	 * @return int The newly created user's ID.
 	 */
-	public function create_test_user( string $user_login ) {
-		return self::factory()->user->create( array( 'user_login' => $user_login ) );
+	public function create_test_user( string $user_login, string $user_role = 'subscriber' ) {
+		return self::factory()->user->create(
+			array(
+				'user_login' => $user_login,
+				'role'       => $user_role,
+			) 
+		);
 	}
 
 	/**
@@ -443,6 +449,14 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 */
 	public function set_admin_user( $admin_user_id = 1 ): void {
 		wp_set_current_user( $admin_user_id );
+	}
+
+	/**
+	 * Create a user with role `contributor` and login.
+	 */
+	public function login_as_contributor(): void {
+		$user_id = $this->create_test_user( 'test_contributor', 'contributor' );
+		wp_set_current_user( $user_id );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Added following filters hooks on remote endpoints so that users can configure it as per their needs:

1. `wp_parsely_user_capability_for_all_private_apis` which changes the default user capability for all remote apis
2. `wp_parsely_user_capability_for_[ENDPOINT_FILTER_KEY]_api` which changes the user capability of each API

Closes: #1415 

## How has this been tested?
- Added integration tests.