### PR TITLE
Update version number and changelog for 3.8.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.4](https://github.com/Parsely/wp-parsely/compare/3.8.3...3.8.4) - 2023-03-16
+
+### Fixed
+
+- Fix "Attempt to read property name on null" warning ([#1494](https://github.com/Parsely/wp-parsely/pull/1494))
+- Fix Admin Bar "Undefined Property" warning ([#1493](https://github.com/Parsely/wp-parsely/pull/1493))
+- Fix NumberFormatter constructor failures ([#1492](https://github.com/Parsely/wp-parsely/pull/1492))
+- PCH Stats Column: Fix avg time display issues ([#1491](https://github.com/Parsely/wp-parsely/pull/1491))
+
+### Dependency Updates
+
+- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.8.4+label%3A%22Component%3A+Dependencies%22).
+
 ## [3.8.3](https://github.com/Parsely/wp-parsely/compare/3.8.2...3.8.3) - 2023-03-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.8.3  
+Stable tag: 3.8.4  
 Requires at least: 5.0  
 Tested up to: 6.1  
 Requires PHP: 7.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.8.3",
+	"version": "3.8.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.8.3",
+			"version": "3.8.4",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.8.3",
+	"version": "3.8.4",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, pauarge",

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -10,7 +10,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.8.3';
+export const PLUGIN_VERSION = '3.8.4';
 
 export const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://www.parse.ly/help/integration/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.8.3
+ * Version:           3.8.4
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -60,7 +60,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.8.3';
+const PARSELY_VERSION = '3.8.4';
 const PARSELY_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
This PR updates the plugin's version number and changelog in preparation for the 3.8.4 release.

## Fixed

- Fix "Attempt to read property name on null" warning ([#1494](https://github.com/Parsely/wp-parsely/pull/1494))
- Fix Admin Bar "Undefined Property" warning ([#1493](https://github.com/Parsely/wp-parsely/pull/1493))
- Fix NumberFormatter constructor failures ([#1492](https://github.com/Parsely/wp-parsely/pull/1492))
- PCH Stats Column: Fix avg time display issues ([#1491](https://github.com/Parsely/wp-parsely/pull/1491))

## Dependency Updates

- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.8.4+label%3A%22Component%3A+Dependencies%22).
