### PR TITLE
Fix integration test warning

### DIFF
--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -174,7 +174,7 @@ final class OtherTest extends TestCase {
 		 */
 		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions
 			static function ( int $errno, string $errstr ): never {
-				throw new \Exception( $errstr, $errno );
+				throw new \UnexpectedValueException( $errstr, $errno );
 			},
 			E_USER_WARNING
 		);


### PR DESCRIPTION
## Description
Some functions have been removed from PHPUnit 10, and PHPUnit 9 throws deprecation notices for them. We happen to use some of them in an integration test, so the test would output a warning. This PR gets rid of the warning by converting the warning to an exception and handling it with a function that is still available in PHPUnit 9 and 10.

## Motivation and context
More context about the deprecated/removed functions are available in https://github.com/sebastianbergmann/phpunit/issues/5062.

## How has this been tested?
The specific test now passes without warning.