### PR TITLE
Content Helper: Fix critical error due to direct views being null

### DIFF
--- a/src/Endpoints/class-referrers-post-detail-api-proxy.php
+++ b/src/Endpoints/class-referrers-post-detail-api-proxy.php
@@ -71,7 +71,7 @@ final class Referrers_Post_Detail_API_Proxy extends Base_API_Proxy {
 	protected function generate_data( $response ): array {
 		$referrers_types = $this->generate_referrer_types_data( $response );
 		$direct_views    = convert_to_positive_integer(
-			$referrers_types->direct->views
+			$referrers_types->direct->views ?? '0'
 		);
 		$referrers_top   = $this->generate_referrers_data( 5, $response, $direct_views );
 


### PR DESCRIPTION
## Description
Direct views could be computed as `null` (an expected possibility) which could result in a critical error in the PCH Sidebar Performance Details pane. This PR fixes the issue.

## Motivation and context
Fix bugs.

## How has this been tested?
- Manually tested that error doesn't occur.
- Existing tests keep passing.