### PR TITLE
Remove jest-unit.config.js

### DIFF
--- a/jest-unit.config.js
+++ b/jest-unit.config.js
@@ -1,9 +1,0 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const baseConfig = require( '@wordpress/scripts/config/jest-unit.config' );
-
-module.exports = {
-	...baseConfig,
-	transformIgnorePatterns: [
-		'\/node_modules\/(?!(uuid\/dist\/esm-browser)/)',
-	],
-};


### PR DESCRIPTION
## Description
The `jest-unit.config.js` file doesn't seem to be needed anymore, so we're removing it.

## Motivation and context
Don't keep unneeded config files.

## How has this been tested?
Unit tests pass even after the file's removal.