### PR TITLE
Add 9 missing supported Post Types

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -107,6 +107,15 @@ class Parsely {
 		'Report',
 		'Review',
 		'CreativeWork',
+		'OpinionNewsArticle',
+		'AnalysisNewsArticle',
+		'BackgroundNewsArticle',
+		'ReviewNewsArticle',
+		'ReportageNewsArticle',
+		'Recipe',
+		'AdvertiserContentArticle',
+		'MedicalWebPage',
+		'PodcastEpisode',
 	);
 
 	/**
@@ -360,7 +369,7 @@ class Parsely {
 		 * POST request options.
 		 *
 		 * @var WP_HTTP_Request_Args $options
-		*/
+		 */
 		$options = array(
 			'method'      => 'POST',
 			'headers'     => $headers,


### PR DESCRIPTION
## Description
This pull request, related to issue #1899, addresses the bug where WP Parse.ly supports only 8 out of 17 `@types` for post content in the JSON-LD output. To fix this issue, this PR adds support for the missing `@types` to ensure that the WordPress plugin provides complete and accurate JSON-LD data representation.

## Motivation and context
This change is necessary to align the plugin with [Parse.ly's post `@types`](https://docs.parse.ly/metadata-jsonld/#distinguishing-between-posts-and-non-posts-pages) and to prevent incomplete data representation. 

## How has this been tested?
I have tested this change by implementing and using the provided filter in #1899 for a couple of the newly supported `@types`.  I have validated that, without this change, when using `repeated_metas`, the post type metadata would return `index`. With the new types added, it now returns `post`.