### PR TITLE
Increase E2E tests stability

### DIFF
--- a/jest-e2e.config.js
+++ b/jest-e2e.config.js
@@ -3,5 +3,5 @@ const baseConfig = require( '@wordpress/scripts/config/jest-e2e.config' );
 
 module.exports = {
 	...baseConfig,
-	testTimeout: 35000, // Increased timeout for e2e tests.
+	testTimeout: 35000, // Increased timeout for E2E tests.
 };

--- a/jest-e2e.config.js
+++ b/jest-e2e.config.js
@@ -3,5 +3,5 @@ const baseConfig = require( '@wordpress/scripts/config/jest-e2e.config' );
 
 module.exports = {
 	...baseConfig,
-	testTimeout: 35000, // Increased timeout for E2E tests.
+	testTimeout: 5000, // Increased timeout for E2E tests.
 };

--- a/jest-e2e.config.js
+++ b/jest-e2e.config.js
@@ -3,5 +3,5 @@ const baseConfig = require( '@wordpress/scripts/config/jest-e2e.config' );
 
 module.exports = {
 	...baseConfig,
-	testTimeout: 5000, // Increased timeout for E2E tests.
+	testTimeout: 35000, // Increased timeout for E2E tests.
 };

--- a/jest-e2e.config.js
+++ b/jest-e2e.config.js
@@ -1,0 +1,7 @@
+// eslint-disable-next-line
+const baseConfig = require( '@wordpress/scripts/config/jest-e2e.config' );
+
+module.exports = {
+	...baseConfig,
+	testTimeout: 35000, // Increased timeout for e2e tests.
+};

