### PR TITLE
Update Help / Docs Links

### DIFF
--- a/src/Endpoints/class-graphql-metadata.php
+++ b/src/Endpoints/class-graphql-metadata.php
@@ -144,7 +144,7 @@ class GraphQL_Metadata extends Metadata_Endpoint {
 		$config = array(
 			'type'        => self::GRAPHQL_CONTAINER_TYPE,
 			'description' => __(
-				'Parse.ly metadata fields, to be rendered in the front-end so they can be parsed by the crawler. See https://www.parse.ly/help/integration/crawler.',
+				'Parse.ly metadata fields, to be rendered in the front-end so they can be parsed by the crawler. See https://docs.parse.ly/crawler/',
 				'wp-parsely'
 			),
 			'resolve'     => $resolve,

--- a/src/Integrations/class-google-web-stories.php
+++ b/src/Integrations/class-google-web-stories.php
@@ -32,7 +32,7 @@ final class Google_Web_Stories extends Integration {
 	 * Loads additional JavaScript for Google's Web Stories WordPress plugin.
 	 * This relies on the `amp-analytics` element.
 	 *
-	 * See more at: https://www.parse.ly/help/integration/google-amp.
+	 * @see https://docs.parse.ly/google-amp/
 	 *
 	 * @since 3.2.0
 	 */

--- a/src/Metadata/class-post-builder.php
+++ b/src/Metadata/class-post-builder.php
@@ -111,7 +111,7 @@ class Post_Builder extends Metadata_Builder {
 			/* translators: 1: JSON @type like NewsArticle, 2: URL */
 				__( '@type %1$s is not supported by Parse.ly. Please use a type mentioned in %2$s', 'wp-parsely' ),
 				$type,
-				'https://www.parse.ly/help/integration/jsonld#distinguishing-between-posts-and-pages'
+				'https://docs.parse.ly/metadata-jsonld/#distinguishing-between-posts-and-non-posts-pages'
 			);
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error( esc_html( $error ), E_USER_WARNING );

--- a/src/UI/class-plugins-actions.php
+++ b/src/UI/class-plugins-actions.php
@@ -54,7 +54,7 @@ final class Plugins_Actions {
 
 		$actions['documentation'] = sprintf(
 			$link_pattern,
-			'https://www.parse.ly/help/integration/wordpress',
+			'https://docs.parse.ly/wordpress-plugin-setup/',
 			esc_html__( 'Documentation', 'wp-parsely' )
 		);
 

--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -79,14 +79,14 @@ final class Recommended_Widget extends WP_Widget {
 	/**
 	 * Gets the URL for the Recommendations API (GET /related).
 	 *
-	 * @see https://www.parse.ly/help/api/recommendations#get-related
+	 * @see https://docs.parse.ly/content-recommendations/
 	 *
 	 * @internal While this is a public method now, this should be moved to a new class.
 	 *
 	 * @since 2.5.0
 	 *
 	 * @param string      $site_id          Publisher Site ID.
-	 * @param int|null    $published_within Publication filter start date; see https://www.parse.ly/help/api/time for
+	 * @param int|null    $published_within Publication filter start date; see https://docs.parse.ly/api-date-time/ for
 	 *                                      formatting details. No restriction by default.
 	 * @param string|null $sort             What to sort the results by. There are currently 2 valid options: `score`,
 	 *                                      which will sort articles by overall relevance and `pub_date` which will sort

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -239,7 +239,7 @@ final class Settings_Page {
 		$field_id   = 'api_secret';
 		$field_args = array(
 			'option_key'    => $field_id,
-			'help_text'     => __( 'Your API secret is your secret code to <a href="https://www.parse.ly/help/api/analytics/">access our API</a>. It can be found at <code>dash.parsely.com/<var>yoursitedomain</var>/settings/api</code> (replace <var>yoursitedomain</var> with your domain name, e.g. <samp>mydomain.com</samp>).<br />If you haven\'t purchased access to the API and would like to do so, email your account manager or <a href="mailto:support@parsely.com">support@parsely.com</a>.', 'wp-parsely' ),
+			'help_text'     => __( 'Your API secret is your secret code to <a href="https://docs.parse.ly/the-parsely-api/">access our API</a>. It can be found at <code>dash.parsely.com/<var>yoursitedomain</var>/settings/api</code> (replace <var>yoursitedomain</var> with your domain name, e.g. <samp>mydomain.com</samp>).<br />If you haven\'t purchased access to the API and would like to do so, email your account manager or <a href="mailto:support@parsely.com">support@parsely.com</a>.', 'wp-parsely' ),
 			'label_for'     => $field_id,
 			'optional_args' => array(
 				'type'                => 'password',
@@ -280,7 +280,7 @@ final class Settings_Page {
 		$field_args = array(
 			'title'         => __( 'Metadata Format', 'wp-parsely' ),
 			'option_key'    => $field_id,
-			'help_text'     => __( 'Choose the metadata format for our crawlers to access. Most publishers are fine with <a href="https://www.parse.ly/help/integration/jsonld/">JSON-LD</a>, but if you prefer to use our proprietary metadata format then you can do so here.', 'wp-parsely' ),
+			'help_text'     => __( 'Choose the metadata format for our crawlers to access. Most publishers are fine with <a href="https://docs.parse.ly/metadata-jsonld/">JSON-LD</a>, but if you prefer to use our proprietary metadata format then you can do so here.', 'wp-parsely' ),
 			'radio_options' => array(
 				'json_ld'        => 'json_ld',
 				'repeated_metas' => 'repeated_metas',

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -85,7 +85,7 @@ class Parsely {
 	/**
 	 * Declare post types that Parse.ly will process as "posts".
 	 *
-	 * @link https://www.parse.ly/help/integration/jsonld#distinguishing-between-posts-and-pages
+	 * @link https://docs.parse.ly/metadata-jsonld/#distinguishing-between-posts-and-non-posts-pages
 	 *
 	 * @since 2.5.0
 	 * @var string[]
@@ -104,7 +104,7 @@ class Parsely {
 	/**
 	 * Declare post types that Parse.ly will process as "non-posts".
 	 *
-	 * @link https://www.parse.ly/help/integration/jsonld#distinguishing-between-posts-and-pages
+	 * @link https://docs.parse.ly/metadata-jsonld/#distinguishing-between-posts-and-non-posts-pages
 	 *
 	 * @since 2.5.0
 	 * @var string[]
@@ -477,7 +477,7 @@ class Parsely {
 	 *
 	 * @since 2.5.0
 	 *
-	 * @see https://www.parse.ly/help/integration/metatags#field-description
+	 * @see https://docs.parse.ly/metatags/#h-field-description
 	 *
 	 * @param string $type JSON-LD type.
 	 * @return string "post" or "index".

--- a/tests/Integration/Metadata/AuthorArchiveTest.php
+++ b/tests/Integration/Metadata/AuthorArchiveTest.php
@@ -15,7 +15,7 @@ use Parsely\Parsely;
 /**
  * Integration Tests for Author Archive pages metadata.
  *
- * @see https://www.parse.ly/help/integration/jsonld
+ * @see https://docs.parse.ly/metadata-jsonld/
  * @covers \Parsely\Metadata::construct_metadata
  */
 final class AuthorArchiveTest extends NonPostTestCase {

--- a/tests/Integration/Metadata/BlogArchiveTest.php
+++ b/tests/Integration/Metadata/BlogArchiveTest.php
@@ -15,7 +15,7 @@ use Parsely\Parsely;
 /**
  * Integration Tests for Blog Archive pages metadata.
  *
- * @see https://www.parse.ly/help/integration/jsonld
+ * @see https://docs.parse.ly/metadata-jsonld/
  * @covers \Parsely\Metadata::construct_metadata
  */
 final class BlogArchiveTest extends NonPostTestCase {

--- a/tests/Integration/Metadata/CustomPostTypeArchiveTest.php
+++ b/tests/Integration/Metadata/CustomPostTypeArchiveTest.php
@@ -15,7 +15,7 @@ use Parsely\Parsely;
 /**
  * Integration Tests for Custom Post Type Archive pages metadata.
  *
- * @see https://www.parse.ly/help/integration/jsonld
+ * @see https://docs.parse.ly/metadata-jsonld/
  * @covers \Parsely\Metadata::construct_metadata
  */
 final class CustomPostTypeArchiveTest extends NonPostTestCase {

--- a/tests/Integration/Metadata/CustomTaxonomyTermArchiveTest.php
+++ b/tests/Integration/Metadata/CustomTaxonomyTermArchiveTest.php
@@ -15,7 +15,7 @@ use Parsely\Parsely;
 /**
  * Integration Tests for Custom Taxonomy Term Archive pages metadata.
  *
- * @see https://www.parse.ly/help/integration/jsonld
+ * @see https://docs.parse.ly/metadata-jsonld/
  * @covers \Parsely\Metadata::construct_metadata
  */
 class CustomTaxonomyTermArchiveTest extends NonPostTestCase {

--- a/tests/Integration/Metadata/DateArchiveTest.php
+++ b/tests/Integration/Metadata/DateArchiveTest.php
@@ -16,7 +16,7 @@ use Parsely\Parsely;
 /**
  * Integration Tests for Date Archive pages metadata.
  *
- * @see https://www.parse.ly/help/integration/jsonld
+ * @see https://docs.parse.ly/metadata-jsonld/
  */
 final class DateArchiveTest extends TestCase {
 	/**

--- a/tests/Integration/Metadata/HomePageTest.php
+++ b/tests/Integration/Metadata/HomePageTest.php
@@ -17,7 +17,7 @@ const TEST_BLOG_NAME = 'Test Blog';
 /**
  * Integration Tests for the Homepage's metadata.
  *
- * @see https://www.parse.ly/help/integration/jsonld
+ * @see https://docs.parse.ly/metadata-jsonld/
  * @covers \Parsely\Metadata::construct_metadata
  */
 final class HomePageTest extends NonPostTestCase {

--- a/tests/Integration/Metadata/SinglePageTest.php
+++ b/tests/Integration/Metadata/SinglePageTest.php
@@ -15,7 +15,7 @@ use Parsely\Parsely;
 /**
  * Integration Tests for Single Page pages metadata.
  *
- * @see https://www.parse.ly/help/integration/jsonld
+ * @see https://docs.parse.ly/metadata-jsonld/
  * @covers \Parsely\Metadata::construct_metadata
  */
 final class SinglePageTest extends NonPostTestCase {

--- a/tests/Integration/Metadata/SinglePostTest.php
+++ b/tests/Integration/Metadata/SinglePostTest.php
@@ -23,7 +23,7 @@ const EXPECTED_POST_DATETIME = '2021-12-30T20:11:42Z';
 /**
  * Integration Tests for Single Post pages metadata.
  *
- * @see https://www.parse.ly/help/integration/jsonld
+ * @see https://docs.parse.ly/metadata-jsonld/
  */
 final class SinglePostTest extends TestCase {
 	/**

--- a/tests/Integration/Metadata/TermArchiveTest.php
+++ b/tests/Integration/Metadata/TermArchiveTest.php
@@ -15,7 +15,7 @@ use Parsely\Parsely;
 /**
  * Integration Tests for Term Archive pages metadata.
  *
- * @see https://www.parse.ly/help/integration/jsonld
+ * @see https://docs.parse.ly/metadata-jsonld/
  * @covers \Parsely\Metadata::construct_metadata
  */
 final class TermArchiveTest extends NonPostTestCase {

--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -175,7 +175,7 @@ final class OtherTest extends TestCase {
 		);
 
 		$this->expectWarning();
-		$this->expectWarningMessage( '@type Not_Supported_Type is not supported by Parse.ly. Please use a type mentioned in https://www.parse.ly/help/integration/jsonld#distinguishing-between-posts-and-pages' );
+		$this->expectWarningMessage( '@type Not_Supported_Type is not supported by Parse.ly. Please use a type mentioned in https://docs.parse.ly/metadata-jsonld/#distinguishing-between-posts-and-non-posts-pages' );
 		$metadata->construct_metadata( $post_obj );
 	}
 

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -9,7 +9,7 @@
  *
  * @wordpress-plugin
  * Plugin Name:       Parse.ly
- * Plugin URI:        https://www.parse.ly/help/integration/wordpress
+ * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
  * Version:           3.8.4
  * Author:            Parse.ly


### PR DESCRIPTION
Change existing links to pointing to `https://www.parse.ly/help/*` to the correct `https://docs.parse.ly/*` links.

The old `parse.ly/help/*` links redirect to the `docs.parse.ly` homepage which is not helpful, especially for links that are included in user-facing screens.