### PR TITLE
class-parsely.php: Fix misspelled return in DocBlock

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -281,7 +281,7 @@ class Parsely {
 		 * @param bool $skip True if the password check should be skipped.
 		 * @param int|WP_Post $post Which post object or ID is being checked.
 		 *
-		 * @returns bool
+		 * @return bool
 		 */
 		$skip_password_check = apply_filters( 'wp_parsely_skip_post_password_check', false, $post );
 		if ( ! $skip_password_check && post_password_required( $post ) ) {


### PR DESCRIPTION
## Description
Within `class-parsely.php`, we had a `@return` DocBlock that was misspelled as `@returns`. This PR fixes the typo.

## Motivation and context
No typos, correct DocBlocks!

## How has this been tested?
Existing tests pass, no functionality change.