### PR TITLE
Fix failing E2E test

### DIFF
--- a/tests/e2e/specs/content-helper/related-top-posts-panel-filters.spec.ts
+++ b/tests/e2e/specs/content-helper/related-top-posts-panel-filters.spec.ts
@@ -54,6 +54,6 @@ describe( 'PCH Editor Sidebar Related Top Post panel filters', () => {
 		const categoryName = 'Parse.ly Tips';
 
 		expect( await getTopRelatedPostsMessage( categoryName, '', 'section', 2000, messageSelector ) )
-			.toMatch( `Top posts in section "${ categoryName }" in the last 7 days.` );
+			.toMatch( `Top posts in section "${ categoryName }" in the last 30 days.` );
 	} );
 } );

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -145,6 +145,13 @@ export const getTopRelatedPostsMessage = async (
 	// Show the panel and get the displayed message.
 	await page.waitForSelector( pluginButton );
 	await page.click( pluginButton );
+
+	// Select 30 days to reduce the possibility of a "No top posts" message.
+	const settingsButton = await findSidebarPanelToggleButtonWithTitle( 'Settings' );
+	await settingsButton.focus();
+	await page.keyboard.press( 'Tab' );
+	await page.keyboard.type( 'l' );
+
 	const topRelatedPostsButton = await findSidebarPanelToggleButtonWithTitle( 'Related Top Posts' );
 	await topRelatedPostsButton.click();
 	if ( '' !== filterType ) {


### PR DESCRIPTION
## Description
The reduction of web traffic during the holidays was resulting in an error in one of our E2E tests. Instead of the last 7 days of traffic, we are now examining the last 30 days of traffic to mitigate this.

## Motivation and context
No failing tests, no broken workflows.

## How has this been tested?
The affected test now passes.