### PR TITLE
Hide Parse.ly Stats column if API Secret is not available

### DIFF
--- a/src/UI/class-admin-columns-parsely-stats.php
+++ b/src/UI/class-admin-columns-parsely-stats.php
@@ -90,7 +90,7 @@ class Admin_Columns_Parsely_Stats {
 	 * @since 3.7.0
 	 */
 	public function run(): void {
-		if ( ! $this->parsely->site_id_is_set() ) {
+		if ( ! $this->parsely->site_id_is_set() || ! $this->parsely->api_secret_is_set() ) {
 			return;
 		}
 

--- a/src/UI/class-admin-columns-parsely-stats.php
+++ b/src/UI/class-admin-columns-parsely-stats.php
@@ -90,14 +90,7 @@ class Admin_Columns_Parsely_Stats {
 	 * @since 3.7.0
 	 */
 	public function run(): void {
-		if ( ! $this->parsely->site_id_is_set() || ! $this->parsely->api_secret_is_set() ) {
-			return;
-		}
-
-		$this->analytics_api = new Analytics_Posts_API( $this->parsely );
-
-		// Don't add the column if the user is not allowed to make the API call.
-		if ( ! $this->analytics_api->is_user_allowed_to_make_api_call() ) {
+		if ( ! $this->should_add_hooks() ) {
 			return;
 		}
 
@@ -108,6 +101,25 @@ class Admin_Columns_Parsely_Stats {
 		add_filter( 'manage_pages_columns', array( $this, 'add_parsely_stats_column_on_list_view' ) );
 		add_action( 'manage_pages_custom_column', array( $this, 'update_published_times_and_show_placeholder' ) );
 		add_action( 'admin_footer', array( $this, 'enqueue_parsely_stats_script_with_data' ) );
+	}
+
+	/**
+	 * Determines whether we should add hooks or not depending on plugin settings
+	 * and user capabilities.
+	 */
+	public function should_add_hooks(): bool {
+		if ( ! $this->parsely->site_id_is_set() || ! $this->parsely->api_secret_is_set() ) {
+			return false;
+		}
+
+		$this->analytics_api = new Analytics_Posts_API( $this->parsely );
+
+		// Don't add the column if the user is not allowed to make the API call.
+		if ( ! $this->analytics_api->is_user_allowed_to_make_api_call() ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/UI/class-metadata-renderer.php
+++ b/src/UI/class-metadata-renderer.php
@@ -115,6 +115,8 @@ final class Metadata_Renderer {
 		} else {
 			// Assume `meta_type` is `repeated_metas`.
 			$parsely_post_type = $this->parsely->convert_jsonld_to_parsely_type( $metadata['@type'] ?? '' );
+
+			// @phpstan-ignore-next-line.
 			if ( isset( $metadata['keywords'] ) && is_array( $metadata['keywords'] ) ) {
 				$metadata['keywords'] = implode( ',', $metadata['keywords'] );
 			}

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -1215,6 +1215,7 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 		$input[ $posts ] = $options[ $posts ];
 		$input[ $pages ] = $options[ $pages ];
 
+		// @phpstan-ignore-next-line.
 		if ( isset( $input[ $track_as ] ) && is_array( $input[ $track_as ] ) && 0 < count( $input[ $track_as ] ) ) {
 			$post_types = get_post_types( array( 'public' => true ) );
 			$temp_posts = array();

--- a/tests/Integration/UI/AdminColumnsParselyStatsTest.php
+++ b/tests/Integration/UI/AdminColumnsParselyStatsTest.php
@@ -741,6 +741,24 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 	}
 
 	/**
+	 * Verifies Parse.ly Stats response.
+	 *
+	 * @covers \Parsely\UI\Admin_Columns_Parsely_Stats::__construct
+	 * @covers \Parsely\UI\Admin_Columns_Parsely_Stats::run
+	 * @covers \Parsely\UI\Admin_Columns_Parsely_Stats::set_current_screen
+	 * @covers \Parsely\UI\Admin_Columns_Parsely_Stats::is_tracked_as_post_type
+	 * @covers \Parsely\UI\Admin_Columns_Parsely_Stats::get_parsely_stats_response
+	 */
+	public function test_parsely_stats_response_on_empty_api_secret(): void {
+		$this->set_empty_api_secret();
+
+		$res = $this->get_parsely_stats_response();
+
+		$this->assert_hooks_for_parsely_stats_response( false );
+		self::assertNull( $res );
+	}
+
+	/**
 	 * Verifies Parse.ly Stats API arguments.
 	 *
 	 * @covers \Parsely\UI\Admin_Columns_Parsely_Stats::__construct

--- a/tests/Integration/UI/AdminColumnsParselyStatsTest.php
+++ b/tests/Integration/UI/AdminColumnsParselyStatsTest.php
@@ -148,7 +148,7 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 		if ( $this->is_php_version_7dot2_or_higher() ) {
 			do_action( 'current_screen' ); // phpcs:ignore
 			do_action( 'admin_enqueue_scripts' ); // phpcs:ignore
-		} else {
+		} elseif ( $obj->should_add_hooks() ) {
 			$obj->set_current_screen();
 			$obj->enqueue_parsely_stats_styles();
 		}
@@ -270,7 +270,7 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 
 		if ( $this->is_php_version_7dot2_or_higher() ) {
 			do_action( 'current_screen' ); // phpcs:ignore
-		} else {
+		} elseif ( $obj->should_add_hooks() ) {
 			$obj->set_current_screen();
 		}
 
@@ -488,7 +488,7 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 	private function show_content_on_parsely_stats_column( $obj, $posts, $post_type ): void {
 		if ( $this->is_php_version_7dot2_or_higher() ) {
 			do_action( 'current_screen' ); // phpcs:ignore
-		} else {
+		} elseif ( $obj->should_add_hooks() ) {
 			$obj->set_current_screen();
 		}
 
@@ -708,7 +708,7 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 		if ( $this->is_php_version_7dot2_or_higher() ) {
 			do_action( 'current_screen' ); // phpcs:ignore
 			do_action( 'admin_footer' ); // phpcs:ignore
-		} else {
+		} elseif ( $obj->should_add_hooks() ) {
 			$obj->set_current_screen();
 			$obj->enqueue_parsely_stats_script_with_data();
 		}

--- a/tests/Integration/UI/AdminColumnsParselyStatsTest.php
+++ b/tests/Integration/UI/AdminColumnsParselyStatsTest.php
@@ -91,7 +91,7 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 	 */
 	public function test_styles_of_parsely_stats_admin_column_on_empty_api_secret(): void {
 		$this->set_empty_api_secret();
-		$this->assert_parsely_stats_admin_styles( true );
+		$this->assert_parsely_stats_admin_styles( false );
 	}
 
 	/**
@@ -191,8 +191,8 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 	public function test_parsely_stats_column_visibility_on_empty_api_secret(): void {
 		$this->set_empty_api_secret();
 
-		self::assertContains( self::$parsely_stats_column_header, $this->get_admin_columns() );
-		$this->assert_hooks_for_parsely_stats_column( true );
+		self::assertNotContains( self::$parsely_stats_column_header, $this->get_admin_columns() );
+		$this->assert_hooks_for_parsely_stats_column( false );
 	}
 
 	/**
@@ -324,15 +324,8 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 		$obj    = $this->init_admin_columns_parsely_stats();
 		$output = $this->set_posts_data_and_get_content_of_parsely_stats_column( $obj );
 
-		$this->assert_hooks_for_parsely_stats_content( true );
-		self::assertEquals(
-			$this->get_parsely_stats_placeholder_content( '/2010/01/01/title-1-publish' ) .
-			$this->get_parsely_stats_placeholder_content( '/2010/01/02/title-2-publish' ) .
-			$this->get_parsely_stats_placeholder_content( '/2010/01/03/title-3-publish' ) .
-			$this->get_parsely_stats_placeholder_content( '/' ) .
-			$this->get_parsely_stats_placeholder_content( '/' ),
-			$output
-		);
+		$this->assert_hooks_for_parsely_stats_content( false );
+		self::assertEquals( '', $output );
 		self::assertEquals( array(), $this->get_utc_published_times_property( $obj ) );
 	}
 
@@ -578,7 +571,7 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 	public function test_script_of_parsely_stats_admin_column_on_empty_api_secret(): void {
 		$this->set_empty_api_secret();
 		$obj = $this->mock_parsely_stats_response( array() );
-		$this->assert_parsely_stats_admin_script( $obj, true );
+		$this->assert_parsely_stats_admin_script( $obj, false );
 	}
 
 	/**
@@ -745,37 +738,6 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 
 		$this->assert_hooks_for_parsely_stats_response( false );
 		self::assertNull( $res );
-	}
-
-	/**
-	 * Verifies Parse.ly Stats response.
-	 *
-	 * @covers \Parsely\UI\Admin_Columns_Parsely_Stats::__construct
-	 * @covers \Parsely\UI\Admin_Columns_Parsely_Stats::run
-	 * @covers \Parsely\UI\Admin_Columns_Parsely_Stats::set_current_screen
-	 * @covers \Parsely\UI\Admin_Columns_Parsely_Stats::is_tracked_as_post_type
-	 * @covers \Parsely\UI\Admin_Columns_Parsely_Stats::get_parsely_stats_response
-	 */
-	public function test_parsely_stats_response_on_empty_api_secret(): void {
-		$this->set_empty_api_secret();
-
-		$res = $this->get_parsely_stats_response();
-
-		$this->assert_hooks_for_parsely_stats_response( true );
-		self::assertEquals(
-			array(
-				'data'  => null,
-				'error' => array(
-					'code'        => 403,
-					'message'     => 'Forbidden.',
-					'htmlMessage' => '<p>' .
-						'We are unable to retrieve data for Parse.ly Stats. ' .
-						'Please contact <a href=\\"mailto:support@parsely.com\\">support@parsely.com</a> for help resolving this issue.' .
-					'</p>',
-				),
-			),
-			$res
-		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Currently we are showing error message on Parse.ly Stats column if the API Secret is not present in settings but instead we should hide the column.

## How has this been tested?
- Updated tests to reflect this use case.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/31419912/221620822-40fdc6d1-d831-4720-9f0e-519379497126.png)
