### PR TITLE
Fix flaky test that verifies loader script

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,3 +15,5 @@ parameters:
       param_type: 59
       property_type: 0 # We can't use property types until we support PHP 7.4.
       print_suggestions: false
+  typeAliases:
+    Asset_Info: 'array{ dependencies: array<string>, version: string }'

--- a/src/UI/class-admin-columns-parsely-stats.php
+++ b/src/UI/class-admin-columns-parsely-stats.php
@@ -16,6 +16,7 @@ use Parsely\RemoteAPI\Remote_API_Base;
 use Parsely\RemoteAPI\Analytics_Posts_API;
 use WP_Screen;
 
+use function Parsely\Utils\get_asset_info;
 use function Parsely\Utils\get_formatted_number;
 use function Parsely\Utils\get_formatted_time;
 use function Parsely\Utils\get_utc_date_format;
@@ -141,14 +142,14 @@ class Admin_Columns_Parsely_Stats {
 			return;
 		}
 
-		$admin_settings_asset = require_once plugin_dir_path( PARSELY_FILE ) . 'build/admin-parsely-stats.asset.php';
+		$admin_settings_asset = get_asset_info( 'build/admin-parsely-stats.asset.php' );
 		$built_assets_url     = plugin_dir_url( PARSELY_FILE ) . 'build/';
 
 		wp_enqueue_style(
 			'admin-parsely-stats-styles',
 			$built_assets_url . 'admin-parsely-stats.css',
-			$admin_settings_asset['dependencies'] ?? null,
-			$admin_settings_asset['version'] ?? Parsely::VERSION
+			$admin_settings_asset['dependencies'],
+			$admin_settings_asset['version']
 		);
 	}
 
@@ -221,14 +222,14 @@ class Admin_Columns_Parsely_Stats {
 			return;
 		}
 
-		$admin_settings_asset = require_once plugin_dir_path( PARSELY_FILE ) . 'build/admin-parsely-stats.asset.php';
+		$admin_settings_asset = get_asset_info( 'build/admin-parsely-stats.asset.php' );
 		$built_assets_url     = plugin_dir_url( PARSELY_FILE ) . 'build/';
 
 		wp_enqueue_script(
 			'admin-parsely-stats-script',
 			$built_assets_url . 'admin-parsely-stats.js',
-			$admin_settings_asset['dependencies'] ?? null,
-			$admin_settings_asset['version'] ?? Parsely::VERSION,
+			$admin_settings_asset['dependencies'],
+			$admin_settings_asset['version'],
 			true
 		);
 

--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -14,6 +14,8 @@ namespace Parsely\UI;
 use Parsely\Parsely;
 use WP_Widget;
 
