### PR TITLE
class-analytics-posts-api-proxy.php: Remove unused imports

### DIFF
--- a/src/Endpoints/class-analytics-posts-api-proxy.php
+++ b/src/Endpoints/class-analytics-posts-api-proxy.php
@@ -13,9 +13,6 @@ namespace Parsely\Endpoints;
 use stdClass;
 use WP_REST_Request;
 use WP_Error;
-use Parsely\Parsely;
-
-use function Parsely\Utils\get_date_format;
 
 /**
  * Configures the `/stats/posts` REST API endpoint.


### PR DESCRIPTION
## Description
We had a couple of unused imports in `class-analytics-posts-api-proxy.php` that we're removing with this PR.

## Motivation and context
Clean code.

## How has this been tested?
Existing tests pass.