### PR TITLE
Improve DocBlocks

### DIFF
--- a/src/Endpoints/class-analytics-post-detail-api-proxy.php
+++ b/src/Endpoints/class-analytics-post-detail-api-proxy.php
@@ -30,7 +30,6 @@ final class Analytics_Post_Detail_API_Proxy extends Base_API_Proxy {
 	 * Cached "proxy" to the Parse.ly `/analytics/post/detail` API endpoint.
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 *
 	 * @return stdClass|WP_Error stdClass containing the data or a WP_Error object on failure.
 	 */
 	public function get_items( WP_REST_Request $request ) {
@@ -41,7 +40,6 @@ final class Analytics_Post_Detail_API_Proxy extends Base_API_Proxy {
 	 * Generates the final data from the passed response.
 	 *
 	 * @param array<stdClass> $response The response received by the proxy.
-	 *
 	 * @return array<stdClass> The generated data.
 	 */
 	protected function generate_data( $response ): array {

--- a/src/Endpoints/class-analytics-posts-api-proxy.php
+++ b/src/Endpoints/class-analytics-posts-api-proxy.php
@@ -33,7 +33,6 @@ final class Analytics_Posts_API_Proxy extends Base_API_Proxy {
 	 * Cached "proxy" to the Parse.ly `/analytics/posts` API endpoint.
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 *
 	 * @return stdClass|WP_Error stdClass containing the data or a WP_Error object on failure.
 	 */
 	public function get_items( WP_REST_Request $request ) {
@@ -44,7 +43,6 @@ final class Analytics_Posts_API_Proxy extends Base_API_Proxy {
 	 * Generates the final data from the passed response.
 	 *
 	 * @param array<stdClass> $response The response received by the proxy.
-	 *
 	 * @return array<stdClass> The generated data.
 	 */
 	protected function generate_data( $response ): array {

--- a/src/Endpoints/class-base-api-proxy.php
+++ b/src/Endpoints/class-base-api-proxy.php
@@ -63,7 +63,6 @@ abstract class Base_API_Proxy {
 	 * Cached "proxy" to the Parse.ly API endpoint.
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 *
 	 * @return stdClass|WP_Error stdClass containing the data or a WP_Error object on failure.
 	 */
 	abstract public function get_items( WP_REST_Request $request );
@@ -133,7 +132,6 @@ abstract class Base_API_Proxy {
 	 *                                            required.
 	 * @param string          $param_item         The param element to use to
 	 *                                            get the items.
-	 *
 	 * @return stdClass|WP_Error stdClass containing the data or a WP_Error object on failure.
 	 */
 	protected function get_data( WP_REST_Request $request, bool $require_api_secret = true, string $param_item = null ) {
@@ -183,7 +181,6 @@ abstract class Base_API_Proxy {
 	 * @since 3.10.0
 	 *
 	 * @param stdClass $item The object to extract the data from.
-	 *
 	 * @return array<string, mixed> The extracted data.
 	 */
 	protected function extract_post_data( stdClass $item ): array {
@@ -246,7 +243,6 @@ abstract class Base_API_Proxy {
 	 * @since 3.10.0
 	 *
 	 * @param array<stdClass> $response The response received by the proxy.
-	 *
 	 * @return array<stdClass> The generated data.
 	 */
 	protected function generate_post_data( array $response ): array {

--- a/src/Endpoints/class-referrers-post-detail-api-proxy.php
+++ b/src/Endpoints/class-referrers-post-detail-api-proxy.php
@@ -44,7 +44,6 @@ final class Referrers_Post_Detail_API_Proxy extends Base_API_Proxy {
 	 * @since 3.6.0
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 *
 	 * @return stdClass|WP_Error stdClass containing the data or a WP_Error object on failure.
 	 */
 	public function get_items( WP_REST_Request $request ) {
@@ -65,7 +64,6 @@ final class Referrers_Post_Detail_API_Proxy extends Base_API_Proxy {
 	 * @since 3.6.0
 	 *
 	 * @param array<stdClass> $response The response received by the proxy.
-	 *
 	 * @return array<stdClass> The generated data.
 	 */
 	protected function generate_data( $response ): array {

--- a/src/Endpoints/class-related-api-proxy.php
+++ b/src/Endpoints/class-related-api-proxy.php
@@ -31,7 +31,6 @@ final class Related_API_Proxy extends Base_API_Proxy {
 	 * Cached "proxy" to the Parse.ly `/related` API endpoint.
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 *
 	 * @return stdClass|WP_Error stdClass containing the data or a WP_Error object on failure.
 	 */
 	public function get_items( WP_REST_Request $request ) {

--- a/src/Endpoints/class-rest-metadata.php
+++ b/src/Endpoints/class-rest-metadata.php
@@ -68,7 +68,6 @@ class Rest_Metadata extends Metadata_Endpoint {
 	 *
 	 * @param array<string, mixed> $object_data The data of the object to render the metadata for,
 	 *                                          usually a post or a page.
-	 *
 	 * @return array<string, mixed> The `parsely` object to be rendered in the REST API. Contains a
 	 *                              version number describing the response and the `meta` object
 	 *                              containing the actual metadata.

--- a/src/Integrations/class-amp.php
+++ b/src/Integrations/class-amp.php
@@ -129,7 +129,6 @@ class Amp extends Integration {
 	 * @since 2.6.0
 	 *
 	 * @param array<string, mixed>|null $analytics The analytics registry.
-	 *
 	 * @return Amp_Analytics|array<string, mixed> The analytics registry.
 	 */
 	public function register_parsely_for_amp_native_analytics( ?array $analytics ): array {

--- a/src/Integrations/class-amp.php
+++ b/src/Integrations/class-amp.php
@@ -180,8 +180,9 @@ class Amp extends Integration {
 	 * consists of the site's Site ID if that's defined, or an empty array
 	 * otherwise.
 	 *
-	 * @link https://docs.parse.ly/google-amp/
 	 * @since 3.2.0
+	 *
+	 * @link https://docs.parse.ly/google-amp/
 	 *
 	 * @return array<string, array<string, string>>
 	 */

--- a/src/Integrations/class-google-web-stories.php
+++ b/src/Integrations/class-google-web-stories.php
@@ -32,9 +32,9 @@ final class Google_Web_Stories extends Integration {
 	 * Loads additional JavaScript for Google's Web Stories WordPress plugin.
 	 * This relies on the `amp-analytics` element.
 	 *
-	 * @see https://docs.parse.ly/google-amp/
-	 *
 	 * @since 3.2.0
+	 *
+	 * @see https://docs.parse.ly/google-amp/
 	 */
 	public function render_amp_analytics_tracker(): void {
 		$json = Amp::construct_amp_json();

--- a/src/Metadata/class-post-builder.php
+++ b/src/Metadata/class-post-builder.php
@@ -275,7 +275,6 @@ class Post_Builder extends Metadata_Builder {
 	 *
 	 * @param WP_Post         $post_obj The object for the post.
 	 * @param Parsely_Options $parsely_options The parsely options.
-	 *
 	 * @return string Cleaned category name for the post in question.
 	 */
 	private function get_category_name( WP_Post $post_obj, $parsely_options ): string {

--- a/src/Metadata/class-post-builder.php
+++ b/src/Metadata/class-post-builder.php
@@ -96,11 +96,11 @@ class Post_Builder extends Metadata_Builder {
 		/**
 		 * Filters the JSON-LD @type.
 		 *
+		 * @since 2.5.0
+		 *
 		 * @param string $jsonld_type JSON-LD @type value, default is NewsArticle.
 		 * @param int $id Post ID.
 		 * @param string $post_type The Post type in WordPress.
-		 *
-		 * @since 2.5.0
 		 */
 		$type            = apply_filters( 'wp_parsely_post_type', 'NewsArticle', $this->post->ID, $this->post->post_type );
 		$supported_types = $this->parsely->get_all_supported_types();
@@ -230,10 +230,10 @@ class Post_Builder extends Metadata_Builder {
 		/**
 		 * Filters the post tags that are used as metadata keywords.
 		 *
+		 * @since 1.8.0
+		 *
 		 * @param array<string> $tags Post tags.
 		 * @param int $ID Post ID.
-		 *
-		 * @since 1.8.0
 		 */
 		$tags = apply_filters( 'wp_parsely_post_tags', $tags, $this->post->ID );
 		$tags = array_map( array( $this, 'clean_value' ), $tags );

--- a/src/RemoteAPI/class-analytics-post-detail-api.php
+++ b/src/RemoteAPI/class-analytics-post-detail-api.php
@@ -25,7 +25,6 @@ class Analytics_Post_Detail_API extends Remote_API_Base {
 	 * Indicates whether the endpoint is public or protected behind permissions.
 	 *
 	 * @since 3.7.0
-	 *
 	 * @var bool
 	 */
 	protected $is_public_endpoint = false;

--- a/src/RemoteAPI/class-analytics-posts-api.php
+++ b/src/RemoteAPI/class-analytics-posts-api.php
@@ -71,7 +71,6 @@ class Analytics_Posts_API extends Remote_API_Base {
 	 * Main purpose of this function is to enforce typing.
 	 *
 	 * @param Analytics_Post_API_Params $api_params Parameters of the API.
-	 *
 	 * @return Analytics_Post[]|WP_Error|null
 	 */
 	public function get_posts_analytics( $api_params ) {

--- a/src/RemoteAPI/class-analytics-posts-api.php
+++ b/src/RemoteAPI/class-analytics-posts-api.php
@@ -61,7 +61,6 @@ class Analytics_Posts_API extends Remote_API_Base {
 	 * Indicates whether the endpoint is public or protected behind permissions.
 	 *
 	 * @since 3.7.0
-	 *
 	 * @var bool
 	 */
 	protected $is_public_endpoint = false;

--- a/src/RemoteAPI/class-referrers-post-detail-api.php
+++ b/src/RemoteAPI/class-referrers-post-detail-api.php
@@ -25,7 +25,6 @@ class Referrers_Post_Detail_API extends Remote_API_Base {
 	 * Indicates whether the endpoint is public or protected behind permissions.
 	 *
 	 * @since 3.7.0
-	 *
 	 * @var bool
 	 */
 	protected $is_public_endpoint = false;

--- a/src/RemoteAPI/class-related-api.php
+++ b/src/RemoteAPI/class-related-api.php
@@ -25,7 +25,6 @@ class Related_API extends Remote_API_Base {
 	 * Indicates whether the endpoint is public or protected behind permissions.
 	 *
 	 * @since 3.7.0
-	 *
 	 * @var bool
 	 */
 	protected $is_public_endpoint = true;

--- a/src/RemoteAPI/class-remote-api-base.php
+++ b/src/RemoteAPI/class-remote-api-base.php
@@ -147,7 +147,6 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	 *
 	 * @param array<string, mixed> $query The query arguments to send to the remote API.
 	 * @param bool                 $associative When TRUE, returned objects will be converted into associative arrays.
-	 *
 	 * @return array<string, mixed>|object|WP_Error
 	 */
 	public function get_items( array $query, bool $associative = false ) {

--- a/src/RemoteAPI/class-remote-api-base.php
+++ b/src/RemoteAPI/class-remote-api-base.php
@@ -41,7 +41,6 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	 * Indicates whether the endpoint is public or protected behind permissions.
 	 *
 	 * @since 3.7.0
-	 *
 	 * @var bool
 	 */
 	protected $is_public_endpoint = false;

--- a/src/RemoteAPI/class-remote-api-base.php
+++ b/src/RemoteAPI/class-remote-api-base.php
@@ -111,10 +111,9 @@ abstract class Remote_API_Base implements Remote_API_Interface {
 	 *
 	 * @since 3.2.0
 	 *
+	 * @param array<string, mixed> $query The query arguments to send to the remote API.
 	 * @throws UnexpectedValueException If the endpoint constant is not defined.
 	 * @throws UnexpectedValueException If the query filter constant is not defined.
-	 *
-	 * @param array<string, mixed> $query The query arguments to send to the remote API.
 	 * @return string
 	 */
 	public function get_api_url( array $query ): string {

--- a/src/RemoteAPI/class-remote-api-cache.php
+++ b/src/RemoteAPI/class-remote-api-cache.php
@@ -50,7 +50,6 @@ class Remote_API_Cache implements Remote_API_Interface {
 	 * @param array<string, mixed> $query The query arguments to send to the remote API.
 	 * @param bool                 $associative Always `false`, just present to make definition compatible
 	 *                             with interface.
-	 *
 	 * @return array<string, mixed>|object|WP_Error The response from the remote API, or false if the
 	 *                                              response is empty.
 	 */

--- a/src/RemoteAPI/class-validate-api.php
+++ b/src/RemoteAPI/class-validate-api.php
@@ -55,7 +55,6 @@ class Validate_API extends Remote_API_Base {
 	 * The API will return a 200 response if the credentials are valid and a 401 response if they are not.
 	 *
 	 * @param array<string, mixed> $query The query arguments to send to the remote API.
-	 *
 	 * @return object|WP_Error The response from the remote API, or a WP_Error object if the response is an error.
 	 */
 	private function api_validate_credentials( array $query ) {
@@ -102,7 +101,6 @@ class Validate_API extends Remote_API_Base {
 	 * @param array<string, mixed> $query The query arguments to send to the remote API.
 	 * @param bool                 $associative (optional) When TRUE, returned objects will be converted into
 	 *                             associative arrays.
-	 *
 	 * @return array<string, mixed>|object|WP_Error
 	 */
 	public function get_items( array $query, bool $associative = false ) {

--- a/src/RemoteAPI/class-wordpress-cache.php
+++ b/src/RemoteAPI/class-wordpress-cache.php
@@ -26,7 +26,6 @@ class WordPress_Cache implements Cache {
 	 *                          from the persistent cache. Default false.
 	 * @param bool       $found Optional. Whether the key was found in the cache (passed by reference).
 	 *                          Disambiguates a return of false, a storable value. Default null.
-	 *
 	 * @return mixed|false The cache contents on success, false on failure to retrieve contents.
 	 */
 	public function get( $key, string $group = '', bool $force = false, bool $found = null ) {

--- a/src/RemoteAPI/interface-remote-api.php
+++ b/src/RemoteAPI/interface-remote-api.php
@@ -22,7 +22,6 @@ interface Remote_API_Interface {
 	 * @param array<string, mixed> $query The query arguments to send to the remote API.
 	 * @param bool                 $associative (optional) When TRUE, returned objects will be converted into
 	 *                             associative arrays.
-	 *
 	 * @return array<string, mixed>|object|WP_Error
 	 */
 	public function get_items( array $query, bool $associative = false );

--- a/src/UI/class-network-admin-sites-list.php
+++ b/src/UI/class-network-admin-sites-list.php
@@ -57,7 +57,6 @@ final class Network_Admin_Sites_List {
 	 * @param array<string, mixed> $actions  The list of actions meant to be displayed for the current site's
 	 *                                       context in the row actions.
 	 * @param int                  $_blog_id The blog ID for the current context.
-	 *
 	 * @return array<string, mixed> The list of actions including ours.
 	 */
 	public static function add_action_link( array $actions, int $_blog_id ): array {

--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -77,11 +77,11 @@ final class Recommended_Widget extends WP_Widget {
 	/**
 	 * Gets the URL for the Recommendations API (GET /related).
 	 *
+	 * @since 2.5.0
+	 *
 	 * @see https://docs.parse.ly/content-recommendations/
 	 *
 	 * @internal While this is a public method now, this should be moved to a new class.
-	 *
-	 * @since 2.5.0
 	 *
 	 * @param string      $site_id          Publisher Site ID.
 	 * @param int|null    $published_within Publication filter start date; see https://docs.parse.ly/api-date-time/ for

--- a/src/UI/class-recommended-widget.php
+++ b/src/UI/class-recommended-widget.php
@@ -279,7 +279,6 @@ final class Recommended_Widget extends WP_Widget {
 	 *
 	 * @param Widget_Settings $new_instance The new values for the db.
 	 * @param Widget_Settings $old_instance Values saved to the db.
-	 *
 	 * @return Widget_Settings
 	 */
 	public function update( $new_instance, $old_instance ) /* @phpstan-ignore-line */ {
@@ -315,7 +314,6 @@ final class Recommended_Widget extends WP_Widget {
 	 * @since 3.7.0
 	 *
 	 * @param array<string, mixed> $settings Widget Options.
-	 *
 	 * @return Widget_Settings
 	 */
 	public function get_widget_settings( array $settings ) {

--- a/src/UI/class-row-actions.php
+++ b/src/UI/class-row-actions.php
@@ -65,7 +65,6 @@ final class Row_Actions {
 	 * @since 2.6.0
 	 *
 	 * @see https://developer.wordpress.org/reference/hooks/page_row_actions/
-	 * @see https://developer.wordpress.org/reference/hooks/post_row_actions/
 	 *
 	 * @param array<string, string> $actions The existing list of actions.
 	 * @param WP_Post               $post    The individual post object the actions apply to.

--- a/src/UI/class-row-actions.php
+++ b/src/UI/class-row-actions.php
@@ -69,7 +69,6 @@ final class Row_Actions {
 	 *
 	 * @param array<string, string> $actions The existing list of actions.
 	 * @param WP_Post               $post    The individual post object the actions apply to.
-	 *
 	 * @return array<string, string> The amended list of actions.
 	 */
 	public function row_actions_add_parsely_link( array $actions, WP_Post $post ): array {

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -942,7 +942,6 @@ final class Settings_Page {
 	 * Validates the options provided by the user.
 	 *
 	 * @param ParselySettingOptions $input Options from the settings page.
-	 *
 	 * @return ParselySettingOptions
 	 */
 	public function validate_options( $input ) {
@@ -957,7 +956,6 @@ final class Settings_Page {
 	 * Validates fields of Basic Section.
 	 *
 	 * @param ParselySettingOptions $input Options from the settings page.
-	 *
 	 * @return ParselySettingOptions Validated inputs.
 	 */
 	private function validate_basic_section( $input ) {
@@ -1053,7 +1051,6 @@ final class Settings_Page {
 	 * Validates fields of Recrawl Section.
 	 *
 	 * @param ParselySettingOptions $input Options from the settings page.
-	 *
 	 * @return ParselySettingOptions Validated inputs.
 	 */
 	private function validate_recrawl_section( $input ) {
@@ -1161,7 +1158,6 @@ final class Settings_Page {
 	 * Validates fields of Advanced Section.
 	 *
 	 * @param ParselySettingOptions $input Options from the settings page.
-	 *
 	 * @return ParselySettingOptions Validated inputs.
 	 */
 	private function validate_advanced_section( $input ) {
@@ -1205,7 +1201,6 @@ final class Settings_Page {
 	 * @since 3.3.0
 	 *
 	 * @param string $site_id The Site ID to be sanitized.
-	 *
 	 * @return string
 	 */
 	private function sanitize_site_id( string $site_id ): string {
@@ -1302,7 +1297,6 @@ final class Settings_Page {
 	 * Gets obfuscated value.
 	 *
 	 * @param string $current_value Current value of the field.
-	 *
 	 * @return string
 	 */
 	private function get_obfuscated_value( $current_value ): string {
@@ -1315,7 +1309,6 @@ final class Settings_Page {
 	 * @param string $current_value Current value of the field.
 	 * @param string $previous_value Previous value of the field. If current
 	 *                               value is obfuscated then we will use this.
-	 *
 	 * @return string
 	 */
 	private function get_unobfuscated_value( $current_value, $previous_value ): string {
@@ -1334,7 +1327,6 @@ final class Settings_Page {
 	 *
 	 * @param string $title The field's title.
 	 * @param string $option_id The option's ID.
-	 *
 	 * @return string The resulting content.
 	 */
 	public function set_field_label_contents( string $title, string $option_id ): string {

--- a/src/UI/class-site-health.php
+++ b/src/UI/class-site-health.php
@@ -63,7 +63,6 @@ final class Site_Health {
 	 * @since 3.4.0
 	 *
 	 * @param array<string, mixed> $tests An associative array of direct and asynchronous tests.
-	 *
 	 * @return array<string, mixed>
 	 */
 	public function check_site_id( array $tests ): array {
@@ -111,7 +110,6 @@ final class Site_Health {
 	 * @since 3.4.0
 	 *
 	 * @param Site_Health_Info $args The debug information to be added to the core information page.
-	 *
 	 * @return Site_Health_Info
 	 */
 	public function options_debug_info( $args ) {

--- a/src/class-dashboard-link.php
+++ b/src/class-dashboard-link.php
@@ -30,7 +30,6 @@ class Dashboard_Link {
 	 * @param string  $site_id Site ID or empty string.
 	 * @param string  $campaign Campaign name for the `utm_campaign` URL parameter.
 	 * @param string  $source Source name for the `utm_source` URL parameter.
-	 *
 	 * @return string
 	 */
 	public static function generate_url( WP_Post $post, string $site_id, string $campaign, string $source ): string {

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -130,13 +130,12 @@ class Metadata {
 		/**
 		 * Filters the structured metadata.
 		 *
+		 * @since 2.5.0
 		 * @var mixed
 		 *
 		 * @param array $parsely_page Existing structured metadata for a page.
 		 * @param WP_Post $post Post object.
 		 * @param array $options The Parse.ly options.
-		 *
-		 * @since 2.5.0
 		 */
 		$filtered = apply_filters( 'wp_parsely_metadata', $parsely_page, $post, $options );
 		if ( is_array( $filtered ) ) {

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -85,7 +85,6 @@ class Metadata {
 	 * Creates Parse.ly metadata object from post metadata.
 	 *
 	 * @param WP_Post $post object.
-	 *
 	 * @return Metadata_Attributes
 	 */
 	public function construct_metadata( WP_Post $post ) {

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -225,7 +225,6 @@ class Parsely {
 	 * head tag.
 	 *
 	 * @since 3.2.0
-	 *
 	 * @deprecated 3.3.0
 	 * @see Metadata_Renderer::render_metadata
 	 *
@@ -243,7 +242,6 @@ class Parsely {
 	 * head tag.
 	 *
 	 * @since 3.0.0
-	 *
 	 * @deprecated 3.3.0
 	 * @see Metadata_Renderer::render_metadata
 	 */

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -93,10 +93,10 @@ class Parsely {
 	/**
 	 * Declare post types that Parse.ly will process as "posts".
 	 *
-	 * @link https://docs.parse.ly/metadata-jsonld/#distinguishing-between-posts-and-non-posts-pages
-	 *
 	 * @since 2.5.0
 	 * @var string[]
+	 *
+	 * @link https://docs.parse.ly/metadata-jsonld/#distinguishing-between-posts-and-non-posts-pages
 	 */
 	public const SUPPORTED_JSONLD_POST_TYPES = array(
 		'NewsArticle',
@@ -121,10 +121,10 @@ class Parsely {
 	/**
 	 * Declare post types that Parse.ly will process as "non-posts".
 	 *
-	 * @link https://docs.parse.ly/metadata-jsonld/#distinguishing-between-posts-and-non-posts-pages
-	 *
 	 * @since 2.5.0
 	 * @var string[]
+	 *
+	 * @link https://docs.parse.ly/metadata-jsonld/#distinguishing-between-posts-and-non-posts-pages
 	 */
 	public const SUPPORTED_JSONLD_NON_POST_TYPES = array(
 		'WebPage',
@@ -150,7 +150,6 @@ class Parsely {
 	 *
 	 * @since 3.9.0
 	 * @access private
-	 *
 	 * @var bool
 	 */
 	public $are_credentials_managed;
@@ -163,7 +162,6 @@ class Parsely {
 	 *
 	 * @since 3.9.0
 	 * @access private
-	 *
 	 * @var array<empty>|array<string, bool|string|null>
 	 */
 	public $managed_options = array();
@@ -227,6 +225,7 @@ class Parsely {
 	 * head tag.
 	 *
 	 * @since 3.2.0
+	 *
 	 * @deprecated 3.3.0
 	 * @see Metadata_Renderer::render_metadata
 	 *
@@ -244,6 +243,7 @@ class Parsely {
 	 * head tag.
 	 *
 	 * @since 3.0.0
+	 *
 	 * @deprecated 3.3.0
 	 * @see Metadata_Renderer::render_metadata
 	 */
@@ -281,7 +281,7 @@ class Parsely {
 		 * @param bool $skip True if the password check should be skipped.
 		 * @param int|WP_Post $post Which post object or ID is being checked.
 		 *
-		 * @returns bool
+		 * @return bool
 		 */
 		$skip_password_check = apply_filters( 'wp_parsely_skip_post_password_check', false, $post );
 		if ( ! $skip_password_check && post_password_required( $post ) ) {

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -315,7 +315,6 @@ class Parsely {
 	 *
 	 * @param array<string, mixed> $parsely_options parsely_options array.
 	 * @param WP_Post              $post object.
-	 *
 	 * @return Metadata_Attributes
 	 */
 	public function construct_parsely_metadata( array $parsely_options, WP_Post $post ) {
@@ -451,7 +450,6 @@ class Parsely {
 	 *
 	 * @param int|null $_blog_id The Blog ID for the multisite subsite to use
 	 *                           for context (Default null for current).
-	 *
 	 * @return string
 	 */
 	public static function get_settings_url( int $_blog_id = null ): string {
@@ -488,7 +486,6 @@ class Parsely {
 	 *
 	 * @param string      $url The URL to modify.
 	 * @param string|null $itm_source The value of the itm_source parameter.
-	 *
 	 * @return string The resulting URL.
 	 */
 	public static function get_url_with_itm_source( string $url, $itm_source ): string {
@@ -750,7 +747,6 @@ class Parsely {
 	 *
 	 * @param string      $option_id The option's ID.
 	 * @param bool|string $value The option's value.
-	 *
 	 * @return bool|string The sanitized option value.
 	 */
 	private function sanitize_managed_option( string $option_id, $value ) {

--- a/src/class-scripts.php
+++ b/src/class-scripts.php
@@ -140,7 +140,6 @@ class Scripts {
 	 * @param string $tag    The `script` tag for the enqueued script.
 	 * @param string $handle The script's registered handle.
 	 * @param string $src    Unused? The script's source URL.
-	 *
 	 * @return string Amended `script` tag.
 	 */
 	public function script_loader_tag( // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed

--- a/src/content-helper/common/class-content-helper-feature.php
+++ b/src/content-helper/common/class-content-helper-feature.php
@@ -22,7 +22,6 @@ abstract class Content_Helper_Feature {
 	 * Instance of Parsely class.
 	 *
 	 * @since 3.9.0
-	 *
 	 * @var Parsely
 	 */
 	protected $parsely;
@@ -83,6 +82,7 @@ abstract class Content_Helper_Feature {
 	 * - Possible invalid filter values will resolve to false.
 	 *
 	 * @since 3.9.0
+	 *
 	 * @param bool ...$conditions Conditions that need to be met besides filters
 	 *                            for the function to return true.
 	 * @return bool Whether the feature can be enabled.

--- a/src/content-helper/post-list-stats/class-post-list-stats.php
+++ b/src/content-helper/post-list-stats/class-post-list-stats.php
@@ -173,7 +173,6 @@ class Post_List_Stats extends Content_Helper_Feature {
 	 * @since 3.7.0
 	 *
 	 * @param array<string, string> $columns Columns array which contain keys and labels.
-	 *
 	 * @return array<string, string>
 	 */
 	public function add_parsely_stats_column_on_list_view( array $columns ): array {
@@ -273,7 +272,6 @@ class Post_List_Stats extends Content_Helper_Feature {
 	 * @since 3.7.0
 	 *
 	 * @param Analytics_Posts_API $analytics_api Instance of Analytics_Posts_API.
-	 *
 	 * @return Parsely_Posts_Stats_Response|null
 	 */
 	public function get_parsely_stats_response( $analytics_api ) {
@@ -404,7 +402,6 @@ class Post_List_Stats extends Content_Helper_Feature {
 	 * @since 3.7.0
 	 *
 	 * @param Analytics_Post $analytics_post Post analytics obj returned from Parse.ly API.
-	 *
 	 * @return string
 	 */
 	private function get_unique_stats_key_from_analytics( $analytics_post ): string {

--- a/tests/Integration/ContentHelperFeatureTest.php
+++ b/tests/Integration/ContentHelperFeatureTest.php
@@ -23,12 +23,12 @@ abstract class ContentHelperFeatureTest extends TestCase {
 	 * Asserts the enqueueing status of the feature's assets according to the
 	 * passed filter values.
 	 *
+	 * @since 3.9.0
+	 *
 	 * @param mixed $global_filter_value The value of the global filter.
 	 * @param mixed $feature_filter_value The value of the feature filter.
 	 * @param bool  $expected Whether the assets should be enqueued.
 	 * @param mixed ...$additional_args Any required additional arguments.
-	 *
-	 * @since 3.9.0
 	 */
 	abstract protected function assert_enqueued_status(
 		$global_filter_value,

--- a/tests/Integration/Metadata/AuthorArchiveTest.php
+++ b/tests/Integration/Metadata/AuthorArchiveTest.php
@@ -16,6 +16,7 @@ use Parsely\Parsely;
  * Integration Tests for Author Archive pages metadata.
  *
  * @see https://docs.parse.ly/metadata-jsonld/
+ *
  * @covers \Parsely\Metadata::construct_metadata
  */
 final class AuthorArchiveTest extends NonPostTestCase {

--- a/tests/Integration/Metadata/BlogArchiveTest.php
+++ b/tests/Integration/Metadata/BlogArchiveTest.php
@@ -16,6 +16,7 @@ use Parsely\Parsely;
  * Integration Tests for Blog Archive pages metadata.
  *
  * @see https://docs.parse.ly/metadata-jsonld/
+ *
  * @covers \Parsely\Metadata::construct_metadata
  */
 final class BlogArchiveTest extends NonPostTestCase {

--- a/tests/Integration/Metadata/CustomPostTypeArchiveTest.php
+++ b/tests/Integration/Metadata/CustomPostTypeArchiveTest.php
@@ -16,6 +16,7 @@ use Parsely\Parsely;
  * Integration Tests for Custom Post Type Archive pages metadata.
  *
  * @see https://docs.parse.ly/metadata-jsonld/
+ *
  * @covers \Parsely\Metadata::construct_metadata
  */
 final class CustomPostTypeArchiveTest extends NonPostTestCase {

--- a/tests/Integration/Metadata/CustomTaxonomyTermArchiveTest.php
+++ b/tests/Integration/Metadata/CustomTaxonomyTermArchiveTest.php
@@ -16,6 +16,7 @@ use Parsely\Parsely;
  * Integration Tests for Custom Taxonomy Term Archive pages metadata.
  *
  * @see https://docs.parse.ly/metadata-jsonld/
+ *
  * @covers \Parsely\Metadata::construct_metadata
  */
 class CustomTaxonomyTermArchiveTest extends NonPostTestCase {

--- a/tests/Integration/Metadata/HomePageTest.php
+++ b/tests/Integration/Metadata/HomePageTest.php
@@ -18,6 +18,7 @@ const TEST_BLOG_NAME = 'Test Blog';
  * Integration Tests for the Homepage's metadata.
  *
  * @see https://docs.parse.ly/metadata-jsonld/
+ *
  * @covers \Parsely\Metadata::construct_metadata
  */
 final class HomePageTest extends NonPostTestCase {

--- a/tests/Integration/Metadata/SinglePageTest.php
+++ b/tests/Integration/Metadata/SinglePageTest.php
@@ -16,6 +16,7 @@ use Parsely\Parsely;
  * Integration Tests for Single Page pages metadata.
  *
  * @see https://docs.parse.ly/metadata-jsonld/
+ *
  * @covers \Parsely\Metadata::construct_metadata
  */
 final class SinglePageTest extends NonPostTestCase {

--- a/tests/Integration/Metadata/TermArchiveTest.php
+++ b/tests/Integration/Metadata/TermArchiveTest.php
@@ -16,6 +16,7 @@ use Parsely\Parsely;
  * Integration Tests for Term Archive pages metadata.
  *
  * @see https://docs.parse.ly/metadata-jsonld/
+ *
  * @covers \Parsely\Metadata::construct_metadata
  */
 final class TermArchiveTest extends NonPostTestCase {

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -61,7 +61,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 *
 	 * @param string $post_type Optional. The post's type. Default is 'post'.
 	 * @param string $post_status Optional. The post's status. Default is 'publish'.
-	 *
 	 * @return array<string, mixed> An array of WP_Post fields.
 	 */
 	public function create_test_post_array( string $post_type = 'post', string $post_status = 'publish' ): array {
@@ -78,7 +77,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * Creates a test category.
 	 *
 	 * @param string $name Category name.
-	 *
 	 * @return int
 	 */
 	public function create_test_category( string $name ): int {
@@ -98,7 +96,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 *
 	 * @param string $user_login The user's login username.
 	 * @param string $user_role The user's role. Default is subscriber.
-	 *
 	 * @return int The newly created user's ID.
 	 */
 	public function create_test_user( string $user_login, string $user_role = 'subscriber' ): int {
@@ -117,7 +114,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * @param string $domain  Site second-level domain without a .com TLD e.g. 'example' will
 	 *                        result in a new subsite of 'http://example.com'.
 	 * @param int    $user_id User ID for the site administrator.
-	 *
 	 * @return int
 	 */
 	public function create_test_blog( string $domain, int $user_id ): int {
@@ -135,7 +131,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 *
 	 * @param string $taxonomy_key Taxonomy key, must not exceed 32 characters.
 	 * @param string $term_name    The term name to add.
-	 *
 	 * @return int
 	 */
 	public function create_test_taxonomy( string $taxonomy_key, string $term_name ): int {
@@ -161,7 +156,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * Creates a new post.
 	 *
 	 * @param string $post_status Optional. The post's status. Default is 'publish'.
-	 *
 	 * @return int The new post's ID.
 	 */
 	public function create_test_post( string $post_status = 'publish' ): int {
@@ -177,7 +171,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * @param int    $num_of_posts Optional. Number of posts we need to create.
 	 * @param string $post_type Optional. Type of the posts.
 	 * @param string $post_status Optional. Status of the posts.
-	 *
 	 * @return WP_Post[]
 	 */
 	public function create_and_get_test_posts( int $num_of_posts = 1, string $post_type = 'post', string $post_status = 'publish' ): array {
@@ -192,7 +185,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * @param int    $num_of_posts Optional. Number of posts we need to create.
 	 * @param string $post_type Optional. Type of the posts.
 	 * @param string $post_status Optional. Status of the posts.
-	 *
 	 * @return int[]
 	 */
 	private function create_posts_and_get_ids( int $num_of_posts = 1, string $post_type = 'post', string $post_status = 'publish' ): array {
@@ -296,7 +288,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * Gets given test posts.
 	 *
 	 * @param int[] $post_ids IDs of the posts.
-	 *
 	 * @return WP_Post[]
 	 */
 	private function get_test_posts( array $post_ids = array() ): array {
@@ -341,7 +332,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * This function ensures strict typing in our codebase.
 	 *
 	 * @param int $term_id ID of the term.
-	 *
 	 * @return WP_Term
 	 */
 	public function get_term( int $term_id ): WP_Term {
@@ -359,7 +349,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * This function ensures strict typing in our codebase.
 	 *
 	 * @param int $term_id ID of the term.
-	 *
 	 * @return array<string, mixed>
 	 */
 	public function get_term_in_array( int $term_id ): array {
@@ -377,7 +366,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * This function ensures strict typing in our codebase.
 	 *
 	 * @param int $term_id ID of the term.
-	 *
 	 * @return string
 	 */
 	public function get_term_link( int $term_id ): string {
@@ -397,7 +385,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * @param string      $format Format to use for retrieving the time.
 	 * @param bool        $is_gmt Whether to retrieve the GMT time.
 	 * @param int|WP_Post $post WP_Post object or ID.
-	 *
 	 * @return int
 	 */
 	public function get_post_time_in_int( string $format, bool $is_gmt, $post ): int {
@@ -415,7 +402,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * This function ensures strict typing in our codebase.
 	 *
 	 * @param mixed $data — Variable (usually an array or object) to encode as JSON.
-	 *
 	 * @return string
 	 */
 	public function wp_json_encode( $data ): string {
@@ -428,7 +414,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * Creates a new post and navigates to it.
 	 *
 	 * @param string $post_status Optional. The post's status. Default is 'publish'.
-	 *
 	 * @return int The new post's ID.
 	 */
 	public function go_to_new_post( string $post_status = 'publish' ): int {
@@ -637,7 +622,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 *
 	 * @param class-string $class_name Name of the class.
 	 * @param string       $property_name Name of the property.
-	 *
 	 * @return ReflectionProperty
 	 */
 	public function get_private_property( string $class_name, string $property_name ): ReflectionProperty {
@@ -654,7 +638,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 *
 	 * @param class-string $class_name Name of the class.
 	 * @param string       $method Name of the method.
-	 *
 	 * @return ReflectionMethod
 	 */
 	public function get_private_method( string $class_name, string $method ): ReflectionMethod {

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -241,9 +241,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * This function ensures strict typing in our codebase.
 	 *
 	 * @param int|WP_Error $post_id Optional. Defaults to global $post.
-	 *
 	 * @throws UnexpectedValueException If $post_id is a WP_Error object.
-	 *
 	 * @return WP_Post
 	 */
 	public function get_post( $post_id = null ): WP_Post {
@@ -269,9 +267,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * This function ensures strict typing in our codebase.
 	 *
 	 * @param int|WP_Error $post_id ID of the posts.
-	 *
 	 * @throws UnexpectedValueException If $post_id is a WP_Error object.
-	 *
 	 * @return array<string, mixed>
 	 */
 	public function get_post_in_array( $post_id ): array {
@@ -311,9 +307,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 * This function ensures strict typing in our codebase.
 	 *
 	 * @param int|WP_Error $post_id ID of the post.
-	 *
 	 * @throws UnexpectedValueException If $post_id is a WP_Error object.
-	 *
 	 * @return string|false
 	 */
 	public function get_permalink( $post_id ) {
@@ -460,7 +454,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 *
 	 * @param string[] $true_hooks Optional. Actions that should have been present.
 	 * @param string[] $false_hooks Optional. Actions that should have not been present.
-	 *
 	 * @throws RiskyTestError If no assertions get passed to the function.
 	 */
 	private function assert_wp_hooks( array $true_hooks = array(), array $false_hooks = array() ): void {
@@ -527,7 +520,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 *                                           'registered', 'queue', 'to_do', and 'done'. Default is an empty array.
 	 * @param array<Script_Status> $assert_false Optional. Statuses that should assert to false. Accepts 'enqueued',
 	 *                                           'registered', 'queue', 'to_do', and 'done'. Default is an empty array.
-	 *
 	 * @throws RiskyTestError If no assertions ($assert_true, $assert_false) get passed to the function.
 	 */
 	private function assert_script_statuses( string $handle, array $assert_true = array(), array $assert_false = array() ): void {
@@ -594,7 +586,6 @@ abstract class TestCase extends WPIntegrationTestCase {
 	 *                                    'registered', 'queue', 'to_do', and 'done'. Default is an empty array.
 	 * @param array<string> $assert_false Optional. Statuses that should assert to false. Accepts 'enqueued',
 	 *                                    'registered', 'queue', 'to_do', and 'done'. Default is an empty array.
-	 *
 	 * @throws RiskyTestError If no assertions ($assert_true, $assert_false) get passed to the function.
 	 */
 	private function assert_style_statuses( string $handle, array $assert_true = array(), array $assert_false = array() ): void {

--- a/tests/Integration/UI/SettingsPageTest.php
+++ b/tests/Integration/UI/SettingsPageTest.php
@@ -632,7 +632,6 @@ final class SettingsPageTest extends TestCase {
 	 * @param string $response The response to mock.
 	 * @param array  $args The arguments passed to the request.
 	 * @param string $url The URL of the request.
-	 *
 	 * @return array<mixed>|false The mocked response.
 	 *
 	 * @phpstan-ignore-next-line
@@ -649,7 +648,6 @@ final class SettingsPageTest extends TestCase {
 	 * @param string $response The response to mock.
 	 * @param array  $args The arguments passed to the request.
 	 * @param string $url The URL of the request.
-	 *
 	 * @return array<mixed>|false The mocked response.
 	 *
 	 * @phpstan-ignore-next-line
@@ -666,7 +664,6 @@ final class SettingsPageTest extends TestCase {
 	 * @param string $result_type The type of result to mock.
 	 * @param array  $args The arguments passed to the request.
 	 * @param string $url The URL of the request.
-	 *
 	 * @return array|false The mocked response.
 	 *
 	 * @phpstan-ignore-next-line

--- a/tests/Integration/content-helper/ContentHelperPostListStatsTest.php
+++ b/tests/Integration/content-helper/ContentHelperPostListStatsTest.php
@@ -69,12 +69,12 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 	 * Asserts the enqueueing status of the feature's assets according to the
 	 * passed filter values.
 	 *
+	 * @since 3.9.0
+	 *
 	 * @param mixed $global_filter_value The value of the global filter.
 	 * @param mixed $feature_filter_value The value of the feature filter.
 	 * @param bool  $expected Whether the assets should be enqueued.
 	 * @param mixed ...$additional_args Any required additional arguments.
-	 *
-	 * @since 3.9.0
 	 */
 	protected function assert_enqueued_status(
 		$global_filter_value,

--- a/tests/Integration/content-helper/ContentHelperPostListStatsTest.php
+++ b/tests/Integration/content-helper/ContentHelperPostListStatsTest.php
@@ -532,7 +532,6 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 	 * @param int    $publish_num_of_posts Number of publish posts that we have to create.
 	 * @param int    $draft_num_of_posts Number of draft posts that we have to create.
 	 * @param string $post_type Type of the post.
-	 *
 	 * @return array<WP_Post>
 	 */
 	private function set_and_get_posts_data(
@@ -551,7 +550,6 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 	 *
 	 * @param array<WP_Post> $posts Available posts.
 	 * @param string         $post_type Type of the post.
-	 *
 	 * @return string
 	 */
 	private function get_content_of_parsely_stats_column( array $posts, string $post_type ): string {
@@ -584,7 +582,6 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 	 * Gets placeholder content of Parse.ly stats column.
 	 *
 	 * @param string $key Stats Key.
-	 *
 	 * @return string
 	 */
 	private function get_parsely_stats_placeholder_content( string $key ): string {
@@ -595,7 +592,6 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 	 * Gets utc_published_times property of given object.
 	 *
 	 * @param Post_List_Stats $obj Instance of Post_List_Stats.
-	 *
 	 * @return array<string>
 	 */
 	private function get_utc_published_times_property( Post_List_Stats $obj ): array {
@@ -772,7 +768,6 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 	 * Mock function is_parsely_stats_column_hidden from class.
 	 *
 	 * @param bool $return_value Value that we have to return from mock function.
-	 *
 	 * @return Post_List_Stats
 	 */
 	private function mock_is_parsely_stats_column_hidden( bool $return_value = false ): Post_List_Stats {
@@ -1243,7 +1238,6 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 	 * @param string                              $post_type Type of the post.
 	 * @param array<Analytics_Post>|WP_Error|null $api_response Mocked response that we return on calling API.
 	 * @param Analytics_Post_API_Params|null      $api_params API Parameters.
-	 *
 	 * @return Parsely_Posts_Stats_Response|null
 	 */
 	private function get_parsely_stats_response(

--- a/tests/trait-tests-reflection.php
+++ b/tests/trait-tests-reflection.php
@@ -18,7 +18,6 @@ trait Tests_Reflection {
 	 *
 	 * @param string       $method_name Name of the method to get.
 	 * @param class-string $class_name  Name of the class the method is in.
-	 *
 	 * @return \ReflectionMethod
 	 * @throws \ReflectionException The method does not exist in the class.
 	 */

--- a/tests/trait-tests-reflection.php
+++ b/tests/trait-tests-reflection.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Parsely\Tests;
 
 use Parsely\Parsely;
+use ReflectionException;
+use ReflectionMethod;
 
 trait Tests_Reflection {
 	/**
@@ -18,8 +20,8 @@ trait Tests_Reflection {
 	 *
 	 * @param string       $method_name Name of the method to get.
 	 * @param class-string $class_name  Name of the class the method is in.
-	 * @return \ReflectionMethod
-	 * @throws \ReflectionException The method does not exist in the class.
+	 * @throws ReflectionException The method does not exist in the class.
+	 * @return ReflectionMethod
 	 */
 	public static function get_method( string $method_name, $class_name = Parsely::class ): \ReflectionMethod {
 		$method = ( new \ReflectionClass( $class_name ) )->getMethod( $method_name );


### PR DESCRIPTION
## Description
This PR attempts to improve our DocBlocks. The source of truth for this effort has been examining the [WordPress PHP Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/).

The docs don't provide examples for certain tags (e.g. `@throws`), so in these cases we're left to our own devices to do what we think is best. Things aren't always coherent either. For example, usually `@since` is separated by blank lines, but this doesn't seem to be the case for [deprecated functions](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#1-2-deprecated-functions) or [class members](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#2-1-class-members).

Summarizing what this PR does:
- Remove empty line between `@return` and `@param`.
- Place some DocBlock tags such as `@access`, `@link`, `@see`, `@since`, `@var`,  in the correct order.
- Move `@throws` tags under `@params` with the reasoning that what a function accepts as params, throws as exceptions and returns in the end as a result are related and can form a section.

## Motivation and context
Attempt to follow WordPress Documentation standards as best as possible.

## How has this been tested?
Existing tests pass.