### PR TITLE
release.php: Add php to command example

### DIFF
--- a/bin/release.php
+++ b/bin/release.php
@@ -12,7 +12,7 @@
  *
  * Usage: Run the command from a terminal that is logged into GitHub. Upgrading
  * from 3.6.2 to 3.7.0 example:
- *   `bin/release.php 3.6.2 3.7.0`
+ *   `php bin/release.php 3.6.2 3.7.0`
  */
 
 // Exit if the GitHub CLI is not available.


### PR DESCRIPTION
## Description
I found myself running the `bin/release.php` script without adding the `php` prefix to it. Having a better command example could have helped me realize this immediately.

## Motivation and context
Provide better instructions.

## How has this been tested?
No code changes.