### PR TITLE
Fix Admin Bar "Undefined Property" warning

### DIFF
--- a/src/UI/class-admin-bar.php
+++ b/src/UI/class-admin-bar.php
@@ -69,17 +69,24 @@ final class Admin_Bar {
 		/**
 		 * Variable.
 		 *
-		 * @var WP_Post|null
+		 * @var \WP_Term|\WP_Post_Type|WP_Post|\WP_User|null
 		 */
-		$current_object = $GLOBALS['wp_the_query']->get_queried_object();
+		$queried_object = $GLOBALS['wp_the_query']->get_queried_object();
 
-		if ( null === $current_object || null === $current_object->post_type || '' === $current_object->post_type ) {
+		if ( null === $queried_object || WP_Post::class !== get_class( $queried_object ) ) {
 			return;
 		}
 
-		$post_type_object = get_post_type_object( $current_object->post_type );
-		if ( null !== $post_type_object && $post_type_object->show_in_admin_bar && Dashboard_Link::can_show_link( $current_object, $this->parsely ) ) {
-			$href = Dashboard_Link::generate_url( $current_object, $this->parsely->get_site_id(), 'wp-page-single', 'admin-bar' );
+		/**
+		 * Variable.
+		 *
+		 * @var WP_Post
+		 */
+		$current_post = $queried_object;
+
+		$post_type_object = get_post_type_object( $current_post->post_type );
+		if ( null !== $post_type_object && $post_type_object->show_in_admin_bar && Dashboard_Link::can_show_link( $current_post, $this->parsely ) ) {
+			$href = Dashboard_Link::generate_url( $current_post, $this->parsely->get_site_id(), 'wp-page-single', 'admin-bar' );
 
 			// Not adding the link if there were issues generating the URL.
 			if ( '' !== $href ) {


### PR DESCRIPTION
## Description
We still had some `Undefined property: WP_Post_Type::$post_type` warnings coming from the Admin bar. This PR fixes this by changing the approach.

## Motivation and context
Don't pollute logs with warnings.

## How has this been tested?
- Used PHPStan to reproduce the error message and fixed it.
- Manually tested that the function continues processing only for `Post`s and `Page`s.