### PR TITLE
Fix fatal errors in Co-Authors plugin integration

### DIFF
--- a/src/Metadata/class-author-archive-builder.php
+++ b/src/Metadata/class-author-archive-builder.php
@@ -13,7 +13,6 @@ namespace Parsely\Metadata;
 use WP_User;
 use stdClass;
 
-use function Parsely\Utils\get_int_query_var;
 use function Parsely\Utils\get_string_query_var;
 
 /**
@@ -56,7 +55,10 @@ class Author_Archive_Builder extends Metadata_Builder {
 		if ( false === $author ) {
 			$author = get_user_by( 'slug', $author_username );
 			if ( false === $author ) {
-				$author = get_userdata( get_int_query_var( 'author' ) );
+				$author_id = get_query_var( 'author' );
+				if ( is_numeric( $author_id ) ) {
+					$author = get_userdata( (int) $author_id );
+				}
 			}
 		}
 

--- a/src/Utils/utils.php
+++ b/src/Utils/utils.php
@@ -109,24 +109,6 @@ function get_string_query_var( $var ): string {
 }
 
 /**
- * Gets 'int' query variable from WP_Query class.
- *
- * @since 3.7.0
- *
- * @param string $var Variable key to retrieve.
- *
- * @return int
- */
-function get_int_query_var( $var ): int {
-	/**
-	 * Variable.
-	 *
-	 * @var int
-	 */
-	return get_query_var( $var, 0 );
-}
-
-/**
  * Gets site date format.
  *
  * @since 3.7.0


### PR DESCRIPTION
## Description
Digging a bit more into the fatal errors we're detecting, I discovered that the `get_int_query_var()` function could produce fatal errors even after my previous fix.

The only place we use this function is our Co-Authors integration. A function is supposed to be generic, but in this case we want a very specific behavior (for example, we do not want it to return `1` if `$var` is `true`, which is what we may want in other cases). As such, I opted for removing the function and implementing the solution where the problem is.

## Motivation and context
Fix fatal errors.

## How has this been tested?
Existing tests pass.