### PR TITLE
Fix failing integration test for WordPress 6.3 versions and newer

### DIFF
--- a/tests/Integration/content-helper/ContentHelperPostListStatsTest.php
+++ b/tests/Integration/content-helper/ContentHelperPostListStatsTest.php
@@ -719,7 +719,15 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 		global $wp_scripts;
 
 		ob_start();
-		var_dump( $wp_scripts->print_inline_script ( 'post-list-stats-script', 'before' ) ); // phpcs:ignore
+
+		global $wp_version;
+		if ( true === version_compare( substr( $wp_version, 0, 3 ), '6.3', '>=' ) ) {
+			// @phpstan-ignore-next-line
+			var_dump( $wp_scripts->get_inline_script_data( 'post-list-stats-script', 'before' ) ); // phpcs:ignore
+		} else {
+			var_dump( $wp_scripts->print_inline_script( 'post-list-stats-script', 'before' ) ); // phpcs:ignore
+		}
+
 		$output = (string) ob_get_clean();
 
 		self::assertStringContainsString( 'window.wpParselyPostsStatsResponse = \'[]\';', $output );


### PR DESCRIPTION
## Description
Upon the launch of WordPress 6.3 Alpha versions, one of our integration tests started failing:

```
Content Helper Post List Stats (Parsely\Tests\ContentHelper\ContentHelperPostListStats)
 ✘ Script of parsely stats admin column on valid posts and valid response
   │
   │ Unexpected deprecation notice for WP_Scripts::print_inline_script.
   │ Function WP_Scripts::print_inline_script is deprecated since version 6.3.0! Use WP_Scripts::get_inline_script_data() or WP_Scripts::get_inline_script_tag() instead.
   │ Failed asserting that an array is empty.
```

This PR fixes the failure by calling the correct function when the test is running on WordPress 6.3 Alpha or newer.

## Motivation and context
No more red warnings everywhere in our PRs.

## How has this been tested?
The test that was failing now passes when tested with the latest WordPress 6.3 Alpha.