### PR TITLE
Initialize Parse.ly options with default values

### DIFF
--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -211,7 +211,8 @@ final class Settings_Page {
 	public function initialize_settings(): void {
 		// Add the option first, to prevent double sanitization of the uninitialized option as reported
 		// in https://core.trac.wordpress.org/ticket/21989.
-		add_option( Parsely::OPTIONS_KEY, array() );
+		// The option will be initialized with the default values.
+		add_option( Parsely::OPTIONS_KEY, $this->parsely->get_options() );
 
 		// All our options are actually stored in one single array to reduce DB queries.
 		register_setting(


### PR DESCRIPTION
## Description
This PR addresses an issue where the Parse.ly options were not being initialized with the default values. Previously, an empty array was being used to initialize the options, which prevented the default settings from being saved. 

The change involves calling `get_options()` method from the `Parsely` class, which returns the default options. These default options are then used to initialize the Parse.ly options using `add_option()`. 

This ensures that the Parse.ly options are correctly set up with the default values upon activation of the plugin.

## Motivation and context

In a [previous PR](https://github.com/Parsely/wp-parsely/pull/2001), we introduced an `add_option` call during the settings initialization process. However, we discovered a bug where default settings were not being applied on new installations. This issue could potentially disrupt the user experience by not providing expected default configurations. This PR addresses and resolves this issue, ensuring that default settings are correctly applied during new installations.


## How has this been tested?
This change has been tested by running the application and verifying that the default settings are correctly saved when the plugin is activated. A new fresh environment was spinned up using [`wp-now`](https://developer.wordpress.com/2023/05/23/wp-now-launch-a-local-environment-in-seconds/), each time I was testing it. 

## Screenshots (if appropriate)
N/A