### PR TITLE
PCH Stats Column: Fix avg time display issues

### DIFF
--- a/src/UI/class-admin-columns-parsely-stats.php
+++ b/src/UI/class-admin-columns-parsely-stats.php
@@ -337,7 +337,7 @@ class Admin_Columns_Parsely_Stats {
 			$metrics         = $post_analytics['metrics'];
 			$views           = isset( $metrics['views'] ) ? $metrics['views'] : 0;
 			$visitors        = isset( $metrics['visitors'] ) ? $metrics['visitors'] : 0;
-			$engaged_seconds = isset( $metrics['avg_engaged'] ) ? $metrics['avg_engaged'] * 60 : 0;
+			$engaged_seconds = isset( $metrics['avg_engaged'] ) ? round( $metrics['avg_engaged'], 2 ) * 60 : 0;
 
 			/**
 			 * Variable.

--- a/tests/Integration/UI/AdminColumnsParselyStatsTest.php
+++ b/tests/Integration/UI/AdminColumnsParselyStatsTest.php
@@ -933,22 +933,38 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 				),
 			),
 			array(
-				'url' => 'http://example.com/2010/01/04/title-4-publish',
+				'url'     => 'http://example.com/2010/01/03/title-4-publish',
+				'metrics' => array(
+					'views'       => 1100,
+					'visitors'    => 1100000,
+					'avg_engaged' => 0.992,
+				),
 			),
 			array(
-				'url'     => 'http://example.com/2010/01/05/title-5-publish',
+				'url'     => 'http://example.com/2010/01/03/title-5-publish',
+				'metrics' => array(
+					'views'       => 1100,
+					'visitors'    => 1100000,
+					'avg_engaged' => 0.995,
+				),
+			),
+			array(
+				'url' => 'http://example.com/2010/01/04/title-6-publish',
+			),
+			array(
+				'url'     => 'http://example.com/2010/01/05/title-7-publish',
 				'metrics' => array(
 					'views' => 1,
 				),
 			),
 			array(
-				'url'     => 'http://example.com/2010/01/06/title-6-publish',
+				'url'     => 'http://example.com/2010/01/06/title-8-publish',
 				'metrics' => array(
 					'visitors' => 1,
 				),
 			),
 			array(
-				'url'     => 'http://example.com/2010/01/07/title-7-publish',
+				'url'     => 'http://example.com/2010/01/07/title-9-publish',
 				'metrics' => array(
 					'avg_engaged' => 0.01,
 				),
@@ -983,17 +999,27 @@ final class AdminColumnsParselyStatsTest extends TestCase {
 					'visitors'   => '1.1M visitors',
 					'avg_time'   => '1:06 avg time',
 				),
-				'/2010/01/05/title-5-publish' => array(
+				'/2010/01/03/title-4-publish' => array(
+					'page_views' => '1.1K page views',
+					'visitors'   => '1.1M visitors',
+					'avg_time'   => '59 sec. avg time',
+				),
+				'/2010/01/03/title-5-publish' => array(
+					'page_views' => '1.1K page views',
+					'visitors'   => '1.1M visitors',
+					'avg_time'   => '1:00 avg time',
+				),
+				'/2010/01/05/title-7-publish' => array(
 					'page_views' => '1 page view',
 					'visitors'   => '0 visitors',
 					'avg_time'   => '0 sec. avg time',
 				),
-				'/2010/01/06/title-6-publish' => array(
+				'/2010/01/06/title-8-publish' => array(
 					'page_views' => '0 page views',
 					'visitors'   => '1 visitor',
 					'avg_time'   => '0 sec. avg time',
 				),
-				'/2010/01/07/title-7-publish' => array(
+				'/2010/01/07/title-9-publish' => array(
 					'page_views' => '0 page views',
 					'visitors'   => '0 visitors',
 					'avg_time'   => '1 sec. avg time',


### PR DESCRIPTION
## Description
In some cases, the PCH Stats column would display an invalid value for `avg time`, like so:

![image](https://user-images.githubusercontent.com/23142906/225243199-04ab1136-ea03-405d-9da2-58d4762bdaa4.png)

This PR fixes the issue.

## Motivation and context
Fix bugs.

## How has this been tested?
Added a couple of related integration tests.