### PR TITLE
Site Health Info: Remove unneeded options

### DIFF
--- a/src/UI/class-site-health.php
+++ b/src/UI/class-site-health.php
@@ -114,6 +114,7 @@ final class Site_Health {
 	 */
 	public function options_debug_info( $args ) {
 		$options = $this->parsely->get_options();
+		unset( $options['api_secret'], $options['metadata_secret'] );
 
 		$args['parsely'] = array(
 			'label'       => __( 'Parse.ly Options', 'wp-parsely' ),


### PR DESCRIPTION
## Description
This PR removes some unneeded options from our Site Health Info screen.

## Motivation and context
Don't display unneeded information.

## How has this been tested?
Existing tests pass.