### PR TITLE
OptionsTest.php: Add phpcs:ignore to line

### DIFF
--- a/tests/Integration/OptionsTest.php
+++ b/tests/Integration/OptionsTest.php
@@ -159,6 +159,7 @@ final class OptionsTest extends TestCase {
 		);
 
 		foreach ( $custom_post_types as $key => $value ) {
+			// phpcs:ignore WordPress.NamingConventions.ValidPostTypeSlug.NotStringLiteral
 			register_post_type( $key, $value );
 		}
 


### PR DESCRIPTION
## Description
This PR adds a `phpcs:ignore` comment to a line in OptionsTest.php to silence a warning.

## How has this been tested?
No code changes.