### PR TITLE
PCH Excerpt Generator: Fix wrong initialization of the module

### DIFF
--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -266,7 +266,7 @@ function init_content_helper_editor_sidebar(): void {
 
 require_once __DIR__ . '/src/content-helper/excerpt-generator/class-excerpt-generator.php';
 
-add_action( 'init', __NAMESPACE__ . '\\init_content_helper_excerpt_generator' );
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\init_content_helper_excerpt_generator' );
 /**
  * Initializes and inserts the PCH Excerpt Generator.
  *

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -266,7 +266,8 @@ function init_content_helper_editor_sidebar(): void {
 
 require_once __DIR__ . '/src/content-helper/excerpt-generator/class-excerpt-generator.php';
 
-add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\init_content_helper_excerpt_generator' );
+// The priority of 9 is used to ensure that the Excerpt Generator is loaded before the PCH Editor Sidebar (10).
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\init_content_helper_excerpt_generator', 9 );
 /**
  * Initializes and inserts the PCH Excerpt Generator.
  *


### PR DESCRIPTION
## Description
The Excerpt Generator feature is currently being initialized in the `init` hook. Since the script only needs to be present on the block editor, using this specific hook is not desirable, since it will load the script everywhere in the site, including the front-end. 

This PR changes the initialisation of the Excerpt Generator feature to the `enqueue_block_editor_assets` hook, and sets it with a priority of 9, to load before the PCH Editor Sidebar. This is required as loading after the sidebar does not work properly. 

## Motivation and context
Make sure that the Excerpt Generator script is only loaded when it is actually needed.

## How has this been tested?
Tested locally on my WordPress environment, and validated that the script is only being loaded in the block editor context, and that it is functioning as before.