### PR TITLE
Fix PHPStan errors in integration tests

### DIFF
--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -593,7 +593,15 @@ abstract class TestCase extends WPIntegrationTestCase {
 			throw new RiskyTestError( 'Function assert_style_statuses() has been used without any arguments' );
 		}
 
+		$valid_statuses = array( 'done', 'enqueued', 'queue', 'registered', 'to_do' );
+
 		foreach ( $assert_true as $status ) {
+			if ( ! in_array( $status, $valid_statuses, true ) ) {
+				throw new RiskyTestError(
+					'Invalid status ' . esc_html( $status ) . ' was passed to assert_style_statuses()'
+				);
+			}
+
 			self::assertTrue(
 				wp_style_is( $handle, $status ),
 				"Unexpected style status: $handle status should be '$status'"
@@ -601,6 +609,12 @@ abstract class TestCase extends WPIntegrationTestCase {
 		}
 
 		foreach ( $assert_false as $status ) {
+			if ( ! in_array( $status, $valid_statuses, true ) ) {
+				throw new RiskyTestError(
+					'Invalid status' . esc_html( $status ) . ' was passed to assert_style_statuses()'
+				);
+			}
+
 			self::assertFalse(
 				wp_style_is( $handle, $status ),
 				"Unexpected style status: $handle status should NOT be '$status'"

--- a/tests/Integration/UI/NetworkAdminSitesListTest.php
+++ b/tests/Integration/UI/NetworkAdminSitesListTest.php
@@ -44,6 +44,7 @@ final class NetworkAdminSitesListTest extends TestCase {
 			self::markTestSkipped();
 		}
 
+		/** @var \WP_MS_Sites_List_Table|false $list_table */
 		$list_table = _get_list_table( 'WP_MS_Sites_List_Table', array( 'screen' => 'ms-sites' ) );
 		if ( false !== $list_table ) {
 			$this->table = $list_table;


### PR DESCRIPTION
## Description
This PR fixes a couple of PHPStan errors that have appeared in our integration tests.

## Motivation and context
No PHPStan errors!

## How has this been tested?
PHPStan passes without errors after the changes.