### PR TITLE
Fix NumberFormatter constructor failures

### DIFF
--- a/src/Utils/utils.php
+++ b/src/Utils/utils.php
@@ -149,7 +149,7 @@ function get_time_format(): string {
  * @return string
  */
 function get_formatted_number( $number ): string {
-	$number_formatter = new NumberFormatter( 'en_US', NumberFormatter::PADDING_POSITION );
+	$number_formatter = new NumberFormatter( 'en', NumberFormatter::PADDING_POSITION );
 	$formatted_number = $number_formatter->format( $number );
 
 	if ( false === $formatted_number ) {
@@ -172,7 +172,7 @@ function get_formatted_number( $number ): string {
  * @return string
  */
 function get_formatted_time( $seconds ): string {
-	$time_formatter = new NumberFormatter( 'en_US', NumberFormatter::DURATION );
+	$time_formatter = new NumberFormatter( 'en', NumberFormatter::DURATION );
 	$formatted_time = $time_formatter->format( $seconds );
 
 	if ( false === $formatted_time ) {


### PR DESCRIPTION
## Description
We had a report of the following fatal error occurring when using the PCH Stats Column:

```
Fatal error: Uncaught Exception: Constructor failed
in /mysitepath.com/wp-content/plugins/wp-parsely/src/Utils/utils.php on line 170

Call stack:

NumberFormatter::__construct()
wp-content/plugins/wp-parsely/src/Utils/utils.php:170
...
```

The point of interest is that we were passing the locale `en_US` in the constructor. After some research, it seems that some installations could be considering this value invalid, and preferring `en-US` instead. However, we had no guarantee that replacing `en_US` to `en-US` wouldn't be problematic for other installations.

As such, we replaced the offending value to `en` which should be globally acceptable, and yields the same result.

## Motivation and context
Fix bugs.

## How has this been tested?
Existing related tests pass.