### PR TITLE
Fix Recommended Widget fatal error

### DIFF
--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -144,7 +144,7 @@ final class Recommended_Widget extends WP_Widget {
 			$instance['published_within'],
 			$instance['sort'],
 			$instance['boost'],
-			$instance['return_limit']
+			(int) $instance['return_limit'] // @phpstan-ignore-line
 		);
 
 		?>


### PR DESCRIPTION
## Description
In some cases, we would get a fatal error coming from the Recommended Widget. This is a quick fix that addresses that, although we might need to find a better final solution.