### PR TITLE
update-version.sh: Update some strings

### DIFF
--- a/bin/update-version.sh
+++ b/bin/update-version.sh
@@ -17,4 +17,4 @@ sed -i '' "s/const PARSELY_VERSION = '.*'/const PARSELY_VERSION = '$1'/" wp-pars
 
 npm install # Update version number in package.lock.json.
 
-git add README.md package.json package-lock.json tests/e2e/utils.ts wp-parsely.php && git commit -m "Update wp-parsely version to $1"
+git add README.md package.json package-lock.json tests/e2e/utils.ts wp-parsely.php && git commit -m "Update wp-parsely version number to $1"

--- a/bin/update-version.sh
+++ b/bin/update-version.sh
@@ -3,8 +3,8 @@
 # Script which updates the wp-parsely version number. It will create a new
 # branch and commit the changes.
 #
-# Usage: Specify the version to update to. For example, to update to 3.7.0:
-#   `bin/update-version.sh 3.7.0)`
+# Usage: Specify the version to update to. For example, to update to 3.12.0:
+#   `bin/update-version.sh 3.12.0`
 # Note: This has only been tested with macOS sed.
 
 git checkout -b update/wp-parsely-version-to-$1


### PR DESCRIPTION
## Description
While using our update version script, I noticed we had a typo (closing parenthesis in example code). I corrected that and updated the version number so it looks more updated. Also updated the commit message generated by the script for more clarity.

## Motivation and context
No typos!

## How has this been tested?
No code changes, existing tests pass.