### PR TITLE
GitHub E2E tests workflow: Archive results on failure

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -45,3 +45,10 @@ jobs:
       - name: Stop WordPress environment
         run: |
           npm run dev:stop
+
+      - name: Archive e2e results
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: test-results
+          path: artifacts


### PR DESCRIPTION
## Description
This code has been authored by @bsessions85 and adds artifact gathering upon test failure for our E2E tests. This should allow us to debug failing tests more easily, especially when they only fail on GiHub.

Thanks to @bsessions85 for writing the code, and to @iamchughmayank for bringing up the idea.

## How has this been tested?
We got our artifacts file (https://github.com/Parsely/wp-parsely/actions/runs/6099498942?pr=1850), so we know the code works.