### PR TITLE
Update rector level set list to PHP 7.2

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -31,7 +31,7 @@ return static function ( RectorConfig $rector_config ): void {
 	// Define sets of rules.
 	$rector_config->sets(
 		array(
-			LevelSetList::UP_TO_PHP_71,
+			LevelSetList::UP_TO_PHP_72,
 		)
 	);
 	$rector_config->skip(


### PR DESCRIPTION
## Description
This PR updates our rector `LeveSetList` to PHP 7.2.

## Motivation and context
Tagging #1401 and #1431 as relevant work, so we can refer to all these when we do our next PHP upgrade.

## How has this been tested?
Issuing a `vendor/bin/rector process --dry-run` command works.