### PR TITLE
Prevent always saving settings on Parsely->run()

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -77,7 +77,7 @@ class Parsely {
 		'logo'                      => '',
 		'metadata_secret'           => '',
 		'disable_autotrack'         => false,
-		'plugin_version'            => '',
+		'plugin_version'            => self::VERSION,
 	);
 
 	/**
@@ -162,6 +162,7 @@ class Parsely {
 				$callable = array( $this, $method );
 				call_user_func_array( $callable, array( $options ) );
 			}
+
 			// Update our version info.
 			$options['plugin_version'] = self::VERSION;
 			update_option( self::OPTIONS_KEY, $options );


### PR DESCRIPTION
## Description
We recently stumbled upon an inexplicable bug, where incorrect setting values were getting saved without apparent reason. The result of the research was that on every `Parsely->run()` call, [the plugin upgrade code ](https://github.com/Parsely/wp-parsely/blob/4375036d9c7ab22e17266ac157317a3e35d9c633/src/class-parsely.php#L155-L167) was being executed.

This had various side-effects such as:
- Plugins settings getting re-saved in unneeded circumstances.
- Plugin settings getting saved multiple times when the settings page was being used to update settings.
- Not saving the correct setting values in a particular scenario (which is what triggered our research, since the bug wasn't known until then).

This PR fixes the issue by setting a correct value for the `plugin_version` default option, which should not have been empty.

## Motivation and context
Eliminate excessive settings saving and fix bugs.

## How has this been tested?
1. Used the `pre_update_option_parsely` hook to verify that options were being saved multiple times when using the settings page.
2. Applied the fix.
3. Used the `pre_update_option_parsely` hook to verify that options were being saved only once when using the settings page.