### PR TITLE
utils.php: Add more type hints

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,7 +14,7 @@ parameters:
     - vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php
   type_coverage:
       return_type: 94
-      param_type: 72
+      param_type: 74
       property_type: 0 # We can't use property types until PHP 7.4 becomes the plugin's minimum version.
       print_suggestions: false
   typeAliases:

--- a/src/Utils/utils.php
+++ b/src/Utils/utils.php
@@ -137,18 +137,19 @@ function get_time_format(): string {
 }
 
 /**
- * Gets number in formatted form i.e. express bigger numbers in form of thousands (K), millions (M), billions (B).
+ * Gets number in formatted form i.e. express bigger numbers in form of
+ * thousands (K), millions (M), billions (B).
  *
  * Example:
  *   - Represent 10000 as 10K.
  *
  * @since 3.7.0
  *
- * @param int|float $number Number that we have to format.
+ * @param int $number The number to format.
  *
  * @return string
  */
-function get_formatted_number( $number ): string {
+function get_formatted_number( int $number ): string {
 	$number_formatter = new NumberFormatter( 'en', NumberFormatter::PADDING_POSITION );
 	$formatted_number = $number_formatter->format( $number );
 
@@ -167,11 +168,11 @@ function get_formatted_number( $number ): string {
  *
  * @since 3.7.0
  *
- * @param int|float $seconds Time in seconds that we have to format.
+ * @param float $seconds Time in seconds to be formatted.
  *
  * @return string
  */
-function get_formatted_time( $seconds ): string {
+function get_formatted_time( float $seconds ): string {
 	$time_formatter = new NumberFormatter( 'en', NumberFormatter::DURATION );
 	$formatted_time = $time_formatter->format( $seconds );
 

--- a/src/content-helper/post-list-stats/class-post-list-stats.php
+++ b/src/content-helper/post-list-stats/class-post-list-stats.php
@@ -352,7 +352,7 @@ class Post_List_Stats extends Content_Helper_Feature {
 			$metrics         = $post_analytics['metrics'];
 			$views           = $metrics['views'] ?? 0;
 			$visitors        = $metrics['visitors'] ?? 0;
-			$engaged_seconds = isset( $metrics['avg_engaged'] ) ? round( $metrics['avg_engaged'], 2 ) * 60 : 0;
+			$engaged_seconds = isset( $metrics['avg_engaged'] ) ? round( $metrics['avg_engaged'], 2 ) * 60 : 0.00;
 
 			/**
 			 * Variable.

--- a/tests/Unit/Utils/UtilsTest.php
+++ b/tests/Unit/Utils/UtilsTest.php
@@ -165,6 +165,21 @@ final class UtilsTest extends TestCase {
 				'msg'             => 'Should show seconds.',
 			),
 			array(
+				'args'            => array( 'seconds' => 0.5 ),
+				'expected_output' => '0 sec.',
+				'msg'             => 'Should show seconds.',
+			),
+			array(
+				'args'            => array( 'seconds' => 0.5000 ),
+				'expected_output' => '0 sec.',
+				'msg'             => 'Should show seconds.',
+			),
+			array(
+				'args'            => array( 'seconds' => 0.51 ),
+				'expected_output' => '1 sec.',
+				'msg'             => 'Should show seconds.',
+			),
+			array(
 				'args'            => array( 'seconds' => 59 ),
 				'expected_output' => '59 sec.',
 				'msg'             => 'Should show seconds.',


### PR DESCRIPTION
## Description
This PR adds more type hints in `utils.php`. It is identical to #1762, but targets our `develop` branch so we can merge it sooner.

## Motivation and context
Improve static analysis coverage.

## How has this been tested?
Existing tests pass, added a couple of unit test cases with floats.