+use function Parsely\Utils\get_asset_info;
+
 use const Parsely\PARSELY_FILE;
 
 /**
@@ -161,13 +163,13 @@ final class Recommended_Widget extends WP_Widget {
 
 		<?php
 
-		$recommended_widget_script_asset = require_once plugin_dir_path( PARSELY_FILE ) . 'build/recommended-widget.asset.php';
+		$recommended_widget_script_asset = get_asset_info( 'build/recommended-widget.asset.php' );
 
 		wp_register_script(
 			'wp-parsely-recommended-widget',
 			plugin_dir_url( PARSELY_FILE ) . 'build/recommended-widget.js',
-			$recommended_widget_script_asset['dependencies'] ?? null,
-			$recommended_widget_script_asset['version'] ?? Parsely::VERSION,
+			$recommended_widget_script_asset['dependencies'],
+			$recommended_widget_script_asset['version'],
 			true
 		);
 
@@ -175,7 +177,7 @@ final class Recommended_Widget extends WP_Widget {
 			'wp-parsely-recommended-widget',
 			plugin_dir_url( PARSELY_FILE ) . 'build/recommended-widget.css',
 			array(),
-			$recommended_widget_script_asset['version'] ?? Parsely::VERSION
+			$recommended_widget_script_asset['version']
 		);
 
 		wp_enqueue_script( 'wp-parsely-recommended-widget' );

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -12,6 +12,8 @@ namespace Parsely\UI;
 
 use Parsely\Parsely;
 
+use function Parsely\Utils\get_asset_info;
+
 use const Parsely\PARSELY_FILE;
 
 /**
@@ -109,22 +111,22 @@ final class Settings_Page {
 			add_filter( 'media_library_months_with_files', '__return_empty_array' );
 			wp_enqueue_media();
 
-			$admin_settings_asset = require_once plugin_dir_path( PARSELY_FILE ) . 'build/admin-settings.asset.php';
+			$admin_settings_asset = get_asset_info( 'build/admin-settings.asset.php' );
 			$built_assets_url     = plugin_dir_url( PARSELY_FILE ) . '/build/';
 
 			wp_enqueue_script(
 				'parsely-admin-settings',
 				$built_assets_url . 'admin-settings.js',
-				$admin_settings_asset['dependencies'] ?? null,
-				$admin_settings_asset['version'] ?? Parsely::VERSION,
+				$admin_settings_asset['dependencies'],
+				$admin_settings_asset['version'],
 				true
 			);
 
 			wp_enqueue_style(
 				'parsely-admin-settings',
 				$built_assets_url . 'admin-settings.css',
-				$admin_settings_asset['dependencies'] ?? null,
-				$admin_settings_asset['version'] ?? Parsely::VERSION
+				$admin_settings_asset['dependencies'],
+				$admin_settings_asset['version']
 			);
 		}
 	}

--- a/src/Utils/utils.php
+++ b/src/Utils/utils.php
@@ -16,6 +16,8 @@ use NumberFormatter;
 use WP_Post;
 use WP_Error;
 
+use const Parsely\PARSELY_FILE;
+
 const DATE_UTC_FORMAT     = 'Y-m-d';
 const WP_DATE_TIME_FORMAT = 'Y-m-d H:i:s';
 
@@ -244,4 +246,17 @@ function convert_to_positive_integer( string $string ): int {
  */
 function convert_endpoint_to_filter_key( string $endpoint ): string {
 	return trim( str_replace( '/', '_', $endpoint ), '_' );
+}
+
+/**
+ * Gets content of asset file.
+ *
+ * @param string $path Path of the asset file.
+ *
+ * @since 3.8.0
+ *
+ * @return Asset_Info
+ */
+function get_asset_info( string $path ) {
+	return require plugin_dir_path( PARSELY_FILE ) . $path;
 }

--- a/src/blocks/content-helper/class-content-helper.php
+++ b/src/blocks/content-helper/class-content-helper.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace Parsely;
 
+use function Parsely\Utils\get_asset_info;
+
 /**
  * Class that generates and manages the PCH Editor Sidebar.
  *
@@ -23,13 +25,13 @@ class Content_Helper {
 	 * @since 3.5.0
 	 */
 	public function run(): void {
-		$content_helper_asset = require_once plugin_dir_path( PARSELY_FILE ) . 'build/content-helper.asset.php';
+		$content_helper_asset = get_asset_info( 'build/content-helper.asset.php' );
 
 		wp_enqueue_script(
 			'wp-parsely-block-content-helper',
 			plugin_dir_url( PARSELY_FILE ) . 'build/content-helper.js',
-			$content_helper_asset['dependencies'] ?? null,
-			$content_helper_asset['version'] ?? Parsely::VERSION,
+			$content_helper_asset['dependencies'],
+			$content_helper_asset['version'],
 			true
 		);
 
@@ -37,7 +39,7 @@ class Content_Helper {
 			'wp-parsely-block-content-helper',
 			plugin_dir_url( PARSELY_FILE ) . 'build/content-helper.css',
 			array(),
-			$content_helper_asset['version'] ?? Parsely::VERSION
+			$content_helper_asset['version']
 		);
 	}
 

--- a/src/class-scripts.php
+++ b/src/class-scripts.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace Parsely;
 
