### PR TITLE
Update version number and changelog for 3.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.0](https://github.com/Parsely/wp-parsely/compare/3.11.1...3.12.0) - 2023-12-05
+
+### Added
+
+- Add Content Helper events to wp-admin telemetry ([#2020](https://github.com/Parsely/wp-parsely/pull/2020))
+- Content Helper Sidebar: Add Title Suggestions feature ([#1967](https://github.com/Parsely/wp-parsely/pull/1967))
+- Add wp-admin telemetry (optional and off by default) ([#1758](https://github.com/Parsely/wp-parsely/pull/1758))
+
+### Changed
+
+- Site Health Info: Remove unneeded options ([#2031](https://github.com/Parsely/wp-parsely/pull/2031))
+
+### Fixed
+
+- Initialize Parse.ly options with default values ([#2052](https://github.com/Parsely/wp-parsely/pull/2052))
+
+### Dependency Updates
+
+- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.12.0+label%3A%22Component%3A+Dependencies%22).
+
 ## [3.11.1](https://github.com/Parsely/wp-parsely/compare/3.11.0...3.11.1) - 2023-11-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.11.1  
+Stable tag: 3.12.0  
 Requires at least: 5.2  
 Tested up to: 6.4  
 Requires PHP: 7.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.11.1",
+	"version": "3.12.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.11.1",
+			"version": "3.12.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.11.1",
+	"version": "3.12.0",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, pauarge",

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.11.1';
+export const PLUGIN_VERSION = '3.12.0';
 export const VALID_API_SECRET = 'valid_api_secret';
 
 export const waitForWpAdmin = () => page.waitForSelector( 'body.wp-admin' );

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.11.1
+ * Version:           3.12.0
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -62,7 +62,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.11.1';
+const PARSELY_VERSION = '3.12.0';
 const PARSELY_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
This PR updates the plugin's version number and changelog in preparation for the 3.12.0 release.

## Added

- Add Content Helper events to wp-admin telemetry ([#2020](https://github.com/Parsely/wp-parsely/pull/2020))
- Content Helper Sidebar: Add Title Suggestions feature ([#1967](https://github.com/Parsely/wp-parsely/pull/1967))
- Add wp-admin telemetry (optional and off by default) ([#1758](https://github.com/Parsely/wp-parsely/pull/1758))

### Changed

- Site Health Info: Remove unneeded options ([#2031](https://github.com/Parsely/wp-parsely/pull/2031))

## Fixed

- Initialize Parse.ly options with default values ([#2052](https://github.com/Parsely/wp-parsely/pull/2052))

## Dependency Updates

- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.12.0+label%3A%22Component%3A+Dependencies%22).