### PR TITLE
Fix risky Validator unit tests

### DIFF
--- a/tests/Unit/ValidatorTest.php
+++ b/tests/Unit/ValidatorTest.php
@@ -71,6 +71,8 @@ final class ValidatorTest extends TestCase {
 	 * Verifies that valid API Secrets pass validation.
 	 *
 	 * @since 3.9.0
+	 *
+	 * @covers \Parsely\Validator::validate_api_secret
 	 */
 	public function test_validate_valid_api_secrets(): void {
 		$valid_api_secrets = array(
@@ -86,6 +88,8 @@ final class ValidatorTest extends TestCase {
 	 * Verifies that invalid API Secrets fail validation.
 	 *
 	 * @since 3.9.0
+	 *
+	 * @covers \Parsely\Validator::validate_api_secret
 	 */
 	public function test_validate_invalid_api_secrets(): void {
 		$valid_api_secrets = array(
@@ -101,6 +105,8 @@ final class ValidatorTest extends TestCase {
 	 * Verifies that valid Metadata Secrets pass validation.
 	 *
 	 * @since 3.9.0
+	 *
+	 * @covers \Parsely\Validator::validate_metadata_secret
 	 */
 	public function test_validate_valid_metadata_secrets(): void {
 		$valid_metadata_secrets = array(
@@ -116,6 +122,8 @@ final class ValidatorTest extends TestCase {
 	 * Verifies that invalid Metadata Secrets fail validation.
 	 *
 	 * @since 3.9.0
+	 *
+	 * @covers \Parsely\Validator::validate_metadata_secret
 	 */
 	public function test_validate_invalid_metadata_secrets(): void {
 		$valid_metadata_secrets = array(


### PR DESCRIPTION
## Description
Some of our `Validator` unit tests would be flagged as risky due to lack of a `@covers` docblock. This PR fixes this.

## Motivation and context
Don't flag valid tests as risky.

## How has this been tested?
Ran the tests locally and they were flagged as risky. Fixed and ran tests again, and now they pass without being flagged as risky.