### PR TITLE
Analytics_Posts_API: Increase request timeout

### DIFF
--- a/src/RemoteAPI/class-analytics-posts-api.php
+++ b/src/RemoteAPI/class-analytics-posts-api.php
@@ -86,7 +86,7 @@ class Analytics_Posts_API extends Remote_API_Base {
 	 *
 	 * @return array<string, mixed> The array of options.
 	 */
-	protected function set_request_options(): array {
+	protected function get_request_options(): array {
 		return array(
 			'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 		);

--- a/src/RemoteAPI/class-analytics-posts-api.php
+++ b/src/RemoteAPI/class-analytics-posts-api.php
@@ -80,7 +80,7 @@ class Analytics_Posts_API extends Remote_API_Base {
 	}
 
 	/**
-	 * Sets the request's options for the remote API call.
+	 * Returns the request's options for the remote API call.
 	 *
 	 * @since 3.9.0
 	 *

--- a/src/RemoteAPI/class-analytics-posts-api.php
+++ b/src/RemoteAPI/class-analytics-posts-api.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class for Analytics Posts API (`/analytics/post`).
+ * Class for Analytics Posts API (`/analytics/posts`).
  *
  * @package Parsely
  * @since   3.4.0
@@ -10,11 +10,10 @@ declare(strict_types=1);
 
 namespace Parsely\RemoteAPI;
 
-use Parsely\Parsely;
 use WP_Error;
 
 /**
- * Class for Analytics Posts API (`/analytics/post`).
+ * Class for Analytics Posts API (`/analytics/posts`).
  *
  * @since 3.4.0
  *
@@ -78,5 +77,18 @@ class Analytics_Posts_API extends Remote_API_Base {
 	 */
 	public function get_posts_analytics( $api_params ) {
 		return $this->get_items( $api_params, true ); // @phpstan-ignore-line
+	}
+
+	/**
+	 * Sets the request's options for the remote API call.
+	 *
+	 * @since 3.9.0
+	 *
+	 * @return array<string, mixed> The array of options.
+	 */
+	protected function set_request_options(): array {
+		return array(
+			'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+		);
 	}
 }

--- a/src/RemoteAPI/class-remote-api-base.php
+++ b/src/RemoteAPI/class-remote-api-base.php
@@ -158,16 +158,6 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 			return $response;
 		}
 
-		$response_code = wp_remote_retrieve_response_code( $response );
-		if ( 200 !== $response_code ) {
-			$error_message = wp_remote_retrieve_response_message( $response );
-			if ( '' === $error_message ) {
-				$error_message = __( 'Unknown error', 'wp-parsely' );
-			}
-
-			return new WP_Error( $response_code, $error_message );
-		}
-
 		$body    = wp_remote_retrieve_body( $response );
 		$decoded = json_decode( $body );
 

--- a/src/RemoteAPI/class-remote-api-base.php
+++ b/src/RemoteAPI/class-remote-api-base.php
@@ -151,14 +151,24 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	 */
 	public function get_items( $query, $associative = false ) {
 		$full_api_url = $this->get_api_url( $query );
+		$options      = $this->set_request_options();
+		$response     = wp_safe_remote_get( $full_api_url, $options );
 
-		$result = wp_safe_remote_get( $full_api_url, array() );
-
-		if ( is_wp_error( $result ) ) {
-			return $result;
+		if ( is_wp_error( $response ) ) {
+			return $response;
 		}
 
-		$body    = wp_remote_retrieve_body( $result );
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $response_code ) {
+			$error_message = wp_remote_retrieve_response_message( $response );
+			if ( '' === $error_message ) {
+				$error_message = __( 'Unknown error', 'wp-parsely' );
+			}
+
+			return new WP_Error( $response_code, $error_message );
+		}
+
+		$body    = wp_remote_retrieve_body( $response );
 		$decoded = json_decode( $body );
 
 		if ( ! is_object( $decoded ) ) {
@@ -173,9 +183,9 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 			return new WP_Error( 400, __( 'Unable to parse data from upstream API', 'wp-parsely' ) );
 		}
 
-		$response = $decoded->data;
+		$data = $decoded->data;
 
-		return $associative ? convert_to_associative_array( $response ) : $response;
+		return $associative ? convert_to_associative_array( $data ) : $data;
 	}
 
 	/**
@@ -197,5 +207,16 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Sets the request's options for the remote API call.
+	 *
+	 * @since 3.9.0
+	 *
+	 * @return array<string, mixed> The array of options.
+	 */
+	protected function set_request_options(): array {
+		return array();
 	}
 }

--- a/src/RemoteAPI/class-remote-api-base.php
+++ b/src/RemoteAPI/class-remote-api-base.php
@@ -200,7 +200,7 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	}
 
 	/**
-	 * Sets the request's options for the remote API call.
+	 * Returns the request's options for the remote API call.
 	 *
 	 * @since 3.9.0
 	 *

--- a/src/RemoteAPI/class-remote-api-base.php
+++ b/src/RemoteAPI/class-remote-api-base.php
@@ -151,7 +151,7 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	 */
 	public function get_items( $query, $associative = false ) {
 		$full_api_url = $this->get_api_url( $query );
-		$options      = $this->set_request_options();
+		$options      = $this->get_request_options();
 		$response     = wp_safe_remote_get( $full_api_url, $options );
 
 		if ( is_wp_error( $response ) ) {
@@ -216,7 +216,7 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	 *
 	 * @return array<string, mixed> The array of options.
 	 */
-	protected function set_request_options(): array {
+	protected function get_request_options(): array {
 		return array();
 	}
 }

--- a/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
@@ -229,11 +229,7 @@ final class AnalyticsPostsProxyEndpointTest extends ProxyEndpointTest {
 			function () use ( &$dispatched ) {
 				$dispatched++;
 				return array(
-					'response' => array(
-						'code'    => 200,
-						'message' => 'OK',
-					),
-					'body'     => '{"data":[
+					'body' => '{"data":[
 						{
 							"author": "Aakash Shah",
 							"metrics": {"views": 142},

--- a/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
@@ -210,6 +210,7 @@ final class AnalyticsPostsProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_api_url
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_items
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_request_options
 	 */
 	public function test_get_items(): void {
 		$this->set_admin_user();

--- a/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
@@ -228,7 +228,11 @@ final class AnalyticsPostsProxyEndpointTest extends ProxyEndpointTest {
 			function () use ( &$dispatched ) {
 				$dispatched++;
 				return array(
-					'body' => '{"data":[
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => '{"data":[
 						{
 							"author": "Aakash Shah",
 							"metrics": {"views": 142},

--- a/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
@@ -195,7 +195,11 @@ final class ReferrersPostDetailProxyEndpointTest extends ProxyEndpointTest {
 			function () use ( &$dispatched ) {
 				$dispatched++;
 				return array(
-					'body' => '{"data":[
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => '{"data":[
 						{
 							"metrics": {"referrers_views": 1500},
 							"name": "google",

--- a/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
@@ -178,6 +178,7 @@ final class ReferrersPostDetailProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_api_url
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_items
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_request_options
 	 */
 	public function test_get_items(): void {
 		$this->set_admin_user();

--- a/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
@@ -196,11 +196,7 @@ final class ReferrersPostDetailProxyEndpointTest extends ProxyEndpointTest {
 			function () use ( &$dispatched ) {
 				$dispatched++;
 				return array(
-					'response' => array(
-						'code'    => 200,
-						'message' => 'OK',
-					),
-					'body'     => '{"data":[
+					'body' => '{"data":[
 						{
 							"metrics": {"referrers_views": 1500},
 							"name": "google",

--- a/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
@@ -116,11 +116,7 @@ final class RelatedProxyEndpointTest extends ProxyEndpointTest {
 			function () use ( &$dispatched ) {
 				$dispatched++;
 				return array(
-					'response' => array(
-						'code'    => 200,
-						'message' => 'OK',
-					),
-					'body'     => '{"data":[
+					'body' => '{"data":[
 						{
 							"image_url":"https:\/\/example.com\/img.png",
 							"thumb_url_medium":"https:\/\/example.com\/thumb.png",

--- a/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
@@ -115,7 +115,11 @@ final class RelatedProxyEndpointTest extends ProxyEndpointTest {
 			function () use ( &$dispatched ) {
 				$dispatched++;
 				return array(
-					'body' => '{"data":[
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => '{"data":[
 						{
 							"image_url":"https:\/\/example.com\/img.png",
 							"thumb_url_medium":"https:\/\/example.com\/thumb.png",

--- a/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
@@ -104,6 +104,7 @@ final class RelatedProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_api_url
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_items
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_request_options
 	 */
 	public function test_get_items(): void {
 		TestCase::set_options( array( 'apikey' => 'example.com' ) );

--- a/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
@@ -178,6 +178,7 @@ final class StatsPostDetailProxyEndpointTest extends ProxyEndpointTest {
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::__construct
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_api_url
 	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_items
+	 * @uses \Parsely\RemoteAPI\Remote_API_Base::get_request_options
 	 */
 	public function test_get_items(): void {
 		$this->set_admin_user();

--- a/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
@@ -196,11 +196,7 @@ final class StatsPostDetailProxyEndpointTest extends ProxyEndpointTest {
 			function () use ( &$dispatched ) {
 				$dispatched++;
 				return array(
-					'response' => array(
-						'code'    => 200,
-						'message' => 'OK',
-					),
-					'body'     => '
+					'body' => '
 						{"data":[{
 							"avg_engaged": 1.911,
 							"metrics": {

--- a/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
@@ -195,7 +195,11 @@ final class StatsPostDetailProxyEndpointTest extends ProxyEndpointTest {
 			function () use ( &$dispatched ) {
 				$dispatched++;
 				return array(
-					'body' => '
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => '
 						{"data":[{
 							"avg_engaged": 1.911,
 							"metrics": {


### PR DESCRIPTION
## Description
This PR:
- Adds the ability to all classes extending `Remote_API_Base` to be able to set their own particular request options like timeout, headers, and [all other WP_Http::request accepted arguments](https://developer.wordpress.org/reference/classes/wp_http/request/#parameters).
- Sets a custom timeout to the `Analytics_Posts_API` because of [timeout issues](https://github.com/Parsely/wp-parsely/issues/1741). The new timeout is currently set to `30 seconds`, but we're awaiting feedback and this might be subject to change.

## Motivation and context
- Closes #1741.
- Gives us the flexibility to set custom request options per endpoint.

## How has this been tested?
- Checked that the code runs and that the timeout is passed into the request.
- This work is based on a private branch that communicates with an API with large timeouts, and it has worked.
- Due to the hard-to-reproduce nature of the issue, we'll need to see what customers report after this gets released.