### PR TITLE
Update version numbers and changelog for 3.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Recommended Widget fatal error ([#1424](https://github.com/Parsely/wp-parsely/pull/1424))
 - Hide Parse.ly Stats column if API Secret is not available ([#1423](https://github.com/Parsely/wp-parsely/pull/1423))
 
-
 ## [3.7.0](https://github.com/Parsely/wp-parsely/compare/3.6.2...3.7.0) - 2023-02-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.1](https://github.com/Parsely/wp-parsely/compare/3.7.0...3.7.1) - 2023-02-27
+
+### Fixed
+
+- Fix Recommended Widget fatal error ([#1424](https://github.com/Parsely/wp-parsely/pull/1424))
+- Hide Parse.ly Stats column if API Secret is not available ([#1423](https://github.com/Parsely/wp-parsely/pull/1423))
+
+
 ## [3.7.0](https://github.com/Parsely/wp-parsely/compare/3.6.2...3.7.0) - 2023-02-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.7.0  
+Stable tag: 3.7.1  
 Requires at least: 5.0  
 Tested up to: 6.1  
 Requires PHP: 7.1  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.7.0",
+	"version": "3.7.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.7.0",
+			"version": "3.7.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.7.0",
+	"version": "3.7.1",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, pauarge",

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -10,7 +10,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.7.0';
+export const PLUGIN_VERSION = '3.7.1';
 
 export const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://www.parse.ly/help/integration/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.7.0
+ * Version:           3.7.1
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -60,7 +60,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.7.0';
+const PARSELY_VERSION = '3.7.1';
 const PARSELY_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
This PR updates all version numbers and the changelog in preparation for the 3.7.1 release.

## Fixed

- Fix Recommended Widget fatal error ([#1424](https://github.com/Parsely/wp-parsely/pull/1424))
- Hide Parse.ly Stats column if API Secret is not available ([#1423](https://github.com/Parsely/wp-parsely/pull/1423))

