### PR TITLE
OtherTest.php: Fix PHPCS errors

### DIFF
--- a/tests/Integration/OtherTest.php
+++ b/tests/Integration/OtherTest.php
@@ -182,8 +182,7 @@ final class OtherTest extends TestCase {
 		 */
 		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions
 			static function ( int $errno, string $errstr ): never {
-				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				throw new \UnexpectedValueException( $errstr, $errno );
+				throw new \UnexpectedValueException( esc_html( $errstr ), intval( $errno ) );
 			},
 			E_USER_WARNING
 		);


### PR DESCRIPTION
## Description
We had a couple of PHPCS errors in `OtherTest.php` and this PR fixes them.

## Motivation and context
Make our GitHub actions pass and our workflow work without disruptions.

## How has this been tested?
Existing tests pass.