### PR TITLE
VSCode Workspace Settings: Update deprecated value

### DIFF
--- a/.vscode/wp-parsely.code-workspace
+++ b/.vscode/wp-parsely.code-workspace
@@ -56,7 +56,7 @@
 		],
 		"[javascript][typescript][javascriptreact][typescriptreact]": {
 			"editor.codeActionsOnSave": {
-				"source.organizeImports": true,
+				"source.organizeImports": "explicit"
 			},
 			"editor.defaultFormatter": "dbaeumer.vscode-eslint",
 		},


### PR DESCRIPTION
## Description
VSCode is deprecating the `true` value of its `source.organizeImports` setting in favor of the `"explicit"` value. This setting is responsible for auto-sorting imports on save, which is enabled for our TypeScript files.

## Motivation and context
Keep our code updated.

## How has this been tested?
Verified that the setting still works under VSCode.