### PR TITLE
Use specific rules in eslint-disable comments

### DIFF
--- a/jest-e2e.config.js
+++ b/jest-e2e.config.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const baseConfig = require( '@wordpress/scripts/config/jest-e2e.config' );
 
 module.exports = {

--- a/jest-unit.config.js
+++ b/jest-unit.config.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const baseConfig = require( '@wordpress/scripts/config/jest-unit.config' );
 
 module.exports = {


### PR DESCRIPTION
## Description
This tiny PR adds a specific rule to a couple of `eslint-disable` comments.

## Motivation and context
Fulfill the promise made to @chriszarate in https://github.com/Parsely/wp-parsely/pull/1847#discussion_r1317247183

## How has this been tested?
No functionality change, ESLint doesn't complain.