### PR TITLE
Include more metadata in content tracked as a Non-Post

### DIFF
--- a/src/Metadata/class-metadata-builder.php
+++ b/src/Metadata/class-metadata-builder.php
@@ -11,6 +11,10 @@ declare(strict_types=1);
 namespace Parsely\Metadata;
 
 use Parsely\Parsely;
+use WP_Post;
+use WP_User;
+
+use function Parsely\Utils\get_default_category;
 
 /**
  * Abstract class that implements modular builders for Metadata.
@@ -20,6 +24,8 @@ use Parsely\Parsely;
  *
  * @since 1.0.0
  * @since 3.3.0 Logic extracted from Parsely\Parsely class to separate file/class.
+ *
+ * @phpstan-import-type Parsely_Options from Parsely
  */
 abstract class Metadata_Builder {
 	/**
@@ -66,12 +72,150 @@ abstract class Metadata_Builder {
 	}
 
 	/**
-	 * Populates the `url` field in the metadata object by getting the current page's URL.
+	 * Populates the url field in the metadata object.
 	 *
 	 * @since 3.4.0
 	 */
 	protected function build_url(): void {
 		$this->metadata['url'] = $this->get_current_url();
+	}
+
+	/**
+	 * Populates the author and creator fields in the metadata object.
+	 *
+	 * @since 3.4.0
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 *
+	 * @param WP_Post $post The post/page for which to populate the fields.
+	 */
+	protected function build_author( WP_Post $post ): void {
+		$authors        = $this->get_author_names( $post );
+		$author_objects = array();
+		foreach ( $authors as $author ) {
+			$author_tag       = array(
+				'@type' => 'Person',
+				'name'  => $author,
+			);
+			$author_objects[] = $author_tag;
+		}
+		$this->metadata['author']  = $author_objects;
+		$this->metadata['creator'] = $authors;
+	}
+
+	/**
+	 * Populates all the fields related to time in the metadata object.
+	 *
+	 * @param WP_Post $post The post/page for which to populate the field.
+	 *
+	 * @since 3.0.2
+	 * @since 3.3.0 Moved to class-metadata.
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 */
+	protected function build_metadata_post_times( WP_Post $post ): void {
+		$date_format      = 'Y-m-d\TH:i:s\Z';
+		$post_created_gmt = get_post_time( $date_format, true, $post );
+
+		if ( false === $post_created_gmt ) {
+			return;
+		}
+
+		$this->metadata['dateCreated']   = $post_created_gmt;
+		$this->metadata['datePublished'] = $post_created_gmt;
+		$this->metadata['dateModified']  = $post_created_gmt;
+
+		$post_modified_gmt = get_post_modified_time( $date_format, true, $post );
+
+		if ( false !== $post_modified_gmt && $post_modified_gmt > $post_created_gmt ) {
+			$this->metadata['dateModified'] = $post_modified_gmt;
+		}
+	}
+
+	/**
+	 * Populates the articleSection field in the metadata object.
+	 *
+	 * @since 3.4.0
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 *
+	 * @param WP_Post $post The post/page for which to populate the field.
+	 */
+	protected function build_article_section( WP_Post $post ): void {
+		$this->metadata['articleSection'] = $this->get_category_name( $post, $this->parsely->get_options() );
+	}
+
+	/**
+	 * Populates the keywords field in the metadata object.
+	 *
+	 * @since 3.4.0
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 *
+	 * @param WP_Post $post The post/page for which to populate the field.
+	 */
+	protected function build_keywords( WP_Post $post ): void {
+		$options = $this->parsely->get_options();
+		$tags    = $this->get_tags( $post->ID );
+		if ( $options['cats_as_tags'] ) {
+			$tags = array_merge( $tags, $this->get_categories( $post->ID ) );
+			// add custom taxonomy values.
+			$tags = array_merge( $tags, $this->get_custom_taxonomy_values( $post ) );
+		}
+		// The function 'mb_strtolower' is not enabled by default in php, so this check
+		// falls back to the native php function 'strtolower' if necessary.
+		if ( function_exists( 'mb_strtolower' ) ) {
+			$lowercase_callback = 'mb_strtolower';
+		} else {
+			$lowercase_callback = 'strtolower';
+		}
+		if ( $options['lowercase_tags'] ) {
+			$tags = array_map( $lowercase_callback, $tags );
+		}
+
+		/**
+		 * Filters the post tags that are used as metadata keywords.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param array<string> $tags Post tags.
+		 * @param int $ID Post ID.
+		 */
+		$tags = apply_filters( 'wp_parsely_post_tags', $tags, $post->ID );
+		$tags = array_map( array( $this, 'clean_value' ), $tags );
+
+		$this->metadata['keywords'] = array_values( array_unique( $tags ) );
+	}
+
+	/**
+	 * Populates the thumbnailUrl field in the metadata object.
+	 *
+	 * @param WP_Post $post The post/page for which to populate the field.
+	 *
+	 * @since 3.4.0
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 */
+	protected function build_thumbnail_url( WP_Post $post ): void {
+		$thumb_url = get_the_post_thumbnail_url( $post, 'thumbnail' );
+		if ( ! is_string( $thumb_url ) ) {
+			$thumb_url = '';
+		}
+		$this->metadata['thumbnailUrl'] = $thumb_url;
+	}
+
+	/**
+	 * Populates the image field in the metadata object.
+	 *
+	 * @param WP_Post $post The post/page for which to populate the field.
+	 *
+	 * @since 3.4.0
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 */
+	protected function build_image( WP_Post $post ): void {
+		$image_url = get_the_post_thumbnail_url( $post, 'full' );
+		if ( ! is_string( $image_url ) ) {
+			$image_url = '';
+		}
+		$this->metadata['image'] = array(
+			'@type' => 'ImageObject',
+			'url'   => $image_url,
+		);
 	}
 
 	/**
@@ -133,5 +277,345 @@ abstract class Metadata_Builder {
 		return $options['force_https_canonicals']
 			? str_replace( 'http://', 'https://', $url )
 			: str_replace( 'https://', 'http://', $url );
+	}
+
+	/**
+	 * Returns a properly cleaned category/taxonomy value and will optionally
+	 * use the top-level category/taxonomy value, if so instructed via the
+	 * use_top_level_cats option.
+	 *
+	 * @since 3.3.0 Moved to class-metadata.
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 *
+	 * @param WP_Post         $post_obj The object for the post.
+	 * @param Parsely_Options $parsely_options The parsely options.
+	 * @return string Cleaned category name for the post in question.
+	 */
+	private function get_category_name( WP_Post $post_obj, $parsely_options ): string {
+		$taxonomy_dropdown_choice = get_the_terms( $post_obj->ID, $parsely_options['custom_taxonomy_section'] );
+		// Get top-level taxonomy name for chosen taxonomy and assign to $parent_name; it will be used
+		// as the category value if 'use_top_level_cats' option is checked.
+		// Assign as the default category name if no value is checked for the chosen taxonomy.
+		$category_name = get_cat_name( get_default_category() );
+		if ( false !== $taxonomy_dropdown_choice && ! is_wp_error( $taxonomy_dropdown_choice ) ) {
+			if ( $parsely_options['use_top_level_cats'] ) {
+				$first_term = array_shift( $taxonomy_dropdown_choice );
+				if ( null !== $first_term ) {
+					$term_name = $this->get_top_level_term( $first_term->term_id, $first_term->taxonomy );
+				}
+			} else {
+				$term_name = $this->get_bottom_level_term( $post_obj->ID, $parsely_options['custom_taxonomy_section'] );
+			}
+
+			if ( isset( $term_name ) && is_string( $term_name ) && 0 < strlen( $term_name ) ) {
+				$category_name = $term_name;
+			}
+		}
+
+		/**
+		 * Filters the constructed category name.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param string  $category    Category name.
+		 * @param WP_Post $post_obj    Post object.
+		 * @param array<string, mixed> $parsely_options The Parsely options.
+		 */
+		$category_name = apply_filters( 'wp_parsely_post_category', $category_name, $post_obj, $parsely_options );
+
+		return $this->clean_value( $category_name );
+	}
+
+	/**
+	 * Returns the top-most category/taxonomy value in a hierarchy given a
+	 * taxonomy value's ID.
+	 *
+	 * (WordPress calls taxonomy values 'terms').
+	 *
+	 * @since 3.3.0 Moved to class-metadata.
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 *
+	 * @param int    $term_id       The ID of the top level term.
+	 * @param string $taxonomy_name The name of the taxonomy.
+	 * @return string|false $parent The top level name of the category/taxonomy.
+	 */
+	private function get_top_level_term( int $term_id, string $taxonomy_name ) {
+		$parent = get_term_by( 'id', $term_id, $taxonomy_name );
+
+		while ( false !== $parent && isset( $parent->parent ) && 0 !== $parent->parent ) {
+			$parent = get_term_by( 'id', $parent->parent, $taxonomy_name );
+		}
+
+		return $parent->name ?? false;
+	}
+
+	/**
+	 * Returns the bottom-most category/taxonomy value in a hierarchy given a
+	 * post ID.
+	 *
+	 * (WordPress calls taxonomy values 'terms').
+	 *
+	 * @since 3.3.0 Moved to class-metadata.
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 *
+	 * @param int    $post_id       The post id you're interested in.
+	 * @param string $taxonomy_name The name of the taxonomy.
+	 * @return string Name of the custom taxonomy.
+	 */
+	private function get_bottom_level_term( int $post_id, string $taxonomy_name ): string {
+		$terms = get_the_terms( $post_id, $taxonomy_name );
+
+		if ( ! is_array( $terms ) ) {
+			return '';
+		}
+
+		$term_ids = wp_list_pluck( $terms, 'term_id' );
+		$parents  = array_filter( wp_list_pluck( $terms, 'parent' ) );
+
+		// Get array of IDs of terms which are not parents.
+		$term_ids_not_parents = array_diff( $term_ids, $parents );
+		// Get corresponding term objects, which are mapped to array index keys.
+		$terms_not_parents = array_intersect_key( $terms, $term_ids_not_parents );
+		// remove array index keys.
+		$terms_not_parents_cleaned = array_values( $terms_not_parents );
+
+		if ( isset( $terms_not_parents_cleaned[0] ) ) {
+			// If you assign multiple child terms in a custom taxonomy, will only return the first.
+			return $terms_not_parents_cleaned[0]->name;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Retrieves all the authors for a post as an array. Can include multiple
+	 * authors if the Co-Authors Plus plugin is in use.
+	 *
+	 * @since 3.3.0 Moved to class-metadata.
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 *
+	 * @param WP_Post $post The post object.
+	 * @return array<string>
+	 */
+	private function get_author_names( WP_Post $post ): array {
+		$authors = $this->get_coauthor_names( $post->ID );
+		if ( 0 === count( $authors ) ) {
+			$post_author = get_user_by( 'id', $post->post_author );
+			if ( false !== $post_author ) {
+				$authors = array( $post_author );
+			}
+		}
+
+		/**
+		 * Filters the list of author WP_User objects for a post.
+		 *
+		 * @since 1.14.0
+		 *
+		 * @param array<WP_User> $authors One or more authors as WP_User objects.
+		 * @param WP_Post        $post    Post object.
+		 */
+		$authors = apply_filters( 'wp_parsely_pre_authors', $authors, $post );
+
+		// Getting the author name for each author.
+		$authors = array_map( array( $this, 'get_author_name' ), $authors );
+
+		/**
+		 * Filters the list of author names for a post.
+		 *
+		 * @since 1.14.0
+		 *
+		 * @param array<string> $authors One or more author names.
+		 * @param WP_Post       $post    Post object.
+		 */
+		$authors = apply_filters( 'wp_parsely_post_authors', $authors, $post );
+
+		return array_map( array( $this, 'clean_value' ), $authors );
+	}
+
+	/**
+	 * Returns a list of coauthors for a post assuming the Co-Authors Plus plugin
+	 * is installed.
+	 *
+	 * Borrowed from
+	 * https://github.com/Automattic/Co-Authors-Plus/blob/master/template-tags.php#L3-35
+	 *
+	 * @since 3.3.0 Moved to class-metadata.
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 *
+	 * @param int $post_id The ID of the post.
+	 * @return array<WP_User> List of coauthors, or an empty array if the Co-Authors Plus plugin is not active.
+	 */
+	private function get_coauthor_names( int $post_id ): array {
+		$coauthors = array();
+		if ( class_exists( 'coauthors_plus' ) ) {
+			global $post, $post_ID, $coauthors_plus;
+
+			if ( $post_id <= 0 && $post_ID ) {
+				$post_id = $post_ID;
+			}
+
+			if ( ! $post_id && $post ) {
+				$post_id = $post->ID;
+			}
+
+			if ( $post_id ) {
+				$coauthor_terms = get_the_terms( $post_id, $coauthors_plus->coauthor_taxonomy );
+
+				if ( is_array( $coauthor_terms ) ) {
+					foreach ( $coauthor_terms as $coauthor ) {
+						$coauthor_slug = preg_replace( '#^cap-#', '', $coauthor->slug );
+						$post_author   = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_slug );
+						// In case the user has been deleted while plugin was deactivated.
+						if ( false !== $post_author ) {
+							$coauthors[] = new WP_User( $post_author );
+						}
+					}
+				} elseif ( ! $coauthors_plus->force_guest_authors ) {
+					if ( $post && $post_id === $post->ID ) {
+						$post_author = get_userdata( $post->post_author );
+					}
+					if ( isset( $post_author ) && false !== $post_author ) {
+						$coauthors[] = $post_author;
+					}
+				}
+				// The empty else case is because if we force guest authors, we don't ever care what value wp_posts.post_author has.
+			}
+		}
+		return $coauthors;
+	}
+
+	/**
+	 * Determines author name from display name, falling back to firstname
+	 * lastname, then nickname and finally the nicename.
+	 *
+	 * @since 3.3.0 Moved to class-metadata.
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 *
+	 * @param ?WP_User $author The author of the post.
+	 * @return string An author name.
+	 */
+	private function get_author_name( ?WP_User $author ): string {
+		// Gracefully handle situation where no author is available.
+		if ( null === $author ) {
+			return '';
+		}
+
+		if ( '' !== $author->display_name ) {
+			return $author->display_name;
+		}
+
+		$author_name = $author->user_firstname . ' ' . $author->user_lastname;
+		if ( ' ' !== $author_name ) {
+			return $author_name;
+		}
+
+		if ( '' !== $author->nickname ) {
+			return $author->nickname;
+		}
+
+		if ( '' !== $author->user_nicename ) {
+			return $author->user_nicename;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Returns the tags associated with this page or post.
+	 *
+	 * @since 3.3.0 Moved to class-metadata.
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 *
+	 * @param int $post_id   The ID of the post you're trying to get tags for.
+	 * @return array<string> The tags of the post represented by the post id.
+	 */
+	private function get_tags( int $post_id ): array {
+		/**
+		 * Variable.
+		 *
+		 * @var array<\WP_Term|null>|\WP_Error
+		 */
+		$post_tags = wp_get_post_tags( $post_id );
+		$tags      = array();
+
+		if ( ! is_wp_error( $post_tags ) ) {
+			foreach ( $post_tags as $wp_tag ) {
+				if ( null !== $wp_tag ) {
+					$tags[] = $wp_tag->name;
+				}
+			}
+		}
+
+		return $tags;
+	}
+
+	/**
+	 * Returns an array of all the child categories for the current post.
+	 *
+	 * @since 3.3.0 Moved to class-metadata.
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 *
+	 * @param int    $post_id   The ID of the post you're trying to get categories for.
+	 * @param string $delimiter What character will delimit the categories.
+	 * @return array<string> All the child categories of the current post.
+	 */
+	private function get_categories( int $post_id, string $delimiter = '/' ): array {
+		$tags = array();
+		foreach ( get_the_category( $post_id ) as $category ) {
+			$hierarchy = get_category_parents( $category->term_id, false, $delimiter );
+			if ( ! is_wp_error( $hierarchy ) ) {
+				$tags[] = rtrim( $hierarchy, '/' );
+			}
+		}
+		// Take last element in the hierarchy, a string representing the full
+		// parent->child tree, and split it into individual category names.
+		$last_tag = end( $tags );
+		if ( false !== $last_tag ) {
+			$tags = explode( '/', $last_tag );
+		}
+
+		// Remove default category name from tags if needed.
+		$default_category_name = get_cat_name( get_default_category() );
+		return array_diff( $tags, array( $default_category_name ) );
+	}
+
+	/**
+	 * Gets all term names from all custom taxonomies assigned to a post.
+	 *
+	 * @since 3.3.0 Moved to class-metadata.
+	 * @since 3.4.0 Moved to class-post-builder.
+	 * @since 3.14.0 Moved from `Post_Builder` to `Metadata_Builder`.
+	 *
+	 * @param WP_Post $post_obj The post object to find the terms for.
+	 * @return array<string> Term names.
+	 */
+	private function get_custom_taxonomy_values( WP_Post $post_obj ): array {
+		// Filter out default WordPress taxonomies.
+		$all_taxonomies = array_diff(
+			get_taxonomies(),
+			array( 'post_tag', 'nav_menu', 'author', 'link_category', 'post_format' )
+		);
+
+		/**
+		 * Filters the taxonomies.
+		 *
+		 * @since 3.11.0
+		 *
+		 * @param array<string> $all_taxonomies Taxonomies.
+		 * @param WP_Post $post_obj    Post object.
+		 */
+		$all_taxonomies = apply_filters( 'wp_parsely_custom_taxonomies', $all_taxonomies, $post_obj );
+		$all_values     = array();
+
+		foreach ( $all_taxonomies as $taxonomy ) {
+			$custom_taxonomy_objects = get_the_terms( $post_obj->ID, $taxonomy );
+			if ( is_array( $custom_taxonomy_objects ) ) {
+				foreach ( $custom_taxonomy_objects as $custom_taxonomy_object ) {
+					$all_values[] = $custom_taxonomy_object->name;
+				}
+			}
+		}
+
+		return $all_values;
 	}
 }

--- a/src/Metadata/class-page-builder.php
+++ b/src/Metadata/class-page-builder.php
@@ -51,11 +51,18 @@ class Page_Builder extends Metadata_Builder {
 		$this->build_headline();
 		$this->build_url();
 
+		$this->build_thumbnail_url( $this->post );
+		$this->build_image( $this->post );
+		$this->build_article_section( $this->post );
+		$this->build_author( $this->post );
+		$this->build_keywords( $this->post );
+		$this->build_metadata_post_times( $this->post );
+
 		return $this->metadata;
 	}
 
 	/**
-	 * Populates the `headline` field in the metadata object.
+	 * Populates the headline field in the metadata object.
 	 *
 	 * @since 3.4.0
 	 */
@@ -64,7 +71,7 @@ class Page_Builder extends Metadata_Builder {
 	}
 
 	/**
-	 * Populates the `url` field in the metadata object by getting the current page's URL.
+	 * Populates the url field in the metadata object by getting the current page's URL.
 	 *
 	 * @since 3.4.0
 	 */

--- a/src/Metadata/class-post-builder.php
+++ b/src/Metadata/class-post-builder.php
@@ -12,17 +12,12 @@ namespace Parsely\Metadata;
 
 use Parsely\Parsely;
 use WP_Post;
-use WP_User;
-
-use function Parsely\Utils\get_default_category;
 
 /**
  * Implements abstract Metadata Builder class to generate the metadata array
  * for a post page.
  *
  * @since 3.4.0
- *
- * @phpstan-import-type Parsely_Options from Parsely
  */
 class Post_Builder extends Metadata_Builder {
 	/**
@@ -58,19 +53,19 @@ class Post_Builder extends Metadata_Builder {
 
 		$this->build_type();
 		$this->build_main_entity();
-		$this->build_thumbnail_url();
-		$this->build_image();
-		$this->build_article_section();
-		$this->build_author();
+		$this->build_thumbnail_url( $this->post );
+		$this->build_image( $this->post );
+		$this->build_article_section( $this->post );
+		$this->build_author( $this->post );
 		$this->build_publisher();
-		$this->build_keywords();
-		$this->build_metadata_post_times();
+		$this->build_keywords( $this->post );
+		$this->build_metadata_post_times( $this->post );
 
 		return $this->metadata;
 	}
 
 	/**
-	 * Populates the `headline` field in the metadata object.
+	 * Populates the headline field in the metadata object.
 	 *
 	 * @since 3.4.0
 	 */
@@ -79,7 +74,7 @@ class Post_Builder extends Metadata_Builder {
 	}
 
 	/**
-	 * Populates the `url` field in the metadata object by getting the current page's URL.
+	 * Populates the url field in the metadata object by getting the current page's URL.
 	 *
 	 * @since 3.4.0
 	 */
@@ -88,7 +83,7 @@ class Post_Builder extends Metadata_Builder {
 	}
 
 	/**
-	 * Populates the `@type` field in the metadata object.
+	 * Populates the @type field in the metadata object.
 	 *
 	 * @since 3.4.0
 	 */
@@ -122,7 +117,7 @@ class Post_Builder extends Metadata_Builder {
 	}
 
 	/**
-	 * Populates the `mainEntityOfPage` field in the metadata object.
+	 * Populates the mainEntityOfPage field in the metadata object.
 	 *
 	 * @since 3.4.0
 	 */
@@ -134,64 +129,7 @@ class Post_Builder extends Metadata_Builder {
 	}
 
 	/**
-	 * Populates the `thumbnailUrl` field in the metadata object.
-	 *
-	 * @since 3.4.0
-	 */
-	private function build_thumbnail_url(): void {
-		$thumb_url = get_the_post_thumbnail_url( $this->post, 'thumbnail' );
-		if ( ! is_string( $thumb_url ) ) {
-			$thumb_url = '';
-		}
-		$this->metadata['thumbnailUrl'] = $thumb_url;
-	}
-
-	/**
-	 * Populates the `image` field in the metadata object.
-	 *
-	 * @since 3.4.0
-	 */
-	private function build_image(): void {
-		$image_url = get_the_post_thumbnail_url( $this->post, 'full' );
-		if ( ! is_string( $image_url ) ) {
-			$image_url = '';
-		}
-		$this->metadata['image'] = array(
-			'@type' => 'ImageObject',
-			'url'   => $image_url,
-		);
-	}
-
-	/**
-	 * Populates the `articleSection` field in the metadata object.
-	 *
-	 * @since 3.4.0
-	 */
-	private function build_article_section(): void {
-		$this->metadata['articleSection'] = $this->get_category_name( $this->post, $this->parsely->get_options() );
-	}
-
-	/**
-	 * Populates the `author` and `creator` fields in the metadata object.
-	 *
-	 * @since 3.4.0
-	 */
-	private function build_author(): void {
-		$authors        = $this->get_author_names( $this->post );
-		$author_objects = array();
-		foreach ( $authors as $author ) {
-			$author_tag       = array(
-				'@type' => 'Person',
-				'name'  => $author,
-			);
-			$author_objects[] = $author_tag;
-		}
-		$this->metadata['author']  = $author_objects;
-		$this->metadata['creator'] = $authors;
-	}
-
-	/**
-	 * Populates the `publisher` field in the metadata object.
+	 * Populates the publisher field in the metadata object.
 	 *
 	 * @since 3.4.0
 	 */
@@ -201,396 +139,5 @@ class Post_Builder extends Metadata_Builder {
 			'name'  => get_bloginfo( 'name' ),
 			'logo'  => $this->parsely->get_options()['logo'],
 		);
-	}
-
-	/**
-	 * Populates the `keywords` field in the metadata object.
-	 *
-	 * @since 3.4.0
-	 */
-	private function build_keywords(): void {
-		$options = $this->parsely->get_options();
-		$tags    = $this->get_tags( $this->post->ID );
-		if ( $options['cats_as_tags'] ) {
-			$tags = array_merge( $tags, $this->get_categories( $this->post->ID ) );
-			// add custom taxonomy values.
-			$tags = array_merge( $tags, $this->get_custom_taxonomy_values( $this->post ) );
-		}
-		// The function 'mb_strtolower' is not enabled by default in php, so this check
-		// falls back to the native php function 'strtolower' if necessary.
-		if ( function_exists( 'mb_strtolower' ) ) {
-			$lowercase_callback = 'mb_strtolower';
-		} else {
-			$lowercase_callback = 'strtolower';
-		}
-		if ( $options['lowercase_tags'] ) {
-			$tags = array_map( $lowercase_callback, $tags );
-		}
-
-		/**
-		 * Filters the post tags that are used as metadata keywords.
-		 *
-		 * @since 1.8.0
-		 *
-		 * @param array<string> $tags Post tags.
-		 * @param int $ID Post ID.
-		 */
-		$tags = apply_filters( 'wp_parsely_post_tags', $tags, $this->post->ID );
-		$tags = array_map( array( $this, 'clean_value' ), $tags );
-
-		$this->metadata['keywords'] = array_values( array_unique( $tags ) );
-	}
-
-	/**
-	 * Sets all metadata values related to post time.
-	 *
-	 * @since 3.0.2
-	 * @since 3.3.0 Moved to class-metadata.
-	 */
-	private function build_metadata_post_times(): void {
-		$date_format      = 'Y-m-d\TH:i:s\Z';
-		$post_created_gmt = get_post_time( $date_format, true, $this->post );
-
-		if ( false === $post_created_gmt ) {
-			return;
-		}
-
-		$this->metadata['dateCreated']   = $post_created_gmt;
-		$this->metadata['datePublished'] = $post_created_gmt;
-		$this->metadata['dateModified']  = $post_created_gmt;
-
-		$post_modified_gmt = get_post_modified_time( $date_format, true, $this->post );
-
-		if ( false !== $post_modified_gmt && $post_modified_gmt > $post_created_gmt ) {
-			$this->metadata['dateModified'] = $post_modified_gmt;
-		}
-	}
-
-	/**
-	 * Returns a properly cleaned category/taxonomy value and will optionally
-	 * use the top-level category/taxonomy value, if so instructed via the
-	 * `use_top_level_cats` option.
-	 *
-	 * @since 3.3.0 Moved to class-metadata.
-	 *
-	 * @param WP_Post         $post_obj The object for the post.
-	 * @param Parsely_Options $parsely_options The parsely options.
-	 * @return string Cleaned category name for the post in question.
-	 */
-	private function get_category_name( WP_Post $post_obj, $parsely_options ): string {
-		$taxonomy_dropdown_choice = get_the_terms( $post_obj->ID, $parsely_options['custom_taxonomy_section'] );
-		// Get top-level taxonomy name for chosen taxonomy and assign to $parent_name; it will be used
-		// as the category value if 'use_top_level_cats' option is checked.
-		// Assign as the default category name if no value is checked for the chosen taxonomy.
-		$category_name = get_cat_name( get_default_category() );
-		if ( false !== $taxonomy_dropdown_choice && ! is_wp_error( $taxonomy_dropdown_choice ) ) {
-			if ( $parsely_options['use_top_level_cats'] ) {
-				$first_term = array_shift( $taxonomy_dropdown_choice );
-				if ( null !== $first_term ) {
-					$term_name = $this->get_top_level_term( $first_term->term_id, $first_term->taxonomy );
-				}
-			} else {
-				$term_name = $this->get_bottom_level_term( $post_obj->ID, $parsely_options['custom_taxonomy_section'] );
-			}
-
-			if ( isset( $term_name ) && is_string( $term_name ) && 0 < strlen( $term_name ) ) {
-				$category_name = $term_name;
-			}
-		}
-
-		/**
-		 * Filters the constructed category name.
-		 *
-		 * @since 1.8.0
-		 *
-		 * @param string  $category    Category name.
-		 * @param WP_Post $post_obj    Post object.
-		 * @param array<string, mixed> $parsely_options The Parsely options.
-		 */
-		$category_name = apply_filters( 'wp_parsely_post_category', $category_name, $post_obj, $parsely_options );
-
-		return $this->clean_value( $category_name );
-	}
-
-	/**
-	 * Returns the top-most category/taxonomy value in a hierarchy given a
-	 * taxonomy value's ID.
-	 *
-	 * (WordPress calls taxonomy values 'terms').
-	 *
-	 * @since 3.3.0 Moved to class-metadata.
-	 *
-	 * @param int    $term_id       The ID of the top level term.
-	 * @param string $taxonomy_name The name of the taxonomy.
-	 * @return string|false $parent The top level name of the category / taxonomy.
-	 */
-	private function get_top_level_term( int $term_id, string $taxonomy_name ) {
-		$parent = get_term_by( 'id', $term_id, $taxonomy_name );
-
-		while ( false !== $parent && isset( $parent->parent ) && 0 !== $parent->parent ) {
-			$parent = get_term_by( 'id', $parent->parent, $taxonomy_name );
-		}
-
-		return $parent->name ?? false;
-	}
-
-	/**
-	 * Returns the bottom-most category/taxonomy value in a hierarchy given a
-	 * post ID.
-	 *
-	 * (WordPress calls taxonomy values 'terms').
-	 *
-	 * @since 3.3.0 Moved to class-metadata.
-	 *
-	 * @param int    $post_id       The post id you're interested in.
-	 * @param string $taxonomy_name The name of the taxonomy.
-	 * @return string Name of the custom taxonomy.
-	 */
-	private function get_bottom_level_term( int $post_id, string $taxonomy_name ): string {
-		$terms = get_the_terms( $post_id, $taxonomy_name );
-
-		if ( ! is_array( $terms ) ) {
-			return '';
-		}
-
-		$term_ids = wp_list_pluck( $terms, 'term_id' );
-		$parents  = array_filter( wp_list_pluck( $terms, 'parent' ) );
-
-		// Get array of IDs of terms which are not parents.
-		$term_ids_not_parents = array_diff( $term_ids, $parents );
-		// Get corresponding term objects, which are mapped to array index keys.
-		$terms_not_parents = array_intersect_key( $terms, $term_ids_not_parents );
-		// remove array index keys.
-		$terms_not_parents_cleaned = array_values( $terms_not_parents );
-
-		if ( isset( $terms_not_parents_cleaned[0] ) ) {
-			// If you assign multiple child terms in a custom taxonomy, will only return the first.
-			return $terms_not_parents_cleaned[0]->name;
-		}
-
-		return '';
-	}
-
-	/**
-	 * Retrieves all the authors for a post as an array. Can include multiple
-	 * authors if the Co-Authors Plus plugin is in use.
-	 *
-	 * @since 3.3.0 Moved to class-metadata.
-	 *
-	 * @param WP_Post $post The post object.
-	 * @return array<string>
-	 */
-	public function get_author_names( WP_Post $post ): array {
-		$authors = $this->get_coauthor_names( $post->ID );
-		if ( 0 === count( $authors ) ) {
-			$post_author = get_user_by( 'id', $post->post_author );
-			if ( false !== $post_author ) {
-				$authors = array( $post_author );
-			}
-		}
-
-		/**
-		 * Filters the list of author WP_User objects for a post.
-		 *
-		 * @since 1.14.0
-		 *
-		 * @param array<WP_User> $authors One or more authors as WP_User objects.
-		 * @param WP_Post        $post    Post object.
-		 */
-		$authors = apply_filters( 'wp_parsely_pre_authors', $authors, $post );
-
-		// Getting the author name for each author.
-		$authors = array_map( array( $this, 'get_author_name' ), $authors );
-
-		/**
-		 * Filters the list of author names for a post.
-		 *
-		 * @since 1.14.0
-		 *
-		 * @param array<string> $authors One or more author names.
-		 * @param WP_Post       $post    Post object.
-		 */
-		$authors = apply_filters( 'wp_parsely_post_authors', $authors, $post );
-
-		return array_map( array( $this, 'clean_value' ), $authors );
-	}
-
-	/**
-	 * Returns a list of coauthors for a post assuming the Co-Authors Plus plugin
-	 * is installed.
-	 *
-	 * Borrowed from
-	 * https://github.com/Automattic/Co-Authors-Plus/blob/master/template-tags.php#L3-35
-	 *
-	 * @since 3.3.0 Moved to class-metadata.
-	 *
-	 * @param int $post_id The ID of the post.
-	 * @return array<WP_User> List of coauthors, or an empty array if the Co-Authors Plus plugin is not active.
-	 */
-	private function get_coauthor_names( int $post_id ): array {
-		$coauthors = array();
-		if ( class_exists( 'coauthors_plus' ) ) {
-			global $post, $post_ID, $coauthors_plus;
-
-			if ( $post_id <= 0 && $post_ID ) {
-				$post_id = $post_ID;
-			}
-
-			if ( ! $post_id && $post ) {
-				$post_id = $post->ID;
-			}
-
-			if ( $post_id ) {
-				$coauthor_terms = get_the_terms( $post_id, $coauthors_plus->coauthor_taxonomy );
-
-				if ( is_array( $coauthor_terms ) ) {
-					foreach ( $coauthor_terms as $coauthor ) {
-						$coauthor_slug = preg_replace( '#^cap-#', '', $coauthor->slug );
-						$post_author   = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_slug );
-						// In case the user has been deleted while plugin was deactivated.
-						if ( false !== $post_author ) {
-							$coauthors[] = new WP_User( $post_author );
-						}
-					}
-				} elseif ( ! $coauthors_plus->force_guest_authors ) {
-					if ( $post && $post_id === $post->ID ) {
-						$post_author = get_userdata( $post->post_author );
-					}
-					if ( isset( $post_author ) && false !== $post_author ) {
-						$coauthors[] = $post_author;
-					}
-				}
-				// The empty else case is because if we force guest authors, we don't ever care what value wp_posts.post_author has.
-			}
-		}
-		return $coauthors;
-	}
-
-	/**
-	 * Determines author name from display name, falling back to firstname
-	 * lastname, then nickname and finally the nicename.
-	 *
-	 * @since 3.3.0 Moved to class-metadata.
-	 *
-	 * @param ?WP_User $author The author of the post.
-	 * @return string An author name.
-	 */
-	private function get_author_name( ?WP_User $author ): string {
-		// Gracefully handle situation where no author is available.
-		if ( null === $author ) {
-			return '';
-		}
-
-		if ( '' !== $author->display_name ) {
-			return $author->display_name;
-		}
-
-		$author_name = $author->user_firstname . ' ' . $author->user_lastname;
-		if ( ' ' !== $author_name ) {
-			return $author_name;
-		}
-
-		if ( '' !== $author->nickname ) {
-			return $author->nickname;
-		}
-
-		if ( '' !== $author->user_nicename ) {
-			return $author->user_nicename;
-		}
-
-		return '';
-	}
-
-	/**
-	 * Returns the tags associated with this page or post.
-	 *
-	 * @since 3.3.0 Moved to class-metadata.
-	 *
-	 * @param int $post_id   The ID of the post you're trying to get tags for.
-	 * @return array<string> The tags of the post represented by the post id.
-	 */
-	private function get_tags( int $post_id ): array {
-		/**
-		 * Variable.
-		 *
-		 * @var array<\WP_Term|null>|\WP_Error
-		 */
-		$post_tags = wp_get_post_tags( $post_id );
-		$tags      = array();
-
-		if ( ! is_wp_error( $post_tags ) ) {
-			foreach ( $post_tags as $wp_tag ) {
-				if ( null !== $wp_tag ) {
-					$tags[] = $wp_tag->name;
-				}
-			}
-		}
-
-		return $tags;
-	}
-
-	/**
-	 * Returns an array of all the child categories for the current post.
-	 *
-	 * @since 3.3.0 Moved to class-metadata.
-	 *
-	 * @param int    $post_id   The ID of the post you're trying to get categories for.
-	 * @param string $delimiter What character will delimit the categories.
-	 * @return array<string> All the child categories of the current post.
-	 */
-	private function get_categories( int $post_id, string $delimiter = '/' ): array {
-		$tags = array();
-		foreach ( get_the_category( $post_id ) as $category ) {
-			$hierarchy = get_category_parents( $category->term_id, false, $delimiter );
-			if ( ! is_wp_error( $hierarchy ) ) {
-				$tags[] = rtrim( $hierarchy, '/' );
-			}
-		}
-		// Take last element in the hierarchy, a string representing the full parent->child tree,
-		// and split it into individual category names.
-		$last_tag = end( $tags );
-		if ( false !== $last_tag ) {
-			$tags = explode( '/', $last_tag );
-		}
-
-		// Remove default category name from tags if needed.
-		$default_category_name = get_cat_name( get_default_category() );
-		return array_diff( $tags, array( $default_category_name ) );
-	}
-
-	/**
-	 * Gets all term names from all custom taxonomies assigned to a post.
-	 *
-	 * @since 3.3.0 Moved to class-metadata.
-	 * @since 3.4.0 Moved to class-post-builder.
-	 *
-	 * @param WP_Post $post_obj The post object to find the terms for.
-	 * @return array<string> Term names.
-	 */
-	private function get_custom_taxonomy_values( WP_Post $post_obj ): array {
-		// Filter out default WordPress taxonomies.
-		$all_taxonomies = array_diff( get_taxonomies(), array( 'post_tag', 'nav_menu', 'author', 'link_category', 'post_format' ) );
-
-		/**
-		 * Filters the taxonomies.
-		 *
-		 * @since 3.11.0
-		 *
-		 * @param array<string> $all_taxonomies Taxonomies.
-		 * @param WP_Post $post_obj    Post object.
-		 */
-		$all_taxonomies = apply_filters( 'wp_parsely_custom_taxonomies', $all_taxonomies, $post_obj );
-		$all_values     = array();
-
-		foreach ( $all_taxonomies as $taxonomy ) {
-			$custom_taxonomy_objects = get_the_terms( $post_obj->ID, $taxonomy );
-			if ( is_array( $custom_taxonomy_objects ) ) {
-				foreach ( $custom_taxonomy_objects as $custom_taxonomy_object ) {
-					$all_values[] = $custom_taxonomy_object->name;
-				}
-			}
-		}
-
-		return $all_values;
 	}
 }

--- a/tests/Integration/Metadata/NonPostTestCase.php
+++ b/tests/Integration/Metadata/NonPostTestCase.php
@@ -34,8 +34,12 @@ abstract class NonPostTestCase extends TestCase {
 
 		array_walk(
 			$required_properties,
-			static function ( $property ) use ( $structured_data ) {
-				self::assertArrayHasKey( $property, $structured_data, 'Data does not have required property: ' . $property );
+			static function ( string $property ) use ( $structured_data ) {
+				self::assertArrayHasKey(
+					$property,
+					$structured_data,
+					'Data does not have required property: ' . $property
+				);
 			}
 		);
 	}
@@ -45,7 +49,7 @@ abstract class NonPostTestCase extends TestCase {
 	 *
 	 * @return array<string>
 	 */
-	private function get_required_properties(): array {
+	protected function get_required_properties(): array {
 		return array(
 			'@context',
 			'@type',

--- a/tests/Integration/Metadata/SinglePageTest.php
+++ b/tests/Integration/Metadata/SinglePageTest.php
@@ -20,14 +20,24 @@ use Parsely\Parsely;
  * @covers \Parsely\Metadata::construct_metadata
  */
 final class SinglePageTest extends NonPostTestCase {
-
 	/**
 	 * Verifies that the metadata generated for Single Page pages is as
-	 * expected.
+	 * expected. No author, category, or tag is set.
 	 *
-	 * @covers \Parsely\Metadata::__construct
-	 * @covers \Parsely\Metadata::construct_metadata
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_article_section
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_author
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_image
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_keywords
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_thumbnail_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_author_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_category_name
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_coauthor_names
 	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_tags
+	 * @uses \Parsely\Metadata::__construct
 	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
 	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
 	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
@@ -35,25 +45,404 @@ final class SinglePageTest extends NonPostTestCase {
 	 * @uses \Parsely\Metadata\Page_Builder::build_headline
 	 * @uses \Parsely\Metadata\Page_Builder::build_url
 	 * @uses \Parsely\Metadata\Page_Builder::get_metadata
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
 	 * @uses \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::set_managed_options
 	 * @uses \Parsely\Parsely::update_metadata_endpoint
+	 * @uses \Parsely\Utils\get_default_category
 	 * @group metadata
 	 */
 	public function test_single_page(): void {
+		$this->run_single_page_test( false, false, false );
+	}
+
+	/**
+	 * Verifies that the metadata generated for Single Page pages is as
+	 * expected. An author is set.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_article_section
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_author
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_image
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_keywords
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_thumbnail_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_author_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_category_name
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_coauthor_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_tags
+	 * @uses \Parsely\Metadata::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Page_Builder::__construct
+	 * @uses \Parsely\Metadata\Page_Builder::build_headline
+	 * @uses \Parsely\Metadata\Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Page_Builder::get_metadata
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Parsely::update_metadata_endpoint
+	 * @uses \Parsely\Utils\get_default_category
+	 * @group metadata
+	 */
+	public function test_single_page_with_author(): void {
+		$this->run_single_page_test( true, false, false );
+	}
+
+	/**
+	 * Verifies that the metadata generated for Single Page pages is as
+	 * expected. A category is set.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_article_section
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_author
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_image
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_keywords
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_thumbnail_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_author_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_category_name
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_coauthor_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_tags
+	 * @uses \Parsely\Metadata::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Page_Builder::__construct
+	 * @uses \Parsely\Metadata\Page_Builder::build_headline
+	 * @uses \Parsely\Metadata\Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Page_Builder::get_metadata
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Parsely::update_metadata_endpoint
+	 * @uses \Parsely\Utils\get_default_category
+	 * @group metadata
+	 */
+	public function test_single_page_with_category(): void {
+		$this->run_single_page_test( false, true, false );
+	}
+
+	/**
+	 * Verifies that the metadata generated for Single Page pages is as
+	 * expected. A tag is set.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_article_section
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_author
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_image
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_keywords
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_thumbnail_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_author_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_category_name
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_coauthor_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_tags
+	 * @uses \Parsely\Metadata::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Page_Builder::__construct
+	 * @uses \Parsely\Metadata\Page_Builder::build_headline
+	 * @uses \Parsely\Metadata\Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Page_Builder::get_metadata
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Parsely::update_metadata_endpoint
+	 * @uses \Parsely\Utils\get_default_category
+	 * @group metadata
+	 */
+	public function test_single_page_with_tag(): void {
+		$this->run_single_page_test( false, false, true );
+	}
+
+	/**
+	 * Verifies that the metadata generated for Single Page pages is as
+	 * expected. A tag is set and the lowercase_tags option is off.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_article_section
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_author
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_image
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_keywords
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_thumbnail_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_author_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_category_name
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_coauthor_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_tags
+	 * @uses \Parsely\Metadata::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Page_Builder::__construct
+	 * @uses \Parsely\Metadata\Page_Builder::build_headline
+	 * @uses \Parsely\Metadata\Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Page_Builder::get_metadata
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Parsely::update_metadata_endpoint
+	 * @uses \Parsely\Utils\get_default_category
+	 * @group metadata
+	 */
+	public function test_single_page_with_tag_lowercase_off(): void {
+		$this->run_single_page_test( false, false, true, false );
+	}
+
+	/**
+	 * Verifies that the metadata generated for Single Page pages is as
+	 * expected. An author and a category are set.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_article_section
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_author
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_image
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_keywords
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_thumbnail_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_author_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_category_name
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_coauthor_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_tags
+	 * @uses \Parsely\Metadata::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Page_Builder::__construct
+	 * @uses \Parsely\Metadata\Page_Builder::build_headline
+	 * @uses \Parsely\Metadata\Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Page_Builder::get_metadata
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Parsely::update_metadata_endpoint
+	 * @uses \Parsely\Utils\get_default_category
+	 * @group metadata
+	 */
+	public function test_single_page_with_author_and_category(): void {
+		$this->run_single_page_test( true, true, false );
+	}
+
+	/**
+	 * Verifies that the metadata generated for Single Page pages is as
+	 * expected. An author and a tag are set.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_article_section
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_author
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_image
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_keywords
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_thumbnail_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_author_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_category_name
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_coauthor_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_tags
+	 * @uses \Parsely\Metadata::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Page_Builder::__construct
+	 * @uses \Parsely\Metadata\Page_Builder::build_headline
+	 * @uses \Parsely\Metadata\Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Page_Builder::get_metadata
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Parsely::update_metadata_endpoint
+	 * @uses \Parsely\Utils\get_default_category
+	 * @group metadata
+	 */
+	public function test_single_page_with_author_and_tag(): void {
+		$this->run_single_page_test( true, false, true );
+	}
+
+	/**
+	 * Verifies that the metadata generated for Single Page pages is as
+	 * expected. A category and a tag are set.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_article_section
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_author
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_image
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_keywords
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_thumbnail_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_author_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_category_name
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_coauthor_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_tags
+	 * @uses \Parsely\Metadata::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Page_Builder::__construct
+	 * @uses \Parsely\Metadata\Page_Builder::build_headline
+	 * @uses \Parsely\Metadata\Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Page_Builder::get_metadata
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Parsely::update_metadata_endpoint
+	 * @uses \Parsely\Utils\get_default_category
+	 * @group metadata
+	 */
+	public function test_single_page_with_category_and_tag(): void {
+		$this->run_single_page_test( false, true, true );
+	}
+
+	/**
+	 * Verifies that the metadata generated for Single Page pages is as
+	 * expected. An author, a category, and a tag are set.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_article_section
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_author
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_image
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_keywords
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_metadata_post_times
+	 * @covers \Parsely\Metadata\Metadata_Builder::build_thumbnail_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_author_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_category_name
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_coauthor_names
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_current_url
+	 * @covers \Parsely\Metadata\Metadata_Builder::get_tags
+	 * @uses \Parsely\Metadata::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::__construct
+	 * @uses \Parsely\Metadata\Metadata_Builder::build_basic
+	 * @uses \Parsely\Metadata\Metadata_Builder::clean_value
+	 * @uses \Parsely\Metadata\Page_Builder::__construct
+	 * @uses \Parsely\Metadata\Page_Builder::build_headline
+	 * @uses \Parsely\Metadata\Page_Builder::build_url
+	 * @uses \Parsely\Metadata\Page_Builder::get_metadata
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Parsely::update_metadata_endpoint
+	 * @uses \Parsely\Utils\get_default_category
+	 * @group metadata
+	 */
+	public function test_single_page_with_author_and_category_and_tag(): void {
+		$this->run_single_page_test( true, true, true );
+	}
+
+	/**
+	 * Runs the single page test with the desired parameters.
+	 *
+	 * @since 3.14.0 Renamed from test_single_page.
+	 *
+	 * @param bool $with_author Whether to test with an author.
+	 * @param bool $with_category Whether to test with a category.
+	 * @param bool $with_tag Whether to test with a tag.
+	 * @param bool $lowercase_tags The value of the `lowercase_tags` option.
+	 */
+	private function run_single_page_test(
+		bool $with_author,
+		bool $with_category,
+		bool $with_tag,
+		bool $lowercase_tags = true
+	): void {
 		// Setup Parsely object.
 		$parsely = new Parsely();
 
+		$page_data = array(
+			'post_type'  => 'page',
+			'post_title' => 'Single Page',
+			'post_name'  => 'foo',
+			'post_date'  => '2024-01-01 12:00:00',
+		);
+
+		if ( $with_author ) {
+			$page_data['post_author'] = 1;
+		}
+
 		// Insert a single page.
 		/** @var int $page_id */
-		$page_id = self::factory()->post->create(
-			array(
-				'post_type'  => 'page',
-				'post_title' => 'Single Page',
-				'post_name'  => 'foo',
-			)
-		);
-		$page    = $this->get_post( $page_id );
+		$page_id = self::factory()->post->create( $page_data );
+
+		if ( $with_category ) {
+			// Create a category and assign it to the page.
+			/** @var int $category_id */
+			$category_id = self::factory()->category->create(
+				array(
+					'name' => 'Category 1',
+					'slug' => 'category-1',
+				)
+			);
+			wp_set_post_categories( $page_id, array( $category_id ) );
+		}
+
+		if ( $with_tag ) {
+			// Set the `lowercase_tags` option as needed.
+			$parsely_options                   = $parsely->get_options();
+			$parsely_options['lowercase_tags'] = $lowercase_tags;
+			update_option( 'parsely', $parsely_options );
+
+			// Create a tag and assign it to the page.
+			$tag_id = self::factory()->tag->create(
+				array(
+					'name' => 'Tag 1',
+					'slug' => 'tag-1',
+				)
+			);
+			wp_set_post_tags( $page_id, array( $tag_id ) );
+		}
+
+		$page = $this->get_post( $page_id );
 
 		// Set permalinks, as Parsely currently strips ?page_id=... from the URL
 		// property. See https://github.com/Parsely/wp-parsely/issues/151.
@@ -74,9 +463,76 @@ final class SinglePageTest extends NonPostTestCase {
 		// The headline should be the post_title of the page.
 		self::assertSame( 'Single Page', $structured_data['headline'] ?? null );
 		self::assertSame( get_permalink( $page_id ), $structured_data['url'] ?? null );
+		self::assertSame( '2024-01-01T12:00:00Z', $structured_data['dateCreated'] );
+		self::assertSame( '2024-01-01T12:00:00Z', $structured_data['datePublished'] );
+		self::assertSame( '2024-01-01T12:00:00Z', $structured_data['dateModified'] );
+		self::assertSame( '', $structured_data['thumbnailUrl'] );
+		self::assertSame(
+			array(
+				'@type' => 'ImageObject',
+				'url'   => '',
+			),
+			$structured_data['image']
+		);
 		self::assertQueryTrue( 'is_page', 'is_singular' );
+
+		// Test author/creator values.
+		if ( $with_author ) {
+			/** @var array<int, array<string, string>> $author */
+			$author = $structured_data['author'];
+			/** @var array<int, string> $creator */
+			$creator = $structured_data['creator'];
+
+			self::assertSame( 'Person', $author[0]['@type'] );
+			self::assertSame( 'admin', $author[0]['name'] );
+			self::assertSame( 'admin', $creator[0] );
+		} else {
+			self::assertSame( array(), $structured_data['author'] );
+			self::assertSame( array(), $structured_data['creator'] );
+		}
+
+		// Test category value.
+		if ( $with_category ) {
+			self::assertSame( 'Category 1', $structured_data['articleSection'] );
+		} else {
+			self::assertSame( 'Uncategorized', $structured_data['articleSection'] );
+		}
+
+		// Test tag value.
+		if ( $with_tag ) {
+			/** @var array<int, string> $keywords */
+			$keywords = $structured_data['keywords'];
+
+			if ( true === $lowercase_tags ) {
+				self::assertSame( 'tag 1', $keywords[0] );
+			} else {
+				self::assertSame( 'Tag 1', $keywords[0] );
+			}
+		} else {
+			self::assertSame( array(), $structured_data['keywords'] );
+		}
 
 		// Reset permalinks to plain.
 		$wp_rewrite->set_permalink_structure( '' );
+	}
+
+	/**
+	 * Returns the required properties for non-posts.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @return array<string>
+	 */
+	protected function get_required_properties(): array {
+		return array(
+			'@context',
+			'@type',
+			'articleSection',
+			'author',
+			'creator',
+			'headline',
+			'keywords',
+			'url',
+		);
 	}
 }

--- a/tests/e2e/specs/front-end-metadata.spec.ts
+++ b/tests/e2e/specs/front-end-metadata.spec.ts
@@ -61,7 +61,7 @@ describe( 'Front end metadata insertion', () => {
 		expect( content ).not.toContain( '<meta name="parsely-title" ' );
 	} );
 
-	it( 'Should insert JSON-LD on post page', async () => {
+	it( 'Should insert JSON-LD on post', async () => {
 		await setMetadataFormat( 'json_ld' );
 
 		await page.goto( createURL( '/', '?p=1' ) );
@@ -70,6 +70,19 @@ describe( 'Front end metadata insertion', () => {
 
 		expect( content ).toContain( '<script type="application/ld+json">' );
 		expect( content ).toContain( '{"@context":"https:\\/\\/schema.org","@type":"NewsArticle","headline":"Hello world!","url":"http:\\/\\/localhost:8889\\/?p=1","mainEntityOfPage":{"@type":"WebPage","@id":"http:\\/\\/localhost:8889\\/?p=1"},"thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"articleSection":"Uncategorized","author":[{"@type":"Person","name":"admin"}],"creator":["admin"],"publisher":{"@type":"Organization","name":"wp-parsely","logo":""},"keywords":[],"' );
+
+		expect( content ).not.toContain( '<meta name="parsely-title" ' );
+	} );
+
+	it( 'Should insert JSON-LD on page', async () => {
+		await setMetadataFormat( 'json_ld' );
+
+		await page.goto( createURL( '/', '?p=2' ) );
+
+		const content = await page.content();
+
+		expect( content ).toContain( '<script type="application/ld+json">' );
+		expect( content ).toContain( '{"@context":"https:\\/\\/schema.org","@type":"WebPage","headline":"Sample Page","url":"http:\\/\\/localhost:8889\\/?page_id=2","thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"articleSection":"Uncategorized","author":[{"@type":"Person","name":"admin"}],"creator":["admin"],"keywords":[],"' );
 
 		expect( content ).not.toContain( '<meta name="parsely-title" ' );
 	} );
@@ -85,10 +98,13 @@ describe( 'Front end metadata insertion', () => {
 		expect( content ).toContain( '<meta name="parsely-link" content="http://localhost:8889">' );
 		expect( content ).toContain( '<meta name="parsely-type" content="index">' );
 
+		expect( content ).not.toMatch( /<meta name="parsely-pub-date" content=".*Z">/ );
+		expect( content ).not.toContain( '<meta name="parsely-section" content="Uncategorized">' );
+		expect( content ).not.toContain( '<meta name="parsely-author" content="admin">' );
 		expect( content ).not.toContain( '<script type="application/ld+json">' );
 	} );
 
-	it( 'Should insert repeated metas on post page', async () => {
+	it( 'Should insert repeated metas on post', async () => {
 		await setMetadataFormat( 'repeated_metas' );
 
 		await page.goto( createURL( '/', '?p=1' ) );
@@ -98,6 +114,23 @@ describe( 'Front end metadata insertion', () => {
 		expect( content ).toContain( '<meta name="parsely-title" content="Hello world!">' );
 		expect( content ).toContain( '<meta name="parsely-link" content="http://localhost:8889/?p=1">' );
 		expect( content ).toContain( '<meta name="parsely-type" content="post">' );
+		expect( content ).toMatch( /<meta name="parsely-pub-date" content=".*Z">/ );
+		expect( content ).toContain( '<meta name="parsely-section" content="Uncategorized">' );
+		expect( content ).toContain( '<meta name="parsely-author" content="admin">' );
+
+		expect( content ).not.toContain( '<script type="application/ld+json">' );
+	} );
+
+	it( 'Should insert repeated metas on page', async () => {
+		await setMetadataFormat( 'repeated_metas' );
+
+		await page.goto( createURL( '/', '?p=2' ) );
+
+		const content = await page.content();
+
+		expect( content ).toContain( '<meta name="parsely-title" content="Sample Page">' );
+		expect( content ).toContain( '<meta name="parsely-link" content="http://localhost:8889/?page_id=2">' );
+		expect( content ).toContain( '<meta name="parsely-type" content="index">' );
 		expect( content ).toMatch( /<meta name="parsely-pub-date" content=".*Z">/ );
 		expect( content ).toContain( '<meta name="parsely-section" content="Uncategorized">' );
 		expect( content ).toContain( '<meta name="parsely-author" content="admin">' );


### PR DESCRIPTION
## Description
This PR adds more metadata into content being tracked as a `Non-Post`<sup>(1)</sup>, almost bringing it into parity<sup>(2)</sup> with content that is being tracked as a `Post`.

1. This behavior only affects content that is caught in [this block of code](https://github.com/Parsely/wp-parsely/blob/0c2572fe76c0223ac3f44a709bdb9a5144b036a0/src/class-metadata.php#L120). Everything else remains untouched. For example, homepage metadata remains the same, even if the homepage happens to be a WordPress `page`.
2. `Posts` run the `build_type()`, `build_main_entity()` and `build_publisher()` functions that are not executed for `Non-Posts`. If we conclude that these are needed as well, we can include them.

Concerning the internal behavior of the additions, for example how `section` or `keywords` are picked, it is identical to what is being done for `Posts`.

WordPress installations that extend the built-in `page` Post Type to support categories and tags should be supported. This is being tested [here](https://github.com/Parsely/wp-parsely/blob/0c2572fe76c0223ac3f44a709bdb9a5144b036a0/tests/Integration/Metadata/SinglePageTest.php#L415-L443). We've also tested the implementation with [this plugin](https://wordpress.org/plugins/pages-with-category-and-tag/) and it has worked. However, any plugin is subject to change and this is not an officially supported integration.

## Motivation and context
- This has been a long time request, and we know that some users want it.
- Closes #1735.

## How has this been tested?
- Manual testing.
- Updated existing tests and added some more.