### PR TITLE
Use a single spelling for wp-admin

### DIFF
--- a/src/UI/class-plugins-actions.php
+++ b/src/UI/class-plugins-actions.php
@@ -29,7 +29,7 @@ final class Plugins_Actions {
 	}
 
 	/**
-	 * Adds a 'Settings' action link to the Plugins screen in WP admin.
+	 * Adds a 'Settings' action link to the Plugins screen in wp-admin.
 	 *
 	 * @param array<string, mixed> $actions An array of plugin action links. By default, this can include 'activate',
 	 *                                      'deactivate', and 'delete'. With Multisite active this can also include

--- a/src/content-helper/post-list-stats/post-list-stats.ts
+++ b/src/content-helper/post-list-stats/post-list-stats.ts
@@ -85,9 +85,9 @@ function showParselyStats( parselyStatsMap: ParselyStatsMap ): void {
 }
 
 /**
- * Shows Parse.ly Stats error as WP Admin Error Notice.
+ * Shows Parse.ly Stats error as a wp-admin error notice.
  *
- * @param {ParselyAPIErrorInfo} parselyStatsError Object which contians info about error.
+ * @param {ParselyAPIErrorInfo} parselyStatsError Object containing info about the error.
  */
 function showParselyStatsError( parselyStatsError: ParselyAPIErrorInfo ): void {
 	const headerEndElement = document.querySelector( '.wp-header-end' ); // WP has this element before admin notices.
@@ -106,7 +106,7 @@ function getAllPostStatsElements(): NodeListOf<Element> {
 }
 
 /**
- * Gets HTML for showing error message as WP Admin Error Notice.
+ * Gets HTML for showing error message as a wp-admin error notice.
  *
  * @param {string} htmlMessage Message to show inside notice.
  */


### PR DESCRIPTION
## Description
We were spelling wp-admin in a couple of different ways across our codebase. In this PR, we're changing everything to use `wp-admin`.

## Motivation and context
Use a single spelling for wp-admin.

## How has this been tested?
Existing tests pass, no functionality changes.