### PR TITLE
PHP 8.2 integration tests: Remove experimental flag

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,7 +46,7 @@ jobs:
           - php: '8.2'
             wp: 'trunk'
             coverage: none
-            experimental: true
+            experimental: false
       fail-fast: false
     continue-on-error: ${{ matrix.experimental }}
     steps:


### PR DESCRIPTION
## Description
This PR removes the experimental flag from our PHP 8.2 tests, which means that any PHP 8.2 deprecations should now make integration tests fail.

## Motivation and context
PHP 8.2 has been around the corner for some time now, so we should handle any deprecations.

## How has this been tested?
Re-running the existing tests.