### PR TITLE
Improve some comments and a test's name

### DIFF
--- a/src/class-validator.php
+++ b/src/class-validator.php
@@ -47,10 +47,9 @@ class Validator {
 	 * @return true|WP_Error True if the API Credentials are valid, WP_Error otherwise.
 	 */
 	public static function validate_api_credentials( Parsely $parsely, string $site_id, string $api_secret ) {
-
-		// If the API secret is empty, the validation endpoint will always fail. Since it's possible to
-		// use the plugin without an API Secret, and providing only a Site ID (API key), we'll skip the validation and
-		// assume it's valid.
+		// If the API secret is empty, the validation endpoint will always fail.
+		// Since it's possible to use the plugin without an API Secret, we'll
+		// skip the validation and assume it's valid.
 		if ( '' === $api_secret ) {
 			return true;
 		}

--- a/tests/Integration/UI/SettingsPageTest.php
+++ b/tests/Integration/UI/SettingsPageTest.php
@@ -83,7 +83,8 @@ final class SettingsPageTest extends TestCase {
 	 * @group settings-page-validation
 	 */
 	public function test_empty_api_credentials_are_retained_when_validated(): void {
-		// First change the option to something valid to make sure they are set back to empty.
+		// First, change the option to something valid to make sure they are set
+		// back to empty.
 		$options               = self::$parsely->get_options();
 		$options['apikey']     = 'mydomain.com';
 		$options['api_secret'] = 'valid_api_secret';
@@ -102,7 +103,8 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Verifies that valid API credentials are retained when validated with the Validation API.
+	 * Verifies that valid API credentials are retained when validated with the
+	 * Validation API.
 	 *
 	 * @since 3.11.0
 	 *
@@ -140,7 +142,8 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Verifies that invalid API credentials are retained when validated with the Validation API.
+	 * Verifies that invalid API credentials are reset to their previous values
+	 * when validated with the Validation API.
 	 *
 	 * @since 3.11.0
 	 *
@@ -165,7 +168,7 @@ final class SettingsPageTest extends TestCase {
 	 * @group settings-page
 	 * @group settings-page-validation
 	 */
-	public function test_invalid_api_credentials_are_retained_when_validated(): void {
+	public function test_invalid_api_credentials_are_reset_to_their_previous_value_when_validated(): void {
 		remove_filter( 'pre_http_request', array( $this, 'mock_request_api_credentials_validation_success' ), 10 );
 		// Mock HTTP request to simulate a failed credentials validation.
 		add_filter( 'pre_http_request', array( $this, 'mock_request_api_credentials_validation_failure' ), 10, 3 );
@@ -209,7 +212,8 @@ final class SettingsPageTest extends TestCase {
 	 */
 	public function test_empty_api_secret_is_retained_when_validated(): void {
 		remove_filter( 'pre_http_request', array( $this, 'mock_request_api_credentials_validation_success' ), 10 );
-		// API Requests without a secret will *always* fail. Therefore, mock HTTP request to simulate a failed credentials' validation.
+		// API Requests without a secret will *always* fail. Therefore, mock the
+		// HTTP request to simulate a failed credentials' validation.
 		add_filter( 'pre_http_request', array( $this, 'mock_request_api_credentials_validation_failure' ), 10, 3 );
 
 		$options = self::$parsely->get_options();


### PR DESCRIPTION
## Description
This PR aims on improving some comments and renaming a test from `test_invalid_api_credentials_are_retained_when_validated()` to `test_invalid_api_credentials_are_reset_to_their_previous_value_when_validated()` which I think better describes the purpose of that test. @vaurdan, keep me honest in case I've misunderstood the test's purpose.

## Motivation and context
- Keep comments to 80 characters length and shorten them.
- Remove the term `API key` that we don't use in the plugin's code anymore.
- Better reflect the test's purpose.

## How has this been tested?
No functionality changes, existing tests pass.