### PR TITLE
Use a single spelling for JSON-LD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -828,7 +828,7 @@ If you are using the plugin without any code-level customizations (for instance,
 
 ## [2.2.1](https://github.com/Parsely/wp-parsely/compare/2.2...2.2.1) - 2020-12-18
 
-- Add logo to JSON LD publisher object.
+- Add logo to JSON-LD publisher object.
 
 ## [2.2](https://github.com/Parsely/wp-parsely/compare/2.1.3...2.2) - 2020-09-14
 
@@ -909,7 +909,7 @@ If you are using the plugin without any code-level customizations (for instance,
 
 ## [1.12](https://github.com/Parsely/wp-parsely/compare/1.11.2...1.12) - 2018-01-26
 
-- Add ability to use repeated meta tags instead of ld+json tags for metadata.
+- Add ability to use repeated meta tags instead of JSON-LD for metadata.
 - Cleanup code to conform to WordPress VIP standards.
 - Fix minor bugs.
 

--- a/tests/e2e/specs/front-end-metadata.spec.ts
+++ b/tests/e2e/specs/front-end-metadata.spec.ts
@@ -48,7 +48,7 @@ describe( 'Front end metadata insertion', () => {
 		await setUserDisplayName( 'admin', '' );
 	} );
 
-	it( 'Should insert JSON LD on homepage', async () => {
+	it( 'Should insert JSON-LD on homepage', async () => {
 		await setMetadataFormat( 'json_ld' );
 
 		await page.goto( createURL( '/' ) );
@@ -60,7 +60,7 @@ describe( 'Front end metadata insertion', () => {
 		expect( content ).not.toContain( '<meta name="parsely-title" ' );
 	} );
 
-	it( 'Should insert JSON LD on post page', async () => {
+	it( 'Should insert JSON-LD on post page', async () => {
 		await setMetadataFormat( 'json_ld' );
 
 		await page.goto( createURL( '/', '?p=1' ) );


### PR DESCRIPTION
## Description
We were spelling JSON-LD in a couple of different ways across our codebase. In this PR, we're changing everything to use `JSON-LD`.

## Motivation and context
Use a single spelling for JSON-LD.

## How has this been tested?
Existing tests pass, no functionality changes.