--- a/tests/Unit/ValidatorTest.php
+++ b/tests/Unit/ValidatorTest.php
@@ -71,6 +71,8 @@ final class ValidatorTest extends TestCase {
 	 * Verifies that valid API Secrets pass validation.
 	 *
 	 * @since 3.9.0
+	 *
+	 * @covers \Parsely\Validator::validate_api_secret
 	 */
 	public function test_validate_valid_api_secrets(): void {
 		$valid_api_secrets = array(
@@ -86,6 +88,8 @@ final class ValidatorTest extends TestCase {
 	 * Verifies that invalid API Secrets fail validation.
 	 *
 	 * @since 3.9.0
+	 *
+	 * @covers \Parsely\Validator::validate_api_secret
 	 */
 	public function test_validate_invalid_api_secrets(): void {
 		$valid_api_secrets = array(
@@ -101,6 +105,8 @@ final class ValidatorTest extends TestCase {
 	 * Verifies that valid Metadata Secrets pass validation.
 	 *
 	 * @since 3.9.0
+	 *
+	 * @covers \Parsely\Validator::validate_metadata_secret
 	 */
 	public function test_validate_valid_metadata_secrets(): void {
 		$valid_metadata_secrets = array(
@@ -116,6 +122,8 @@ final class ValidatorTest extends TestCase {
 	 * Verifies that invalid Metadata Secrets fail validation.
 	 *
 	 * @since 3.9.0
+	 *
+	 * @covers \Parsely\Validator::validate_metadata_secret
 	 */
 	public function test_validate_invalid_metadata_secrets(): void {
 		$valid_metadata_secrets = array(

--- a/tests/Unit/ValidatorTest.php
+++ b/tests/Unit/ValidatorTest.php
@@ -71,8 +71,6 @@ final class ValidatorTest extends TestCase {
 	 * Verifies that valid API Secrets pass validation.
 	 *
 	 * @since 3.9.0
-	 *
-	 * @covers \Parsely\Validator::validate_api_secret
 	 */
 	public function test_validate_valid_api_secrets(): void {
 		$valid_api_secrets = array(
@@ -88,8 +86,6 @@ final class ValidatorTest extends TestCase {
 	 * Verifies that invalid API Secrets fail validation.
 	 *
 	 * @since 3.9.0
-	 *
-	 * @covers \Parsely\Validator::validate_api_secret
 	 */
 	public function test_validate_invalid_api_secrets(): void {
 		$valid_api_secrets = array(
@@ -105,8 +101,6 @@ final class ValidatorTest extends TestCase {
 	 * Verifies that valid Metadata Secrets pass validation.
 	 *
 	 * @since 3.9.0
-	 *
-	 * @covers \Parsely\Validator::validate_metadata_secret
 	 */
 	public function test_validate_valid_metadata_secrets(): void {
 		$valid_metadata_secrets = array(
@@ -122,8 +116,6 @@ final class ValidatorTest extends TestCase {
 	 * Verifies that invalid Metadata Secrets fail validation.
 	 *
 	 * @since 3.9.0
-	 *
-	 * @covers \Parsely\Validator::validate_metadata_secret
 	 */
 	public function test_validate_invalid_metadata_secrets(): void {
 		$valid_metadata_secrets = array(

--- a/tests/e2e/specs/activation-flow.spec.ts
+++ b/tests/e2e/specs/activation-flow.spec.ts
@@ -8,13 +8,10 @@ import { visitAdminPage } from '@wordpress/e2e-test-utils';
  */
 import {
 	setSiteKeys,
-	startUpTest,
 	waitForWpAdmin,
 } from '../utils';
 
 describe( 'Activation flow', (): void => {
-	beforeAll( startUpTest );
-
 	it( 'Should progress as intended', async (): Promise<void> => {
 		await setSiteKeys( '' );
 

--- a/tests/e2e/specs/activation-flow.spec.ts
+++ b/tests/e2e/specs/activation-flow.spec.ts
@@ -16,7 +16,6 @@ describe( 'Activation flow', (): void => {
 		await setSiteKeys( '' );
 
 		await visitAdminPage( '/options-general.php', '?page=parsely' );
-		await waitForWpAdmin();
 
 		const versionText: string = await page.$eval( '#wp-parsely_version', ( el : Element ) => el.textContent ?? '' );
 		expect( versionText ).toMatch( /^Version \d+.\d+/ );
@@ -39,7 +38,6 @@ describe( 'Activation flow', (): void => {
 
 	it( 'Should display all admin sections', async (): Promise<void> => {
 		await visitAdminPage( '/options-general.php', '?page=parsely' );
-		await waitForWpAdmin();
 
 		// Default tab.
 		expect( page ).not.toBe( null );

--- a/tests/e2e/specs/blocks/recommendations/errors.spec.ts
+++ b/tests/e2e/specs/blocks/recommendations/errors.spec.ts
@@ -12,7 +12,6 @@ import {
  */
 import {
 	setSiteKeys,
-	startUpTest,
 } from '../../../utils';
 
 /**
@@ -25,7 +24,6 @@ describe( 'Recommendations Block', () => {
 	 */
 	beforeAll( async () => {
 		enablePageDialogAccept();
-		await startUpTest();
 	} );
 
 	/**

--- a/tests/e2e/specs/blocks/recommendations/settings.spec.ts
+++ b/tests/e2e/specs/blocks/recommendations/settings.spec.ts
@@ -14,7 +14,6 @@ import {
 import {
 	arraysEqual,
 	setSiteKeys,
-	startUpTest,
 } from '../../../utils';
 
 /**
@@ -27,7 +26,6 @@ describe( 'Recommendations Block', () => {
 	 */
 	beforeAll( async () => {
 		enablePageDialogAccept();
-		await startUpTest();
 	} );
 
 	/**

--- a/tests/e2e/specs/browse-logo-button.spec.ts
+++ b/tests/e2e/specs/browse-logo-button.spec.ts
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { visitAdminPage } from '@wordpress/e2e-test-utils';
+import {
+	enablePageDialogAccept,
+	visitAdminPage,
+} from '@wordpress/e2e-test-utils';
 import * as path from 'path';
 
 // General initializations.
@@ -34,11 +37,7 @@ describe( 'Browse for logo button', () => {
 		await page.click( modalAttachment );
 		await page.waitForSelector( modalEditAttachment, { visible: true } );
 
-		// Confirm image deletion.
-		// Note: Dialog handling must be placed before the click event.
-		page.on( 'dialog', async ( dialog ) => {
-			await dialog.accept();
-		} );
+		enablePageDialogAccept(); // Confirm image deletion.
 		await page.click( modalDeleteAttachmentLink );
 	} );
 

--- a/tests/e2e/specs/browse-logo-button.spec.ts
+++ b/tests/e2e/specs/browse-logo-button.spec.ts
@@ -4,13 +4,6 @@
 import { visitAdminPage } from '@wordpress/e2e-test-utils';
 import * as path from 'path';
 
-/**
- * Internal dependencies
- */
-import {
-	waitForWpAdmin,
-} from '../utils';
-
 // General initializations.
 const imageLocalPath: string = path.resolve( __dirname, '../../../.wordpress-org/icon-256x256.png' );
 const uploadedImagePattern = /\/wp-content\/uploads\/\d{4}\/\d{2}\/icon-256x256-?\d*\.png$/;
@@ -54,7 +47,6 @@ describe( 'Browse for logo button', () => {
 	 */
 	beforeEach( async () => {
 		await visitAdminPage( '/options-general.php', '?page=parsely' );
-		await waitForWpAdmin();
 
 		// Click browse button and wait for Media Library to appear.
 		await page.click( modalSelectFilesButton );

--- a/tests/e2e/specs/browse-logo-button.spec.ts
+++ b/tests/e2e/specs/browse-logo-button.spec.ts
@@ -8,7 +8,6 @@ import * as path from 'path';
  * Internal dependencies
  */
 import {
-	startUpTest,
 	waitForWpAdmin,
 } from '../utils';
 
@@ -32,8 +31,6 @@ const modalDeleteAttachmentLink = `${ modalEditAttachment } button.delete-attach
  * Browse button tests
  */
 describe( 'Browse for logo button', () => {
-	beforeAll( startUpTest );
-
 	/**
 	 * Remove the uploaded image.
 	 */

--- a/tests/e2e/specs/content-helper/errors.spec.ts
+++ b/tests/e2e/specs/content-helper/errors.spec.ts
@@ -5,7 +5,6 @@ import {
 	VALID_API_SECRET,
 	getTopRelatedPostsMessage,
 	setSiteKeys,
-	startUpTest,
 } from '../../utils';
 
 /**
@@ -14,13 +13,6 @@ import {
  */
 describe( 'PCH Editor Sidebar Related Top Posts panel', () => {
 	const contactMessage = 'Contact us about advanced plugin features and the Parse.ly dashboard.';
-
-	/**
-	 * Logs in to WordPress and activates the Parse.ly plugin.
-	 */
-	beforeAll( async () => {
-		await startUpTest();
-	} );
 
 	/**
 	 * Verifies that the panel will display an error when an invalid Site ID is

--- a/tests/e2e/specs/content-helper/related-top-posts-panel-filters.spec.ts
+++ b/tests/e2e/specs/content-helper/related-top-posts-panel-filters.spec.ts
@@ -14,7 +14,6 @@ import {
 	insertRecordIntoTaxonomy,
 	setSiteKeys,
 	setUserDisplayName,
-	startUpTest,
 } from '../../utils';
 
 /**
@@ -29,7 +28,6 @@ describe( 'PCH Editor Sidebar Related Top Post panel filters', () => {
 	 */
 	beforeAll( async () => {
 		enablePageDialogAccept();
-		await startUpTest();
 		await setSiteKeys( 'blog.parsely.com', VALID_API_SECRET );
 	} );
 

--- a/tests/e2e/specs/content-helper/top-bar-icon.spec.ts
+++ b/tests/e2e/specs/content-helper/top-bar-icon.spec.ts
@@ -12,7 +12,6 @@ import {
 import {
 	VALID_API_SECRET,
 	setSiteKeys,
-	startUpTest,
 } from '../../utils';
 
 // Selectors.
@@ -24,13 +23,6 @@ const pluginButton = 'button[aria-label="Parse.ly Editor Sidebar"]';
 describe( 'PCH Editor Sidebar top bar icon in the WordPress Post Editor', () => {
 	const postNotPublishedMessage = 'Performance DetailsThis post is not published, so its details are unavailable.Related Top Posts';
 	const emptyCredentialsMessage = 'Performance DetailsContact us about advanced plugin features and the Parse.ly dashboard.Existing Parse.ly customers can enable this feature by setting their Site ID and API Secret in wp-parsely options.Related Top Posts';
-
-	/**
-	 * Logs in to WordPress and activates the Parse.ly plugin.
-	 */
-	beforeAll( async () => {
-		await startUpTest();
-	} );
 
 	/**
 	 * Verifies that the top bar icon gets displayed when the Site ID and API

--- a/tests/e2e/specs/front-end-metadata.spec.ts
+++ b/tests/e2e/specs/front-end-metadata.spec.ts
@@ -12,7 +12,6 @@ import {
 import {
 	setSiteKeys,
 	setUserDisplayName,
-	startUpTest,
 	waitForWpAdmin,
 } from '../utils';
 
@@ -44,7 +43,6 @@ async function setTrackLoggedInUsers( shouldTrack = false ) {
 
 describe( 'Front end metadata insertion', () => {
 	beforeAll( async () => {
-		await startUpTest();
 		await setSiteKeys();
 		await setTrackLoggedInUsers( true );
 

--- a/tests/e2e/specs/front-end-metadata.spec.ts
+++ b/tests/e2e/specs/front-end-metadata.spec.ts
@@ -17,7 +17,6 @@ import {
 
 const setMetadataFormat = async ( format: string ) => {
 	await visitAdminPage( '/options-general.php', '?page=parsely' );
-	await waitForWpAdmin();
 
 	const selectedMetadataFormat = await page.$( `#meta_type_${ format }` );
 	await selectedMetadataFormat?.click();
@@ -30,7 +29,6 @@ const setMetadataFormat = async ( format: string ) => {
 
 async function setTrackLoggedInUsers( shouldTrack = false ) {
 	await visitAdminPage( '/options-general.php', '?page=parsely' );
-	await waitForWpAdmin();
 
 	const trackLoggedInUserRadioButton = await page.$( `#track_authenticated_users_${ shouldTrack }` );
 	await trackLoggedInUserRadioButton?.click();

--- a/tests/e2e/specs/front-end-tracker.spec.ts
+++ b/tests/e2e/specs/front-end-tracker.spec.ts
@@ -11,7 +11,6 @@ import {
 	PLUGIN_VERSION,
 	VALID_API_SECRET,
 	setSiteKeys,
-	startUpTest,
 } from '../utils';
 
 const getAssetVersion = () => {
@@ -22,8 +21,6 @@ const getAssetVersion = () => {
 };
 
 describe( 'Front end tracking code insertion', () => {
-	beforeAll( startUpTest );
-
 	it( 'Should inject loading script homepage', async () => {
 		await setSiteKeys();
 

--- a/tests/e2e/specs/plugin-action-link.spec.ts
+++ b/tests/e2e/specs/plugin-action-link.spec.ts
@@ -13,7 +13,6 @@ import {
 describe( 'Plugin action link', () => {
 	it( 'Should link to plugin settings page', async () => {
 		await visitAdminPage( '/plugins.php', '' );
-		await waitForWpAdmin();
 
 		await expect( page ).toClick( '[data-slug=wp-parsely] .settings>a', { text: 'Settings' } );
 		await waitForWpAdmin();

--- a/tests/e2e/specs/plugin-action-link.spec.ts
+++ b/tests/e2e/specs/plugin-action-link.spec.ts
@@ -7,13 +7,10 @@ import { visitAdminPage } from '@wordpress/e2e-test-utils';
  * Internal dependencies
  */
 import {
-	startUpTest,
 	waitForWpAdmin,
 } from '../utils';
 
 describe( 'Plugin action link', () => {
-	beforeAll( startUpTest );
-
 	it( 'Should link to plugin settings page', async () => {
 		await visitAdminPage( '/plugins.php', '' );
 		await waitForWpAdmin();

--- a/tests/e2e/specs/recommended-widget.spec.ts
+++ b/tests/e2e/specs/recommended-widget.spec.ts
@@ -3,6 +3,7 @@
  */
 import {
 	activateTheme,
+	enablePageDialogAccept,
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
@@ -38,9 +39,7 @@ const getNonActiveWidgetText = async () => {
 
 describe( 'Recommended widget', () => {
 	beforeAll( async () => {
-		page.on( 'dialog', async function( dialog ) {
-			await dialog.accept();
-		} );
+		enablePageDialogAccept();
 
 		await activateTheme( 'twentytwentyone' );
 	} );

--- a/tests/e2e/specs/recommended-widget.spec.ts
+++ b/tests/e2e/specs/recommended-widget.spec.ts
@@ -17,8 +17,9 @@ import {
 
 const deactivatedPluginWidgetText = 'The Parse.ly Site ID and Parse.ly API Secret fields need to be populated on the Parse.ly settings page for this widget to work.';
 
+const closeWidgetScreenModal = () => page.keyboard.press( 'Escape' );
+
 const insertParselyWidget = async () => {
-	await waitForWpAdmin();
 	await page.waitForTimeout( 500 );
 	await page.click( '.block-editor-button-block-appender' );
 	await page.waitForTimeout( 500 );
@@ -51,6 +52,9 @@ describe( 'Recommended widget', () => {
 		await setSiteKeys( '' );
 
 		await visitAdminPage( '/widgets.php', '' );
+
+		await waitForWpAdmin();
+		await closeWidgetScreenModal();
 		await insertParselyWidget();
 
 		expect( await getNonActiveWidgetText() ).toContain( deactivatedPluginWidgetText );
@@ -60,6 +64,9 @@ describe( 'Recommended widget', () => {
 		await setSiteKeys();
 
 		await visitAdminPage( '/widgets.php', '' );
+
+		await waitForWpAdmin();
+		await closeWidgetScreenModal();
 		await insertParselyWidget();
 
 		expect( await getNonActiveWidgetText() ).toContain( deactivatedPluginWidgetText );

--- a/tests/e2e/specs/recommended-widget.spec.ts
+++ b/tests/e2e/specs/recommended-widget.spec.ts
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import {
-	activateTheme,
 	enablePageDialogAccept,
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
@@ -11,15 +10,15 @@ import {
  * Internal dependencies
  */
 import {
+	activateTheme,
 	setSiteKeys,
 	waitForWpAdmin,
 } from '../utils';
 
 const deactivatedPluginWidgetText = 'The Parse.ly Site ID and Parse.ly API Secret fields need to be populated on the Parse.ly settings page for this widget to work.';
 
-const closeWidgetScreenModal = () => page.keyboard.press( 'Escape' );
-
 const insertParselyWidget = async () => {
+	await waitForWpAdmin();
 	await page.waitForTimeout( 500 );
 	await page.click( '.block-editor-button-block-appender' );
 	await page.waitForTimeout( 500 );
@@ -52,9 +51,6 @@ describe( 'Recommended widget', () => {
 		await setSiteKeys( '' );
 
 		await visitAdminPage( '/widgets.php', '' );
-		await waitForWpAdmin();
-
-		await closeWidgetScreenModal();
 		await insertParselyWidget();
 
 		expect( await getNonActiveWidgetText() ).toContain( deactivatedPluginWidgetText );
@@ -64,9 +60,6 @@ describe( 'Recommended widget', () => {
 		await setSiteKeys();
 
 		await visitAdminPage( '/widgets.php', '' );
-		await waitForWpAdmin();
-
-		await closeWidgetScreenModal();
 		await insertParselyWidget();
 
 		expect( await getNonActiveWidgetText() ).toContain( deactivatedPluginWidgetText );

--- a/tests/e2e/specs/recommended-widget.spec.ts
+++ b/tests/e2e/specs/recommended-widget.spec.ts
@@ -11,7 +11,6 @@ import {
  */
 import {
 	setSiteKeys,
-	startUpTest,
 	waitForWpAdmin,
 } from '../utils';
 
@@ -43,7 +42,6 @@ describe( 'Recommended widget', () => {
 			await dialog.accept();
 		} );
 
-		await startUpTest();
 		await activateTheme( 'twentytwentyone' );
 	} );
 

--- a/tests/e2e/specs/settings-track-post-types-as.spec.ts
+++ b/tests/e2e/specs/settings-track-post-types-as.spec.ts
@@ -8,7 +8,6 @@ import { visitAdminPage } from '@wordpress/e2e-test-utils';
  */
 import {
 	saveSettingsAndHardRefresh,
-	startUpTest,
 	waitForWpAdmin,
 } from '../utils';
 
@@ -31,8 +30,6 @@ describe( 'Track Post Types as', () => {
 	 * Login, activate the Parse.ly plugin and show recrawl settings.
 	 */
 	beforeAll( async () => {
-		await startUpTest();
-
 		await visitAdminPage( '/options-general.php', '?page=parsely' );
 		await waitForWpAdmin();
 		await page.click( '.recrawl-section-tab' );

--- a/tests/e2e/specs/settings-track-post-types-as.spec.ts
+++ b/tests/e2e/specs/settings-track-post-types-as.spec.ts
@@ -31,7 +31,6 @@ describe( 'Track Post Types as', () => {
 	 */
 	beforeAll( async () => {
 		await visitAdminPage( '/options-general.php', '?page=parsely' );
-		await waitForWpAdmin();
 		await page.click( '.recrawl-section-tab' );
 	} );
 

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -167,15 +167,6 @@ export const saveSettingsAndHardRefresh = async () => {
 };
 
 /**
- * Performs preparatory actions before starting the tests.
- *
- * @return {Promise<void>}
- */
-export const startUpTest = async () => {
-	await visitAdminPage( '/' );
-};
-
-/**
  * Returns whether the passed arrays are equal.
  *
  * This function is meant to compare very simple arrays.Please don't use it to

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -177,3 +177,19 @@ export const saveSettingsAndHardRefresh = async () => {
  * @return {boolean} Whether the passed arrays are equal.
  */
 export const arraysEqual = ( array1: ( string | null )[], array2: ( string | null )[] ) => JSON.stringify( array1 ) === JSON.stringify( array2 );
+
+/**
+ * Activates the passed WordPress theme.
+ *
+ * Acts as a lightweight replacement for the `activatePlugin()` function from
+ * `@wordpress/e2e-test-utils`.
+ *
+ * @param {string} slug The theme's slug.
+ */
+export const activateTheme = async ( slug: string ): Promise<void> => {
+	await visitAdminPage( 'themes.php' );
+	await waitForWpAdmin();
+
+	await page.click( `div[data-slug="${ slug }"] .button.activate` );
+	await page.waitForSelector( `div[data-slug="${ slug }"].active` );
+};

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -6,7 +6,6 @@ import {
 	createNewPost,
 	ensureSidebarOpened,
 	findSidebarPanelToggleButtonWithTitle,
-	loginUser,
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
@@ -174,7 +173,6 @@ export const saveSettingsAndHardRefresh = async () => {
  * @return {Promise<void>}
  */
 export const startUpTest = async () => {
-	await loginUser();
 	await activatePlugin( 'wp-parsely' );
 	await waitForWpAdmin();
 };

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import {
-	activatePlugin,
 	createNewPost,
 	ensureSidebarOpened,
 	findSidebarPanelToggleButtonWithTitle,
@@ -173,8 +172,7 @@ export const saveSettingsAndHardRefresh = async () => {
  * @return {Promise<void>}
  */
 export const startUpTest = async () => {
-	await activatePlugin( 'wp-parsely' );
-	await waitForWpAdmin();
+	await visitAdminPage( '/' );
 };
 
 /**


### PR DESCRIPTION
## Description
This PR should improve the stability of our E2E tests.

## Motivation and context
In the last couple of days and when GitHub ran our E2E tests, there seemed to be degraded performance and E2E tests would always fail. This was seriously hindering our workflow.

This PR started as a timeout increase for E2E tests from 30 seconds to 35 seconds to mitigate the degraded performance. However, tests kept failing, largely from functions coming from the `@wordpress/e2e-test-utils` package. This wasn't reproducible locally and had to be tested on GitHub to make sure that any code changes were impactful.

## How has this been tested?
- For every new commit, ran E2E tests until failure.
- Did this until E2E tests seemed stable enough (last commit was tested 5 times).
- Other PRs that had failing E2E tests were based to this branch as their target branch, and their E2E tests passed.