### PR TITLE
Update Content Suggestions API base URL

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -63,7 +63,7 @@ class Parsely {
 	public const CAPABILITY                      = 'manage_options'; // The capability required to administer settings.
 	public const DASHBOARD_BASE_URL              = 'https://dash.parsely.com';
 	public const PUBLIC_API_BASE_URL             = 'https://api.parsely.com/v2';
-	public const PUBLIC_SUGGESTIONS_API_BASE_URL = 'https://suggestion-api.parsely.com';
+	public const PUBLIC_SUGGESTIONS_API_BASE_URL = 'https://content-suggestions-beta.parsely-recspod.net';
 
 	/**
 	 * Declare some class properties


### PR DESCRIPTION
## Description
After internal discussion, we've decided to update the Content Suggestions base URL. This URL is considered temporary and will be updated in the future.

## Motivation and context
Update the Content Suggestions base URL to a location that gets updated more easily and regularly.

## How has this been tested?
Manually tested that the new URL returns results in the Title Suggestions feature.