### PR TITLE
Fix PHPStan error in utils.php

### DIFF
--- a/src/Utils/utils.php
+++ b/src/Utils/utils.php
@@ -357,5 +357,5 @@ function str_starts_with( string $haystack, string $needle ): bool {
 	if ( function_exists( '\str_starts_with' ) ) {
 		return \str_starts_with( $haystack, $needle );
 	}
-	return 0 === strpos( (string) $haystack, (string) $needle );
+	return 0 === strpos( $haystack, $needle );
 }


### PR DESCRIPTION
## Description
This PR introduces a fix for our pre-commit hooks that would fail with the following PHPStan error:

```
 ------ ---------------------------------------------------- 
  Line   src/Utils/utils.php                                 
 ------ ---------------------------------------------------- 
  360    Casting to string something that's already string.  
  360    Casting to string something that's already string.  
 ------ ---------------------------------------------------- 
```

## Motivation and context
Avoid our workflows from breaking.

## How has this been tested?
No testing, code does not change essentially.