### PR TITLE
Fix failing E2E test

### DIFF
--- a/tests/e2e/specs/content-helper/related-top-posts-panel-filters.spec.ts
+++ b/tests/e2e/specs/content-helper/related-top-posts-panel-filters.spec.ts
@@ -27,7 +27,7 @@ describe( 'PCH Editor Sidebar Related Top Post panel filters', () => {
 	 */
 	beforeAll( async () => {
 		enablePageDialogAccept();
-		await setSiteKeys( 'blog.parsely.com', VALID_API_SECRET );
+		await setSiteKeys( 'demoaccount.parsely.com', VALID_API_SECRET );
 	} );
 
 	/**
@@ -51,7 +51,7 @@ describe( 'PCH Editor Sidebar Related Top Post panel filters', () => {
 	 * into the database and then picked up by the Related Top Posts panel.
 	 */
 	it( 'Should work correctly when a taxonomy is added from within the WordPress Post Editor', async () => {
-		const categoryName = 'Parse.ly Tips';
+		const categoryName = 'Analytics That Matter';
 
 		expect( await getTopRelatedPostsMessage( categoryName, '', 'section', 2000, messageSelector ) )
 			.toMatch( `Top posts in section "${ categoryName }" in the last 30 days.` );


### PR DESCRIPTION
## Description
This PR fixes the failing E2E test issue that is described in #2140.

## Motivation and context
Stop our workflow from breaking.

## How has this been tested?
The test that was failing now passes.