### PR TITLE
Increase PHPStan param_type coverage to 80

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,7 +14,7 @@ parameters:
     - vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php
   type_coverage:
       return_type: 91
-      param_type: 74
+      param_type: 80
       property_type: 0 # We can't use property types until PHP 7.4 becomes the plugin's minimum version.
       print_suggestions: false
   typeAliases:

--- a/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/AnalyticsPostsProxyEndpointTest.php
@@ -226,7 +226,7 @@ final class AnalyticsPostsProxyEndpointTest extends ProxyEndpointTest {
 
 		add_filter(
 			'pre_http_request',
-			function () use ( &$dispatched ) {
+			function () use ( &$dispatched ): array {
 				$dispatched++;
 				return array(
 					'body' => '{"data":[

--- a/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/ReferrersPostDetailProxyEndpointTest.php
@@ -193,7 +193,7 @@ final class ReferrersPostDetailProxyEndpointTest extends ProxyEndpointTest {
 
 		add_filter(
 			'pre_http_request',
-			function () use ( &$dispatched ) {
+			function () use ( &$dispatched ): array {
 				$dispatched++;
 				return array(
 					'body' => '{"data":[

--- a/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/RelatedProxyEndpointTest.php
@@ -113,7 +113,7 @@ final class RelatedProxyEndpointTest extends ProxyEndpointTest {
 
 		add_filter(
 			'pre_http_request',
-			function () use ( &$dispatched ) {
+			function () use ( &$dispatched ): array {
 				$dispatched++;
 				return array(
 					'body' => '{"data":[

--- a/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
+++ b/tests/Integration/Endpoints/StatsPostDetailProxyEndpointTest.php
@@ -193,7 +193,7 @@ final class StatsPostDetailProxyEndpointTest extends ProxyEndpointTest {
 
 		add_filter(
 			'pre_http_request',
-			function () use ( &$dispatched ) {
+			function () use ( &$dispatched ): array {
 				$dispatched++;
 				return array(
 					'body' => '

--- a/tests/Integration/ProxyEndpointTest.php
+++ b/tests/Integration/ProxyEndpointTest.php
@@ -141,7 +141,9 @@ abstract class ProxyEndpointTest extends TestCase {
 	 *
 	 * @param WP_REST_Request|null $request The request object to be used.
 	 */
-	public function run_test_get_items_fails_without_site_id_set( $request = null ): void {
+	public function run_test_get_items_fails_without_site_id_set(
+		?WP_REST_Request $request = null
+	): void {
 		$this->run_test_get_items_fails(
 			array( 'apikey' => '' ),
 			'parsely_site_id_not_set',
@@ -156,7 +158,9 @@ abstract class ProxyEndpointTest extends TestCase {
 	 *
 	 * @param WP_REST_Request|null $request The request object to be used.
 	 */
-	public function run_test_get_items_fails_without_api_secret_set( $request = null ): void {
+	public function run_test_get_items_fails_without_api_secret_set(
+		?WP_REST_Request $request = null
+	): void {
 		$this->run_test_get_items_fails(
 			array(
 				'apikey'     => 'example.com',
@@ -181,21 +185,12 @@ abstract class ProxyEndpointTest extends TestCase {
 		array $options,
 		string $expected_error_code,
 		string $expected_error_message,
-		$request = null
+		?WP_REST_Request $request = null
 	): void {
 		TestCase::set_options( $options );
 		if ( null === $request ) {
 			$request = new WP_REST_Request( 'GET', self::$route );
 		}
-
-		$dispatched = 0;
-		add_filter(
-			'pre_http_request',
-			function () use ( &$dispatched ) {
-				$dispatched++;
-				return null;
-			}
-		);
 
 		$response = rest_get_server()->dispatch( $request );
 		/**


### PR DESCRIPTION
## Description
After a `composer update`, PHPStan gave me an error. Investigating, I found that the error was located in unneeded code, which I removed. While at it, I also increased our `param_type` coverage to 80.

## Motivation and context
Increasing our code coverage and removing unneeded code is always good.

## How has this been tested?
Tests continue to pass.