### PR TITLE
Update version number and changelog for 3.8.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.2](https://github.com/Parsely/wp-parsely/compare/3.8.1...3.8.2) - 2023-03-08
+
+### Fixed
+
+- Fix some fatal errors and warnings ([#1477](https://github.com/Parsely/wp-parsely/pull/1477))
+
+### Dependency Updates
+
+- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.8.2+label%3A%22Component%3A+Dependencies%22).
+
 ## [3.8.1](https://github.com/Parsely/wp-parsely/compare/3.8.0...3.8.1) - 2023-03-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.8.1  
+Stable tag: 3.8.2  
 Requires at least: 5.0  
 Tested up to: 6.1  
 Requires PHP: 7.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.8.1",
+	"version": "3.8.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.8.1",
+			"version": "3.8.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.8.1",
+	"version": "3.8.2",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, pauarge",

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -10,7 +10,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.8.1';
+export const PLUGIN_VERSION = '3.8.2';
 
 export const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://www.parse.ly/help/integration/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.8.1
+ * Version:           3.8.2
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -60,7 +60,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.8.1';
+const PARSELY_VERSION = '3.8.2';
 const PARSELY_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
This PR updates the plugin's version number and changelog in preparation for the 3.8.2 release.

## Fixed

- Fix some fatal errors and warnings ([#1477](https://github.com/Parsely/wp-parsely/pull/1477))

## Dependency Updates

- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.8.2+label%3A%22Component%3A+Dependencies%22).
