### PR TITLE
Remove Intl dependency from utils.php

### DIFF
--- a/src/Utils/utils.php
+++ b/src/Utils/utils.php
@@ -172,14 +172,31 @@ function get_formatted_number( $number ): string {
  * @return string
  */
 function get_formatted_time( $seconds ): string {
-	$time_formatter = new NumberFormatter( 'en', NumberFormatter::DURATION );
-	$formatted_time = $time_formatter->format( $seconds );
+	$seconds = round( $seconds );
+	$hours   = floor( $seconds / 3600 );
 
-	if ( false === $formatted_time ) {
-		return '';
+	if ( $hours >= 1 ) {
+		$seconds = $seconds - ( $hours * 3600 );
+		$minutes = floor( $seconds / 60 );
+		$seconds = round( $seconds % 60 );
+
+		return esc_html( /* translators: 1: Number of hours 2: Number of minutes 3: Number of seconds */
+			sprintf( __( '%1$d:%2$02d:%3$02d', 'wp-parsely' ), $hours, $minutes, $seconds )
+		);
 	}
 
-	return $formatted_time;
+	$minutes = floor( $seconds / 60 );
+	$seconds = round( $seconds % 60 );
+
+	if ( $minutes >= 1 ) {
+		return esc_html( /* translators: 1: Number of minutes 2: Number of seconds */
+			sprintf( __( '%1$d:%2$02d', 'wp-parsely' ), $minutes, $seconds )
+		);
+	}
+
+	return esc_html( /* translators: 1: Number of seconds */
+		sprintf( __( '%1$d sec.', 'wp-parsely' ), round( $seconds ) )
+	);
 }
 
 /**

--- a/src/Utils/utils.php
+++ b/src/Utils/utils.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Parsely\Utils;
 
-use NumberFormatter;
 use WP_Post;
 use WP_Error;
 
@@ -137,26 +136,68 @@ function get_time_format(): string {
 }
 
 /**
- * Gets number in formatted form i.e. express bigger numbers in form of thousands (K), millions (M), billions (B).
+ * Gets number in formatted form i.e. express bigger numbers in form of
+ * thousands (k), millions (M), billions (B).
+ *
+ * Note: This function is not made to process float numbers, and it is a PHP
+ * port of our formatToImpreciseNumber() TypeScript function.
  *
  * Example:
  *   - Represent 10000 as 10K.
  *
  * @since 3.7.0
  *
- * @param int|float $number Number that we have to format.
+ * @param string $value           The number to process. It can be formatted.
+ * @param int    $fraction_digits The number of desired fraction digits.
+ * @param string $glue            A string to put between the number and unit.
  *
- * @return string
+ * @return string The number formatted as an imprecise number.
  */
-function get_formatted_number( $number ): string {
-	$number_formatter = new NumberFormatter( 'en', NumberFormatter::PADDING_POSITION );
-	$formatted_number = $number_formatter->format( $number );
+function get_formatted_number( string $value, int $fraction_digits = 1, string $glue = '' ): string {
+	$number = (int) preg_replace( '/\D/', '', $value );
 
-	if ( false === $formatted_number ) {
-		return '';
+	if ( $number < 1000 ) {
+		return $value;
+	} elseif ( $number < 10000 ) {
+		$fraction_digits = 1;
 	}
 
-	return $formatted_number;
+	$unit_names               = array(
+		'1000'             => 'k',
+		'1000000'          => 'M',
+		'1000000000'       => 'B',
+		'1000000000000'    => 'T',
+		'1000000000000000' => 'Q',
+	);
+	$current_number           = $number;
+	$current_number_as_string = (string) $number;
+	$unit                     = '';
+	$previous_number          = 0;
+
+	foreach ( $unit_names as $thousands => $suffix ) {
+		$thousands_int = (int) preg_replace( '/\D/', '', (string) $thousands );
+
+		if ( $number >= $thousands_int ) {
+			$current_number = $number / $thousands_int;
+			$precision      = $fraction_digits;
+
+			// For over 10 units, we reduce the precision to 1 fraction digit.
+			if ( 0 !== $previous_number && $current_number % 1 > 1 / $previous_number ) {
+				$precision = $current_number > 10 ? 1 : 2;
+			}
+
+			// Precision override, where we want to show 2 fraction digits.
+			$zeroes                   = floatval( number_format( $current_number, 2 ) ) ===
+										floatval( number_format( $current_number, 0 ) );
+			$precision                = $zeroes ? 0 : $precision;
+			$current_number_as_string = number_format( $current_number, $precision, '.', '' );
+			$unit                     = $suffix;
+		}
+
+		$previous_number = $current_number;
+	}
+
+	return $current_number_as_string . $glue . $unit;
 }
 
 /**

--- a/src/Utils/utils.php
+++ b/src/Utils/utils.php
@@ -182,7 +182,8 @@ function get_formatted_number( string $value, int $fraction_digits = 1, string $
 			$precision      = $fraction_digits;
 
 			// For over 10 units, we reduce the precision to 1 fraction digit.
-			if ( 0 !== $previous_number && $current_number % 1 > 1 / $previous_number ) {
+			$modulo = (int) fmod( $current_number, 1 );
+			if ( 0 !== $previous_number && $modulo > 1 / $previous_number ) {
 				$precision = $current_number > 10 ? 1 : 2;
 			}
 

--- a/src/content-helper/post-list-stats/class-post-list-stats.php
+++ b/src/content-helper/post-list-stats/class-post-list-stats.php
@@ -352,7 +352,7 @@ class Post_List_Stats extends Content_Helper_Feature {
 			$metrics         = $post_analytics['metrics'];
 			$views           = $metrics['views'] ?? 0;
 			$visitors        = $metrics['visitors'] ?? 0;
-			$engaged_seconds = isset( $metrics['avg_engaged'] ) ? round( $metrics['avg_engaged'], 2 ) * 60 : 0;
+			$engaged_seconds = isset( $metrics['avg_engaged'] ) ? round( $metrics['avg_engaged'] * 60, 2 ) : 0;
 
 			/**
 			 * Variable.

--- a/src/content-helper/post-list-stats/class-post-list-stats.php
+++ b/src/content-helper/post-list-stats/class-post-list-stats.php
@@ -360,8 +360,8 @@ class Post_List_Stats extends Content_Helper_Feature {
 			 * @var Parsely_Post_Stats
 			 */
 			$stats = array(
-				'page_views' => get_formatted_number( $views ) . ' ' . _n( 'page view', 'page views', $views, 'wp-parsely' ),
-				'visitors'   => get_formatted_number( $visitors ) . ' ' . _n( 'visitor', 'visitors', $visitors, 'wp-parsely' ),
+				'page_views' => get_formatted_number( (string) $views ) . ' ' . _n( 'page view', 'page views', $views, 'wp-parsely' ),
+				'visitors'   => get_formatted_number( (string) $visitors ) . ' ' . _n( 'visitor', 'visitors', $visitors, 'wp-parsely' ),
 				'avg_time'   => get_formatted_time( $engaged_seconds ) . ' ' . __( 'avg time', 'wp-parsely' ),
 			);
 

--- a/tests/Integration/content-helper/ContentHelperPostListStatsTest.php
+++ b/tests/Integration/content-helper/ContentHelperPostListStatsTest.php
@@ -1139,12 +1139,12 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 					'avg_time'   => '59 sec. avg time', // 59 seconds.
 				),
 				'/2010/01/05/title-5-publish'  => array(
-					'page_views' => '1.1K page views',
+					'page_views' => '1.1k page views',
 					'visitors'   => '1.1M visitors',
 					'avg_time'   => '1:00 avg time', // 59.52 seconds.
 				),
 				'/2010/01/06/title-6-publish'  => array(
-					'page_views' => '1.1K page views',
+					'page_views' => '1.1k page views',
 					'visitors'   => '1.1M visitors',
 					'avg_time'   => '1:00 avg time', // 59.7 seconds.
 				),
@@ -1154,12 +1154,12 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 					'avg_time'   => '1:05 avg time', // 65 seconds.
 				),
 				'/2010/01/08/title-8-publish'  => array(
-					'page_views' => '1.1K page views',
+					'page_views' => '1.1k page views',
 					'visitors'   => '1.1M visitors',
 					'avg_time'   => '1:06 avg time', // 66 seconds.
 				),
 				'/2010/01/09/title-9-publish'  => array(
-					'page_views' => '1.1K page views',
+					'page_views' => '1.1k page views',
 					'visitors'   => '1.1M visitors',
 					'avg_time'   => '1:01:05 avg time', // 3665 seconds.
 				),
@@ -1224,7 +1224,7 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 		self::assertSame(
 			array(
 				'/2010/01/01/title-1-publish' => array(
-					'page_views' => '1.1K page views',
+					'page_views' => '1.1k page views',
 					'visitors'   => '1.1M visitors',
 					'avg_time'   => '1:06 avg time',
 				),

--- a/tests/Integration/content-helper/ContentHelperPostListStatsTest.php
+++ b/tests/Integration/content-helper/ContentHelperPostListStatsTest.php
@@ -1023,19 +1023,27 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 				'metrics' => array(
 					'views'       => 1,
 					'visitors'    => 1,
-					'avg_engaged' => 0.01,
+					'avg_engaged' => 0.005,
 				),
 			),
 			array(
 				'url'     => 'http://example.com/2010/01/03/title-3-publish',
 				'metrics' => array(
-					'views'       => 1100,
-					'visitors'    => 1100000,
-					'avg_engaged' => 1.1,
+					'views'       => 1,
+					'visitors'    => 1,
+					'avg_engaged' => 0.01,
 				),
 			),
 			array(
-				'url'     => 'http://example.com/2010/01/03/title-4-publish',
+				'url'     => 'http://example.com/2010/01/04/title-4-publish',
+				'metrics' => array(
+					'views'       => 1,
+					'visitors'    => 1,
+					'avg_engaged' => 0.9833,
+				),
+			),
+			array(
+				'url'     => 'http://example.com/2010/01/05/title-5-publish',
 				'metrics' => array(
 					'views'       => 1100,
 					'visitors'    => 1100000,
@@ -1043,7 +1051,7 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 				),
 			),
 			array(
-				'url'     => 'http://example.com/2010/01/03/title-5-publish',
+				'url'     => 'http://example.com/2010/01/06/title-6-publish',
 				'metrics' => array(
 					'views'       => 1100,
 					'visitors'    => 1100000,
@@ -1051,22 +1059,46 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 				),
 			),
 			array(
-				'url' => 'http://example.com/2010/01/04/title-6-publish',
+				'url'     => 'http://example.com/2010/01/07/title-7-publish',
+				'metrics' => array(
+					'views'       => 1,
+					'visitors'    => 1,
+					'avg_engaged' => 1.083,
+				),
 			),
 			array(
-				'url'     => 'http://example.com/2010/01/05/title-7-publish',
+				'url'     => 'http://example.com/2010/01/08/title-8-publish',
+				'metrics' => array(
+					'views'       => 1100,
+					'visitors'    => 1100000,
+					'avg_engaged' => 1.1,
+				),
+			),
+			array(
+				'url'     => 'http://example.com/2010/01/09/title-9-publish',
+				'metrics' => array(
+					'views'       => 1100,
+					'visitors'    => 1100000,
+					'avg_engaged' => 61.083,
+				),
+			),
+			array(
+				'url' => 'http://example.com/2010/01/10/title-10-publish',
+			),
+			array(
+				'url'     => 'http://example.com/2010/01/11/title-11-publish',
 				'metrics' => array(
 					'views' => 1,
 				),
 			),
 			array(
-				'url'     => 'http://example.com/2010/01/06/title-8-publish',
+				'url'     => 'http://example.com/2010/01/12/title-12-publish',
 				'metrics' => array(
 					'visitors' => 1,
 				),
 			),
 			array(
-				'url'     => 'http://example.com/2010/01/07/title-9-publish',
+				'url'     => 'http://example.com/2010/01/13/title-13-publish',
 				'metrics' => array(
 					'avg_engaged' => 0.01,
 				),
@@ -1086,45 +1118,65 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 		self::assertNull( $res['error'] ?? null );
 		self::assertSame(
 			array(
-				'/2010/01/01/title-1-publish' => array(
+				'/2010/01/01/title-1-publish'  => array(
 					'page_views' => '0 page views',
 					'visitors'   => '0 visitors',
 					'avg_time'   => '0 sec. avg time',
 				),
-				'/2010/01/02/title-2-publish' => array(
+				'/2010/01/02/title-2-publish'  => array(
 					'page_views' => '1 page view',
 					'visitors'   => '1 visitor',
-					'avg_time'   => '1 sec. avg time',
+					'avg_time'   => '0 sec. avg time', // 0.3 seconds.
 				),
-				'/2010/01/03/title-3-publish' => array(
+				'/2010/01/03/title-3-publish'  => array(
+					'page_views' => '1 page view',
+					'visitors'   => '1 visitor',
+					'avg_time'   => '1 sec. avg time', // 0.6 seconds.
+				),
+				'/2010/01/04/title-4-publish'  => array(
+					'page_views' => '1 page view',
+					'visitors'   => '1 visitor',
+					'avg_time'   => '59 sec. avg time', // 59 seconds.
+				),
+				'/2010/01/05/title-5-publish'  => array(
 					'page_views' => '1.1K page views',
 					'visitors'   => '1.1M visitors',
-					'avg_time'   => '1:06 avg time',
+					'avg_time'   => '1:00 avg time', // 59.52 seconds.
 				),
-				'/2010/01/03/title-4-publish' => array(
+				'/2010/01/06/title-6-publish'  => array(
 					'page_views' => '1.1K page views',
 					'visitors'   => '1.1M visitors',
-					'avg_time'   => '59 sec. avg time',
+					'avg_time'   => '1:00 avg time', // 59.7 seconds.
 				),
-				'/2010/01/03/title-5-publish' => array(
+				'/2010/01/07/title-7-publish'  => array(
+					'page_views' => '1 page view',
+					'visitors'   => '1 visitor',
+					'avg_time'   => '1:05 avg time', // 65 seconds.
+				),
+				'/2010/01/08/title-8-publish'  => array(
 					'page_views' => '1.1K page views',
 					'visitors'   => '1.1M visitors',
-					'avg_time'   => '1:00 avg time',
+					'avg_time'   => '1:06 avg time', // 66 seconds.
 				),
-				'/2010/01/05/title-7-publish' => array(
+				'/2010/01/09/title-9-publish'  => array(
+					'page_views' => '1.1K page views',
+					'visitors'   => '1.1M visitors',
+					'avg_time'   => '1:01:05 avg time', // 3665 seconds.
+				),
+				'/2010/01/11/title-11-publish' => array(
 					'page_views' => '1 page view',
 					'visitors'   => '0 visitors',
 					'avg_time'   => '0 sec. avg time',
 				),
-				'/2010/01/06/title-8-publish' => array(
+				'/2010/01/12/title-12-publish' => array(
 					'page_views' => '0 page views',
 					'visitors'   => '1 visitor',
 					'avg_time'   => '0 sec. avg time',
 				),
-				'/2010/01/07/title-9-publish' => array(
+				'/2010/01/13/title-13-publish' => array(
 					'page_views' => '0 page views',
 					'visitors'   => '0 visitors',
-					'avg_time'   => '1 sec. avg time',
+					'avg_time'   => '1 sec. avg time', // 0.6 seconds.
 				),
 			),
 			$res['data'] ?? null

--- a/tests/Unit/Utils/UtilsTest.php
+++ b/tests/Unit/Utils/UtilsTest.php
@@ -153,6 +153,8 @@ final class UtilsTest extends TestCase {
 	 * @covers function \Parsely\Utils\get_formatted_time
 	 */
 	public function test_get_formatted_time(): void {
+		$this->mock_wordpress_functions();
+
 		/**
 		 * Variable.
 		 *
@@ -241,5 +243,30 @@ final class UtilsTest extends TestCase {
 
 			self::assertSame( $t['expected_output'], $output, $t['msg'] );
 		}
+	}
+
+	/**
+	 * Mocks some WordPress functions needed by the calling tests.
+	 *
+	 * @since 3.9.1
+	 */
+	public function mock_wordpress_functions(): void {
+		// Mock __() function.
+		\Brain\Monkey\Functions\expect( '__' )
+			->with( \Mockery::type( 'string' ) )
+			->andReturnUsing(
+				function ( string $str ): string {
+					return $str;
+				}
+			);
+
+		// Mock esc_html() function.
+		\Brain\Monkey\Functions\expect( 'esc_html' )
+			->with( \Mockery::type( 'string' ) )
+			->andReturnUsing(
+				function ( string $str ): string {
+					return $str;
+				}
+			);
 	}
 }

--- a/tests/Unit/Utils/UtilsTest.php
+++ b/tests/Unit/Utils/UtilsTest.php
@@ -101,6 +101,8 @@ final class UtilsTest extends TestCase {
 	 * @covers function \Parsely\Utils\get_formatted_number
 	 */
 	public function test_get_formatted_number(): void {
+		$this->mock_wordpress_functions();
+
 		/**
 		 * Variable.
 		 *
@@ -119,12 +121,12 @@ final class UtilsTest extends TestCase {
 			),
 			array(
 				'args'            => array( 'number' => 1000 ),
-				'expected_output' => '1K',
+				'expected_output' => '1k',
 				'msg'             => 'Should show number in thousands format.',
 			),
 			array(
 				'args'            => array( 'number' => 1100 ),
-				'expected_output' => '1.1K',
+				'expected_output' => '1.1k',
 				'msg'             => 'Should show number in thousands format.',
 			),
 			array(
@@ -141,7 +143,7 @@ final class UtilsTest extends TestCase {
 
 		foreach ( $tests_data as $t ) {
 			$args   = $t['args'];
-			$output = get_formatted_number( $args['number'] );
+			$output = get_formatted_number( (string) $args['number'] );
 
 			self::assertSame( $t['expected_output'], $output, $t['msg'] );
 		}


### PR DESCRIPTION
## Description
The `get_formatted_time()` and `get_formatted_number()` functions located in utils.php were relying on the `Intl` PHP extension by using `NumberFormatter`. However, it seems that the said extension is not installed in all hosting environments, which was resulting in fatal errors for certain installations. This PR replaces the functions  that were using Intl with functions that don't.

## Motivation and context
Fixes #1558.

## How has this been tested?
Existing tests pass, and some of them were modified to work with the new functions.