### PR TITLE
Update Site ID column in Network Admin List to show — instead of text

### DIFF
--- a/src/UI/class-network-admin-sites-list.php
+++ b/src/UI/class-network-admin-sites-list.php
@@ -130,7 +130,7 @@ final class Network_Admin_Sites_List {
 		if ( strlen( $site_id ) > 0 ) {
 			echo esc_html( $site_id );
 		} else {
-			echo '<em>' . esc_html__( 'Parse.ly Site ID is missing', 'wp-parsely' ) . '</em>';
+			echo esc_html( '—' );
 		}
 	}
 }

--- a/tests/Integration/UI/NetworkAdminSitesListTest.php
+++ b/tests/Integration/UI/NetworkAdminSitesListTest.php
@@ -111,7 +111,7 @@ final class NetworkAdminSitesListTest extends TestCase {
 				);
 			} else {
 				self::assertSame(
-					'<em>Parse.ly Site ID is missing</em>',
+					'—',
 					$site_id_col_value,
 					'The default value was not printed and should have been.'
 				);


### PR DESCRIPTION
## Description

Currently we are showing `Parse.ly Site ID is missing` if Site ID isn't available for that specific network site even when the plugin is not enabled so its better to show `—` which covers both not enabled and not present cases.

## How has this been tested?

Updated available test.