### PR TITLE
Add periods to since docblocks with text

### DIFF
--- a/src/Metadata/class-metadata-builder.php
+++ b/src/Metadata/class-metadata-builder.php
@@ -78,7 +78,7 @@ abstract class Metadata_Builder {
 	 * Sanitizes string content.
 	 *
 	 * @since 2.6.0
-	 * @since 3.4.0 Moved to class-metadata-builder
+	 * @since 3.4.0 Moved to class-metadata-builder.
 	 *
 	 * @param string|null $val The content you'd like sanitized.
 	 * @return string
@@ -97,7 +97,7 @@ abstract class Metadata_Builder {
 	 * A fall-back implementation to determine permalink.
 	 *
 	 * @since 3.0.0 $parsely_type Default parameter changed to `non-post`.
-	 * @since 3.4.0 Moved to class-metadata-builder
+	 * @since 3.4.0 Moved to class-metadata-builder.
 	 *
 	 * @param string $parsely_type Optional. Parse.ly post type you're interested in, either 'post'
 	 *                             or 'non-post'. Default is 'non-post'.

--- a/src/Metadata/class-post-builder.php
+++ b/src/Metadata/class-post-builder.php
@@ -245,7 +245,7 @@ class Post_Builder extends Metadata_Builder {
 	 * Sets all metadata values related to post time.
 	 *
 	 * @since 3.0.2
-	 * @since 3.3.0 Moved to class-metadata
+	 * @since 3.3.0 Moved to class-metadata.
 	 */
 	private function build_metadata_post_times(): void {
 		$date_format      = 'Y-m-d\TH:i:s\Z';
@@ -271,7 +271,7 @@ class Post_Builder extends Metadata_Builder {
 	 * use the top-level category/taxonomy value, if so instructed via the
 	 * `use_top_level_cats` option.
 	 *
-	 * @since 3.3.0 Moved to class-metadata
+	 * @since 3.3.0 Moved to class-metadata.
 	 *
 	 * @param WP_Post         $post_obj The object for the post.
 	 * @param Parsely_Options $parsely_options The parsely options.
@@ -319,7 +319,7 @@ class Post_Builder extends Metadata_Builder {
 	 *
 	 * (WordPress calls taxonomy values 'terms').
 	 *
-	 * @since 3.3.0 Moved to class-metadata
+	 * @since 3.3.0 Moved to class-metadata.
 	 *
 	 * @param int    $term_id       The ID of the top level term.
 	 * @param string $taxonomy_name The name of the taxonomy.
@@ -341,7 +341,7 @@ class Post_Builder extends Metadata_Builder {
 	 *
 	 * (WordPress calls taxonomy values 'terms').
 	 *
-	 * @since 3.3.0 Moved to class-metadata
+	 * @since 3.3.0 Moved to class-metadata.
 	 *
 	 * @param int    $post_id       The post id you're interested in.
 	 * @param string $taxonomy_name The name of the taxonomy.
@@ -376,7 +376,7 @@ class Post_Builder extends Metadata_Builder {
 	 * Retrieves all the authors for a post as an array. Can include multiple
 	 * authors if the Co-Authors Plus plugin is in use.
 	 *
-	 * @since 3.3.0 Moved to class-metadata
+	 * @since 3.3.0 Moved to class-metadata.
 	 *
 	 * @param WP_Post $post The post object.
 	 * @return array<string>
@@ -423,7 +423,7 @@ class Post_Builder extends Metadata_Builder {
 	 * Borrowed from
 	 * https://github.com/Automattic/Co-Authors-Plus/blob/master/template-tags.php#L3-35
 	 *
-	 * @since 3.3.0 Moved to class-metadata
+	 * @since 3.3.0 Moved to class-metadata.
 	 *
 	 * @param int $post_id The ID of the post.
 	 * @return array<WP_User> List of coauthors, or an empty array if the Co-Authors Plus plugin is not active.
@@ -471,7 +471,7 @@ class Post_Builder extends Metadata_Builder {
 	 * Determines author name from display name, falling back to firstname
 	 * lastname, then nickname and finally the nicename.
 	 *
-	 * @since 3.3.0 Moved to class-metadata
+	 * @since 3.3.0 Moved to class-metadata.
 	 *
 	 * @param ?WP_User $author The author of the post.
 	 * @return string An author name.
@@ -505,7 +505,7 @@ class Post_Builder extends Metadata_Builder {
 	/**
 	 * Returns the tags associated with this page or post.
 	 *
-	 * @since 3.3.0 Moved to class-metadata
+	 * @since 3.3.0 Moved to class-metadata.
 	 *
 	 * @param int $post_id   The ID of the post you're trying to get tags for.
 	 * @return array<string> The tags of the post represented by the post id.
@@ -533,7 +533,7 @@ class Post_Builder extends Metadata_Builder {
 	/**
 	 * Returns an array of all the child categories for the current post.
 	 *
-	 * @since 3.3.0 Moved to class-metadata
+	 * @since 3.3.0 Moved to class-metadata.
 	 *
 	 * @param int    $post_id   The ID of the post you're trying to get categories for.
 	 * @param string $delimiter What character will delimit the categories.
@@ -562,8 +562,8 @@ class Post_Builder extends Metadata_Builder {
 	/**
 	 * Gets all term names from all custom taxonomies assigned to a post.
 	 *
-	 * @since 3.3.0 Moved to class-metadata
-	 * @since 3.4.0 Moved to class-post-builder
+	 * @since 3.3.0 Moved to class-metadata.
+	 * @since 3.4.0 Moved to class-post-builder.
 	 *
 	 * @param WP_Post $post_obj The post object to find the terms for.
 	 * @return array<string> Term names.

--- a/src/UI/class-metadata-renderer.php
+++ b/src/UI/class-metadata-renderer.php
@@ -72,7 +72,7 @@ final class Metadata_Renderer {
 	 * Inserts the code for the meta parameter within the head tag.
 	 *
 	 * @since 3.2.0
-	 * @since 3.3.0 Moved from `Parsely` class to `Metadata_Header`
+	 * @since 3.3.0 Moved from `Parsely` class to `Metadata_Header`.
 	 *
 	 * @param string $meta_type `json_ld` or `repeated_metas`.
 	 */
@@ -151,7 +151,7 @@ final class Metadata_Renderer {
 	 * Function to be used in `array_filter` to clean up repeated metas.
 	 *
 	 * @since 2.6.0
-	 * @since 3.3.0 Moved from `Parsely` class to `Metadata_Header`
+	 * @since 3.3.0 Moved from `Parsely` class to `Metadata_Header`.
 	 *
 	 * @param mixed $var Value to filter from the array.
 	 * @return bool True if the variable is not empty, and it's a string.

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -496,7 +496,7 @@ class Parsely {
 	 * Determines if a Site ID is saved in the options.
 	 *
 	 * @since 2.6.0
-	 * @since 3.7.0 renamed from api_key_is_set
+	 * @since 3.7.0 renamed from api_key_is_set.
 	 *
 	 * @return bool True is Site ID is set, false if it is missing.
 	 */
@@ -510,7 +510,7 @@ class Parsely {
 	 * Determines if a Site ID is not saved in the options.
 	 *
 	 * @since 2.6.0
-	 * @since 3.7.0 renamed from api_key_is_missing
+	 * @since 3.7.0 renamed from api_key_is_missing.
 	 *
 	 * @return bool True if Site ID is missing, false if it is set.
 	 */
@@ -522,7 +522,7 @@ class Parsely {
 	 * Gets the Site ID if set.
 	 *
 	 * @since 2.6.0
-	 * @since 3.7.0 renamed from get_site_id
+	 * @since 3.7.0 renamed from get_site_id.
 	 *
 	 * @return string Site ID if set, or empty string if not.
 	 */

--- a/src/class-scripts.php
+++ b/src/class-scripts.php
@@ -16,7 +16,7 @@ use function Parsely\Utils\get_asset_info;
  * Inserts the scripts and tracking code into the site's front-end.
  *
  * @since 1.0.0
- * @since 3.0.0 Moved from class-parsely to separate file
+ * @since 3.0.0 Moved from class-parsely to separate file.
  */
 class Scripts {
 	/**
@@ -52,7 +52,7 @@ class Scripts {
 	 * Registers scripts, if there's a Site ID value saved.
 	 *
 	 * @since 2.5.0
-	 * @since 3.0.0 Rename from register_js
+	 * @since 3.0.0 Rename from register_js.
 	 */
 	public function register_scripts(): void {
 		wp_register_script(
@@ -77,8 +77,8 @@ class Scripts {
 	/**
 	 * Enqueues the JavaScript code required to send off beacon requests.
 	 *
-	 * @since 2.5.0 Rename from insert_parsely_javascript
-	 * @since 3.0.0 Rename from load_js_tracker
+	 * @since 2.5.0 Rename from insert_parsely_javascript.
+	 * @since 3.0.0 Rename from load_js_tracker.
 	 */
 	public function enqueue_js_tracker(): void {
 		if ( is_preview() ) {

--- a/src/content-helper/editor-sidebar/class-editor-sidebar.php
+++ b/src/content-helper/editor-sidebar/class-editor-sidebar.php
@@ -21,7 +21,7 @@ use const Parsely\PARSELY_FILE;
  * Class that generates and manages the PCH Editor Sidebar.
  *
  * @since 3.5.0
- * @since 3.9.0 Renamed FQCN from `Parsely\Content_Helper` to `Parsely\Content_Helper\Editor_Sidebar`
+ * @since 3.9.0 Renamed FQCN from `Parsely\Content_Helper` to `Parsely\Content_Helper\Editor_Sidebar`.
  */
 class Editor_Sidebar extends Content_Helper_Feature {
 	/**

--- a/src/content-helper/post-list-stats/class-post-list-stats.php
+++ b/src/content-helper/post-list-stats/class-post-list-stats.php
@@ -28,7 +28,7 @@ use const Parsely\Utils\DATE_UTC_FORMAT;
  * Class for adding `Parse.ly Stats` on admin columns.
  *
  * @since 3.7.0
- * @since 3.9.0 Renamed FQCN from `Parsely\UI\Admin_Columns_Parsely_Stats` to `Parsely\Content_Helper\Post_List_Stats`
+ * @since 3.9.0 Renamed FQCN from `Parsely\UI\Admin_Columns_Parsely_Stats` to `Parsely\Content_Helper\Post_List_Stats`.
  *
  * @phpstan-import-type Analytics_Post_API_Params from Analytics_Posts_API
  * @phpstan-import-type Analytics_Post from Analytics_Posts_API

--- a/tests/Integration/DashboardLinkTest.php
+++ b/tests/Integration/DashboardLinkTest.php
@@ -75,7 +75,7 @@ final class DashboardLinkTest extends TestCase {
 	 * Verifies that determining whether a link can be shown works as expected.
 	 *
 	 * @since 2.6.0
-	 * @since 3.1.0 Moved to `DashboardLinkTest.php`
+	 * @since 3.1.0 Moved to `DashboardLinkTest.php`.
 	 *
 	 * @covers \Parsely\Dashboard_Link::can_show_link
 	 * @uses \Parsely\Parsely::site_id_is_set
@@ -99,7 +99,7 @@ final class DashboardLinkTest extends TestCase {
 	 * Only published posts are tracked by default.
 	 *
 	 * @since 2.6.0
-	 * @since 3.1.0 Moved to `DashboardLinkTest.php`
+	 * @since 3.1.0 Moved to `DashboardLinkTest.php`.
 	 *
 	 * @covers \Parsely\Dashboard_Link::can_show_link
 	 * @uses \Parsely\Parsely::site_id_is_set
@@ -121,7 +121,7 @@ final class DashboardLinkTest extends TestCase {
 	 * Verifies that links for unviewable posts aren't being shown.
 	 *
 	 * @since 2.6.0
-	 * @since 3.1.0 Moved to `DashboardLinkTest.php`
+	 * @since 3.1.0 Moved to `DashboardLinkTest.php`.
 	 *
 	 * @covers \Parsely\Dashboard_Link::can_show_link
 	 * @uses \Parsely\Parsely::site_id_is_set
@@ -144,7 +144,7 @@ final class DashboardLinkTest extends TestCase {
 	 * set.
 	 *
 	 * @since 2.6.0
-	 * @since 3.1.0 Moved to `DashboardLinkTest.php`
+	 * @since 3.1.0 Moved to `DashboardLinkTest.php`.
 	 *
 	 * @covers \Parsely\Dashboard_Link::can_show_link
 	 * @uses \Parsely\Parsely::site_id_is_set

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -216,7 +216,7 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\init_content_helper
 /**
  * Inserts the PCH Editor Sidebar.
  *
- * @since 3.5.0 Moved from Parsely\Scripts\enqueue_block_editor_assets()
+ * @since 3.5.0 Moved from Parsely\Scripts\enqueue_block_editor_assets().
  */
 function init_content_helper(): void {
 	( new Editor_Sidebar( $GLOBALS['parsely'] ) )->run();


### PR DESCRIPTION
## Description
According to [WordPress PHP Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#since-section-changelogs), `@since` docblocks that have text should end with a period. This PR fixes that in places where a period was omitted.

## Motivation and context
Make our comments reflect the standards as much as possible.

## How has this been tested?
No code changes.