### PR TITLE
Fix follow-redirects dependency security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14786,9 +14786,9 @@
 			"dev": true
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+			"version": "1.15.4",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+			"integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
 			"dev": true,
 			"funding": [
 				{
@@ -39301,9 +39301,9 @@
 			"dev": true
 		},
 		"follow-redirects": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+			"version": "1.15.4",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+			"integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
 			"dev": true
 		},
 		"for-each": {


### PR DESCRIPTION
## Description
`npm` reported a high severity vulnerability, which is fixed in this PR.

```
❯ npm audit
# npm audit report

follow-redirects  <1.15.4
Severity: high
Follow Redirects improperly handles URLs in the url.parse() function - https://github.com/advisories/GHSA-jchw-25xp-jwwc
fix available via `npm audit fix`
node_modules/follow-redirects

1 high severity vulnerability

To address all issues, run:
  npm audit fix
```

## Motivation and context
No vulnerabilities please!

## How has this been tested?
`npm` finds no vulnerabilities after the fix.