### PR TITLE
Fix "No error to ignore is reported" errors

### DIFF
--- a/src/UI/class-metadata-renderer.php
+++ b/src/UI/class-metadata-renderer.php
@@ -116,7 +116,6 @@ final class Metadata_Renderer {
 			// Assume `meta_type` is `repeated_metas`.
 			$parsely_post_type = $this->parsely->convert_jsonld_to_parsely_type( $metadata['@type'] ?? '' );
 
-			// @phpstan-ignore-next-line.
 			if ( isset( $metadata['keywords'] ) && is_array( $metadata['keywords'] ) ) {
 				$metadata['keywords'] = implode( ',', $metadata['keywords'] );
 			}

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -1215,7 +1215,6 @@ Once you have changed a value and saved, please contact support@parsely.com to r
 		$input[ $posts ] = $options[ $posts ];
 		$input[ $pages ] = $options[ $pages ];
 
-		// @phpstan-ignore-next-line.
 		if ( isset( $input[ $track_as ] ) && is_array( $input[ $track_as ] ) && 0 < count( $input[ $track_as ] ) ) {
 			$post_types = get_post_types( array( 'public' => true ) );
 			$temp_posts = array();


### PR DESCRIPTION
## Description
Fixes the following errors, introduced in previous PRs:

```
 ------ --------------------------------------------- 
  Line   src/UI/class-metadata-renderer.php           
 ------ --------------------------------------------- 
  :120   No error to ignore is reported on line 120.  
 ------ --------------------------------------------- 

 ------- ---------------------------------------------- 
  Line    src/UI/class-settings-page.php                
 ------- ---------------------------------------------- 
  :1219   No error to ignore is reported on line 1219.  
 ------- ---------------------------------------------- 
```