### PR TITLE
README.md: Add statistics and stats tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tested up to: 6.3
 Requires PHP: 7.2  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
-Tags: analytics, content marketing, parse.ly, parsely, parsley  
+Tags: analytics, statistics, stats, content marketing, parsely, parsley, parse.ly  
 Contributors: parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak
 
 The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.


### PR DESCRIPTION
## Description
With this PR, we're adding the `statistics` and `stats` tags to our README.md. Since the plugin is itself named Parse.ly, we're also moving the `parse.ly` tag to the end, to give priority to the possible misspellings.

## Motivation and context
Attempt for the plugin to be searchable by more tags.

## How has this been tested?
No code changes. It's up to wordpress.org to show and use the new tags.