### PR TITLE
Fix Integration tests on PHP 8.2 and 8.3

### DIFF
--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -519,10 +519,11 @@ final class ScriptsTest extends TestCase {
 		$output       = ob_get_clean();
 		$loader_asset = get_asset_info( 'build/loader.asset.php' );
 
-		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		self::assertStringContainsString( "<script data-cfasync=\"false\" type='text/javascript' src='http://example.org/wp-content/plugins/wp-parsely/tests/Integration/../../build/loader.js?ver=" . $loader_asset['version'] . "' id='wp-parsely-loader-js'></script>", $output );
-		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		self::assertStringContainsString( "<script data-cfasync=\"false\" type='text/javascript' data-parsely-site=\"blog.parsely.com\" src='https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=123456.78.9' id=\"parsely-cfg\"></script>", $output );
+		self::assertStringContainsString( "data-cfasync=\"false\"", $output );
+		self::assertStringContainsString( "http://example.org/wp-content/plugins/wp-parsely/tests/Integration/../../build/loader.js?ver=" . $loader_asset['version'], $output );
+
+		self::assertStringContainsString( "data-parsely-site=\"blog.parsely.com\"", $output );
+		self::assertStringContainsString( "https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=123456.78.9", $output );
 	}
 
 	/**

--- a/tests/Integration/ScriptsTest.php
+++ b/tests/Integration/ScriptsTest.php
@@ -519,11 +519,11 @@ final class ScriptsTest extends TestCase {
 		$output       = ob_get_clean();
 		$loader_asset = get_asset_info( 'build/loader.asset.php' );
 
-		self::assertStringContainsString( "data-cfasync=\"false\"", $output );
-		self::assertStringContainsString( "http://example.org/wp-content/plugins/wp-parsely/tests/Integration/../../build/loader.js?ver=" . $loader_asset['version'], $output );
+		self::assertStringContainsString( 'data-cfasync="false"', $output );
+		self::assertStringContainsString( 'http://example.org/wp-content/plugins/wp-parsely/tests/Integration/../../build/loader.js?ver=' . $loader_asset['version'], $output );
 
-		self::assertStringContainsString( "data-parsely-site=\"blog.parsely.com\"", $output );
-		self::assertStringContainsString( "https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=123456.78.9", $output );
+		self::assertStringContainsString( 'data-parsely-site="blog.parsely.com"', $output );
+		self::assertStringContainsString( 'https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=123456.78.9', $output );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Address failing Integration tests in [PHP 8.2 ](https://github.com/Parsely/wp-parsely/actions/runs/6310739788/job/17141991896) and [8.3](https://github.com/Parsely/wp-parsely/actions/runs/6310739788/job/17141992381).

## Motivation and context

The `test_tracker_markup_has_attribute_when_cfasync_filter_is_used` test case was looking for the full script tag, that is being built by WordPress enqueuing. However, for some reason, since PHP 8.2, it started generating the attribute values with double quotes, instead of single quotes. For example, on PHP < 8.2:

```
<script data-cfasync="false" type='text/javascript' src='http://example.org/wp-content/plugins/wp-parsely/build/loader.js?ver=1d54726e91ce976b3e82' id='wp-parsely-loader-js'></script>
```

While on PHP 8.2 and 8.3 the script is being outputted with double quotes:

```
<script data-cfasync="false" type="text/javascript" src="http://example.org/wp-content/plugins/wp-parsely/tests/Integration/../../build/loader.js?ver=1d54726e91ce976b3e82" id="wp-parsely-loader-js"></script>
```

Since we only need to validate if the `data-cfasync` attribute is present, and if  `http://example.org/wp-content/plugins/wp-parsely/tests/Integration/../../build/loader.js` and `https://cdn.parsely.com/keys/blog.parsely.com/p.js?ver=123456.78.9` are being enqueued, it was changed to look for those specific substrings and ignore the actual generated HTML. 
