### PR TITLE
phpstan.neon: Improve comment for clarity

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,7 +15,7 @@ parameters:
   type_coverage:
       return_type: 94
       param_type: 72
-      property_type: 0 # We can't use property types until we support PHP 7.4.
+      property_type: 0 # We can't use property types until PHP 7.4 becomes the plugin's minimum version.
       print_suggestions: false
   typeAliases:
     Asset_Info: 'array{ dependencies: array<string>, version: string }'


### PR DESCRIPTION
## Description
Based on the discussion [here](https://github.com/Parsely/wp-parsely/pull/1733#discussion_r1272650687), in this PR we're updating a comment in our `phpstan.neon` file to improve clarity.

## Motivation and context
The comment needed to be improved, as it could be misunderstood.

## How has this been tested?
No code changes.