+use function Parsely\Utils\get_asset_info;
+
 /**
  * Inserts the scripts and tracking code into the site's front-end.
  *
@@ -61,12 +63,13 @@ class Scripts {
 			true
 		);
 
-		$loader_asset = require_once plugin_dir_path( PARSELY_FILE ) . 'build/loader.asset.php';
+		$loader_asset = get_asset_info( 'build/loader.asset.php' );
+
 		wp_register_script(
 			'wp-parsely-loader',
 			plugin_dir_url( PARSELY_FILE ) . 'build/loader.js',
-			$loader_asset['dependencies'] ?? null,
-			$loader_asset['version'] ?? Parsely::VERSION,
+			$loader_asset['dependencies'],
+			$loader_asset['version'],
 			true
 		);
 	}

--- a/src/content-helper/dashboard-widget/class-dashboard-widget.php
+++ b/src/content-helper/dashboard-widget/class-dashboard-widget.php
@@ -13,6 +13,8 @@ namespace Parsely\ContentHelper;
 use Parsely\Parsely;
 use Parsely\RemoteAPI\Analytics_Posts_API;
 
+use function Parsely\Utils\get_asset_info;
+
 use const Parsely\PARSELY_FILE;
 
 /**
@@ -62,14 +64,14 @@ class Dashboard_Widget {
 	 */
 	public function enqueue_assets( $hook_suffix ): void {
 		if ( 'index.php' === $hook_suffix ) {
-			$asset_php        = require_once plugin_dir_path( PARSELY_FILE ) . 'build/content-helper/dashboard-widget.asset.php';
+			$asset_php        = get_asset_info( 'build/content-helper/dashboard-widget.asset.php' );
 			$built_assets_url = plugin_dir_url( PARSELY_FILE ) . 'build/content-helper/';
 
 			wp_enqueue_script(
 				'wp-parsely-dashboard-widget',
 				$built_assets_url . 'dashboard-widget.js',
-				$asset_php['dependencies'] ?? null,
-				$asset_php['version'] ?? Parsely::VERSION,
+				$asset_php['dependencies'],
+				$asset_php['version'],
 				true
 			);
 
@@ -77,7 +79,7 @@ class Dashboard_Widget {
 				'wp-parsely-dashboard-widget',
 				$built_assets_url . 'dashboard-widget.css',
 				array(),
-				$asset_php['version'] ?? Parsely::VERSION
+				$asset_php['version']
 			);
 		}
 	}

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -13,6 +13,8 @@ use Parsely\Parsely;
 use Parsely\Scripts;
 use WP_Scripts;
 
+use function Parsely\Utils\get_asset_info;
+
 use const Parsely\PARSELY_FILE;
 
 /**
@@ -507,17 +509,11 @@ final class ScriptsTest extends TestCase {
 		 *
 		 * @var string
 		 */
-		$output = ob_get_clean();
+		$output       = ob_get_clean();
+		$loader_asset = get_asset_info( 'build/loader.asset.php' );
 
-		$loader_asset = require_once plugin_dir_path( PARSELY_FILE ) . 'build/loader.asset.php';
-		/**
-		 * Variable.
-		 *
-		 * @var string
-		 */
-		$version = is_bool( $loader_asset ) ? Parsely::VERSION : $loader_asset['version'];
 		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		self::assertStringContainsString( "<script data-cfasync=\"false\" type='text/javascript' src='http://example.org/wp-content/plugins/wp-parsely/tests/Integration/../../build/loader.js?ver=" . $version . "' id='wp-parsely-loader-js'></script>", $output );
+		self::assertStringContainsString( "<script data-cfasync=\"false\" type='text/javascript' src='http://example.org/wp-content/plugins/wp-parsely/tests/Integration/../../build/loader.js?ver=" . $loader_asset['version'] . "' id='wp-parsely-loader-js'></script>", $output );
 		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		self::assertStringContainsString( "<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=123456.78.9' id=\"parsely-cfg\"></script>", $output );
 	}


### PR DESCRIPTION
## Description
Recently we have fixed some SonarCloud issues and in that PR we have replaced loading of files via `require` to `require_once` as suggested by SonarCloud but those changes were causing the loader script test to fail under some race conditions. The root cause of the problem is that `require_once` loads the data first time and for subsequent times it just returns `true` due to which value doesn't match and test fails.

Closes: #1442 

## How does this PR fixes the issue?
- This PR replaces `require_once` with `require` so that we load same data each time
- To avoid multiple SonarCloud issues a util function `get_asset_info` is used which we have to only ignore once in SonarCloud.

## How has this been tested?
Ran `composer testwp` couple of hundred times and verfies that no test is failing.
