### PR TITLE
Improve argument of wp_parsely_credentials from bool to array

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -607,7 +607,7 @@ class Parsely {
 			return array();
 		}
 
-		$credentials = apply_filters( 'wp_parsely_credentials', false );
+		$credentials = apply_filters( 'wp_parsely_credentials', array() );
 		$result      = array();
 
 		if ( isset( $credentials['site_id'] ) ) {
@@ -634,7 +634,7 @@ class Parsely {
 	 * @return bool Whether credentials are being managed at the platform level.
 	 */
 	private function are_credentials_managed(): bool {
-		$credentials = apply_filters( 'wp_parsely_credentials', false );
+		$credentials = apply_filters( 'wp_parsely_credentials', array() );
 
 		if ( ! is_array( $credentials ) ) {
 			return false;


### PR DESCRIPTION
## Description

In `wp_parsely_credentials` filter we are passing `false` as argument due to which more checks are needed on MU Plugins side so we can make the implementation simple by just passing `array` as first argument which also seems more appropriate considering filter.

## Motivation and context

Closes: https://github.com/Automattic/vip-parsely/issues/61

## How has this been tested?

- Tested manually and makes sure that existing tests are passing without any issue.