### PR TITLE
.phpcs.xml.dist: Fix erroneous rule property name

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -73,7 +73,7 @@
 	<rule ref="WordPress.Files.FileName">
 		<exclude-pattern>tests/</exclude-pattern>
 		<properties>
-			<property name="custom_test_class_whitelist" type="array">
+			<property name="custom_test_classes" type="array">
 				<element value="TestCase"/>
 			</property>
 		</properties>


### PR DESCRIPTION
## Description
Certain of our tests started failing today. When running `composer cs`, we would get the following error:

> ERROR: Ruleset invalid. Property "custom_test_class_whitelist" does not exist on sniff WordPress.Files.FileName

It turns out that WPCS 3.0 moved the `custom_test_class_whitelist` whitelist from the Sniff class to [this IsUnitTestTrait trait](https://github.com/WordPress/WordPress-Coding-Standards/blob/0aa6cf750b4bfd6a3bc9fc47d7a219a5081a5d54/WordPress/Helpers/IsUnitTestTrait.php#L62). That trait is [used in a few different sniff classes](https://github.com/search?q=repo%3AWordPress%2FWordPress-Coding-Standards+IsUnitTestTrait+language%3APHP&type=code&l=PHP), but the important change, is that the property in the trait also got [renamed](https://github.com/WordPress/WordPress-Coding-Standards/blob/0aa6cf750b4bfd6a3bc9fc47d7a219a5081a5d54/CHANGELOG.md?plain=1#L152) to `custom_test_classes`.

This meant that we just had to update the property name in our `.phpcs.xml.dist` file. Thanks to @GaryJones for pointing this out to us, which made the fix very easy!

## Motivation and context
Make our tests pass.

## How has this been tested?
The failing tests are now passing.