### PR TITLE
Add option for full metadata in non-posts

### DIFF
--- a/src/Metadata/class-page-builder.php
+++ b/src/Metadata/class-page-builder.php
@@ -51,12 +51,14 @@ class Page_Builder extends Metadata_Builder {
 		$this->build_headline();
 		$this->build_url();
 
-		$this->build_thumbnail_url( $this->post );
-		$this->build_image( $this->post );
-		$this->build_article_section( $this->post );
-		$this->build_author( $this->post );
-		$this->build_keywords( $this->post );
-		$this->build_metadata_post_times( $this->post );
+		if ( true === $this->parsely->get_options()['full_metadata_in_non_posts'] ) {
+			$this->build_thumbnail_url( $this->post );
+			$this->build_image( $this->post );
+			$this->build_article_section( $this->post );
+			$this->build_author( $this->post );
+			$this->build_keywords( $this->post );
+			$this->build_metadata_post_times( $this->post );
+		}
 
 		return $this->metadata;
 	}

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -1097,7 +1097,8 @@ final class Settings_Page {
 		if ( ! isset( $input['full_metadata_in_non_posts'] ) ) {
 			$input['full_metadata_in_non_posts'] = true;
 		} else {
-			$input['full_metadata_in_non_posts'] = 'true' === $input['full_metadata_in_non_posts'];
+			// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+			$input['full_metadata_in_non_posts'] = 'true' == $input['full_metadata_in_non_posts'];
 		}
 
 		// Allow for Top-level categories setting to be conditionally included on the page.

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -55,6 +55,7 @@ use const Parsely\PARSELY_FILE;
  *   track_post_types_as?: array<string, string>,
  *   track_post_types: string[],
  *   track_page_types: string[],
+ *   full_metadata_in_non_posts: ?bool,
  *   content_id_prefix?: string,
  *   use_top_level_cats?:bool|string,
  *   custom_taxonomy_section?: string,
@@ -428,6 +429,25 @@ final class Settings_Page {
 				'option_key' => $field_id,
 				'help_text'  => $field_help,
 				'filter'     => 'wp_parsely_trackable_statuses',
+			)
+		);
+
+		// Use full metadata in non-posts.
+		$field_id = 'full_metadata_in_non_posts';
+		add_settings_field(
+			$field_id,
+			$this->set_field_label_contents( __( 'Use Full Metadata in Non-Posts', 'wp-parsely' ), $field_id ),
+			array( $this, 'print_radio_tags' ),
+			Parsely::MENU_SLUG,
+			$section_key,
+			array(
+				'title'         => __( 'Use Full Metadata in Non-Posts', 'wp-parsely' ), // Passed for legend element.
+				'option_key'    => $field_id,
+				'radio_options' => array(
+					'true'  => __( 'Yes, add full metadata to Post Types being tracked as Non-Posts.', 'wp-parsely' ),
+					'false' => __( 'No, we have code that modifies metadata and that has not been tested for compatibility yet.', 'wp-parsely' ),
+				),
+				'help_text'     => __( '<strong><span style="color:#d63638">Important: This setting will be removed in the future, force-enabling this behavior.</span></strong> If you\'re using any code that modifies metadata in a way that conflicts with this setting when it is enabled, please apply any needed fixes.', 'wp-parsely' ),
 			)
 		);
 
@@ -1071,6 +1091,13 @@ final class Settings_Page {
 			$input['content_id_prefix'] = $options['content_id_prefix'];
 		} else {
 			$input['content_id_prefix'] = sanitize_text_field( $input['content_id_prefix'] );
+		}
+
+		// Full metadata in non-posts.
+		if ( ! isset( $input['full_metadata_in_non_posts'] ) ) {
+			$input['full_metadata_in_non_posts'] = true;
+		} else {
+			$input['full_metadata_in_non_posts'] = 'true' === $input['full_metadata_in_non_posts'];
 		}
 
 		// Allow for Top-level categories setting to be conditionally included on the page.

--- a/src/class-metadata.php
+++ b/src/class-metadata.php
@@ -87,7 +87,7 @@ class Metadata {
 	 * @param WP_Post $post object.
 	 * @return Metadata_Attributes
 	 */
-	public function construct_metadata( WP_Post $post ) {
+	public function construct_metadata( WP_Post $post ): array {
 		$options           = $this->parsely->get_options();
 		$queried_object_id = get_queried_object_id();
 
@@ -121,9 +121,9 @@ class Metadata {
 		}
 
 		if ( isset( $builder ) ) {
-			$parsely_page = $builder->get_metadata();
+			$current_metadata = $builder->get_metadata();
 		} else {
-			$parsely_page = array();
+			$current_metadata = array();
 		}
 
 		/**
@@ -132,11 +132,11 @@ class Metadata {
 		 * @since 2.5.0
 		 * @var mixed
 		 *
-		 * @param array $parsely_page Existing structured metadata for a page.
+		 * @param array $current_metadata The currently generated metadata.
 		 * @param WP_Post $post Post object.
 		 * @param array $options The Parse.ly options.
 		 */
-		$filtered = apply_filters( 'wp_parsely_metadata', $parsely_page, $post, $options );
+		$filtered = apply_filters( 'wp_parsely_metadata', $current_metadata, $post, $options );
 		if ( is_array( $filtered ) ) {
 			return $filtered;
 		}

--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -33,6 +33,7 @@ use WP_Post;
  *   track_post_types: string[],
  *   track_page_types: string[],
  *   track_post_types_as?: array<string, string>,
+ *   full_metadata_in_non_posts: ?bool,
  *   disable_javascript: bool,
  *   disable_amp: bool,
  *   meta_type: string,
@@ -71,24 +72,25 @@ class Parsely {
 	 * @var Parsely_Options $option_defaults The defaults we need for the class.
 	 */
 	private $option_defaults = array(
-		'apikey'                    => '',
-		'content_id_prefix'         => '',
-		'api_secret'                => '',
-		'use_top_level_cats'        => false,
-		'custom_taxonomy_section'   => 'category',
-		'cats_as_tags'              => false,
-		'track_authenticated_users' => false,
-		'lowercase_tags'            => true,
-		'force_https_canonicals'    => false,
-		'track_post_types'          => array(),
-		'track_page_types'          => array(),
-		'disable_javascript'        => false,
-		'disable_amp'               => false,
-		'meta_type'                 => 'json_ld',
-		'logo'                      => '',
-		'metadata_secret'           => '',
-		'disable_autotrack'         => false,
-		'plugin_version'            => self::VERSION,
+		'apikey'                     => '',
+		'content_id_prefix'          => '',
+		'api_secret'                 => '',
+		'use_top_level_cats'         => false,
+		'custom_taxonomy_section'    => 'category',
+		'cats_as_tags'               => false,
+		'track_authenticated_users'  => false,
+		'lowercase_tags'             => true,
+		'force_https_canonicals'     => false,
+		'track_post_types'           => array(),
+		'track_page_types'           => array(),
+		'full_metadata_in_non_posts' => true,
+		'disable_javascript'         => false,
+		'disable_amp'                => false,
+		'meta_type'                  => 'json_ld',
+		'logo'                       => '',
+		'metadata_secret'            => '',
+		'disable_autotrack'          => false,
+		'plugin_version'             => self::VERSION,
 	);
 
 	/**
@@ -403,8 +405,13 @@ class Parsely {
 		 */
 		$options = get_option( self::OPTIONS_KEY, null );
 
+		if ( is_array( $options ) && ! isset( $options['full_metadata_in_non_posts'] ) ) {
+			$this->set_default_full_metadata_in_non_posts();
+		}
+
 		if ( ! is_array( $options ) ) {
 			$this->set_default_track_as_values();
+			$this->set_default_full_metadata_in_non_posts();
 			$options = $this->option_defaults;
 		}
 
@@ -442,6 +449,35 @@ class Parsely {
 				$this->option_defaults['track_page_types'][] = $post_type;
 			} else {
 				$this->option_defaults['track_post_types'][] = $post_type;
+			}
+		}
+	}
+
+	/**
+	 * Sets the default value for the full_metadata_in_non_posts option.
+	 *
+	 * @since 3.14.0
+	 */
+	public function set_default_full_metadata_in_non_posts(): void {
+		$this->option_defaults['full_metadata_in_non_posts'] = true;
+
+		// Usage of any of these filters will result in the setting being set
+		// to false.
+		$filter_tags = array(
+			'wp_parsely_metadata',
+			'wp_parsely_post_tags',
+			'wp_parsely_permalink',
+			'wp_parsely_post_category',
+			'wp_parsely_pre_authors',
+			'wp_parsely_post_authors',
+			'wp_parsely_custom_taxonomies',
+			'wp_parsely_post_type',
+		);
+
+		foreach ( $filter_tags as $filter_tag ) {
+			if ( has_filter( $filter_tag ) ) {
+				$this->option_defaults['full_metadata_in_non_posts'] = false;
+				break;
 			}
 		}
 	}

--- a/tests/Integration/OptionsTest.php
+++ b/tests/Integration/OptionsTest.php
@@ -46,12 +46,13 @@ final class OptionsTest extends TestCase {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @covers \Parsely\Parsely::get_options
 	 * @covers \Parsely\Parsely::get_default_options
+	 * @covers \Parsely\Parsely::get_options
 	 * @uses \Parsely\Parsely::__construct
 	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
 	 * @uses \Parsely\Parsely::are_credentials_managed
 	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
 	 */
@@ -71,11 +72,12 @@ final class OptionsTest extends TestCase {
 	 * @since 3.9.0
 	 *
 	 * @covers \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_managed_credentials
-	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::__construct
 	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
 	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
+	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
 	 */
 	public function test_get_options_returns_correct_track_as_defaults(): void {
@@ -91,10 +93,11 @@ final class OptionsTest extends TestCase {
 	 * @since 3.9.0
 	 *
 	 * @covers \Parsely\Parsely::get_options
-	 * @uses \Parsely\Parsely::get_managed_credentials
 	 * @uses \Parsely\Parsely::__construct
 	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
 	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
 	 */
@@ -122,6 +125,7 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
 	 * @uses \Parsely\Parsely::are_credentials_managed
 	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_managed_options
 	 */
 	public function test_get_options_track_as_defaults_when_cpts_are_registered(): void {
@@ -188,6 +192,202 @@ final class OptionsTest extends TestCase {
 	}
 
 	/**
+	 * Verifies that get_options() returns the correct full_metadata_in_non_posts
+	 * option default value.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
+	 * @uses \Parsely\Parsely::set_default_track_as_values
+	 * @uses \Parsely\Parsely::set_managed_options
+	 */
+	public function test_get_options_returns_correct_full_metadata_in_non_posts_default_value(): void {
+		$options = self::$parsely->get_options();
+		self::assertSame( true, $options['full_metadata_in_non_posts'] );
+	}
+
+	/**
+	 * Verifies that the set_default_full_metadata_in_non_posts() function
+	 * doesn't get called when saved plugin options exist.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
+	 * @uses \Parsely\Parsely::set_default_track_as_values
+	 * @uses \Parsely\Parsely::set_managed_options
+	 */
+	public function test_set_default_full_metadata_in_non_posts_values_should_not_be_called_when_saved_options_exist(): void {
+		$option_key             = 'full_metadata_in_non_posts';
+		$options                = self::$parsely->get_options();
+		$options[ $option_key ] = false;
+
+		add_option( Parsely::OPTIONS_KEY, $options );
+		$saved_options = self::$parsely->get_options();
+
+		self::assertSame( false, $saved_options[ $option_key ] );
+	}
+
+	/**
+	 * Verifies that the set_default_full_metadata_in_non_posts() function
+	 * returns the expected value under different circumstances:
+	 *
+	 * - Option is saved (get value from database).
+	 * - Option isn't saved (get value from defaults).
+	 * - Option value is influenced by a metadata filter (modify default value).
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Parsely::get_options
+	 * @covers \Parsely\Parsely::set_default_full_metadata_in_non_posts
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_default_options
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::sanitize_managed_option
+	 * @uses \Parsely\Parsely::set_default_track_as_values
+	 * @uses \Parsely\Parsely::set_managed_options
+	 */
+	public function test_set_default_full_metadata_in_non_posts_returns_expected_values(): void {
+		$option_key      = 'full_metadata_in_non_posts';
+		$default_options = self::$parsely->get_default_options();
+		self::assertSame( true, $default_options[ $option_key ] );
+
+		// Add a filter that will make the default value to return false.
+		add_filter( 'wp_parsely_metadata', '__return_true' );
+
+		// No options are saved. Should get the value from option defaults.
+		self::assertSame(
+			false,
+			( new Parsely() )->get_options()[ $option_key ]
+		);
+
+		// Options are saved. Should get the value from the saved option.
+		add_option( Parsely::OPTIONS_KEY, $default_options );
+		self::assertSame(
+			true,
+			( new Parsely() )->get_options()[ $option_key ]
+		);
+	}
+
+	/**
+	 * Verifies that the set_default_full_metadata_in_non_posts() function
+	 * returns false when different metadata filters are being used.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Parsely::get_options
+	 * @covers \Parsely\Parsely::set_default_full_metadata_in_non_posts
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::set_default_track_as_values
+	 * @uses \Parsely\Parsely::set_managed_options
+	 */
+	public function test_set_default_full_metadata_in_non_posts_returns_false_when_metadata_filters_are_used(): void {
+		$option_key = 'full_metadata_in_non_posts';
+
+		// Filter tags and how they should influence the expected value of the
+		// full_metadata_in_non_posts option.
+		$filters = array(
+			'wp_parsely_metadata'          => false,
+			'imaginary_filter'             => true, // Fake filter tag that should have no effect.
+			'wp_parsely_post_tags'         => false,
+			'wp_parsely_load_js_tracker'   => true, // Real filter tag that should have no effect.
+			'wp_parsely_permalink'         => false,
+			'wp_parsely_enable_admin_bar'  => true, // Real filter tag that should have no effect.
+			'wp_parsely_post_category'     => false,
+			'wp_parsely_pre_authors'       => false,
+			'wp_parsely_post_authors'      => false,
+			'wp_parsely_custom_taxonomies' => false,
+			'wp_parsely_post_type'         => false,
+		);
+
+		/**
+		 * Fake callback to be used when adding filters.
+		 */
+		$callback_function = function (): bool {
+			return true;
+		};
+
+		foreach ( $filters as $filter_name => $expected_value ) {
+			// Filter is not in use yet, so the result should always be true.
+			self::assertSame(
+				true,
+				( new Parsely() )->get_options()[ $option_key ]
+			);
+
+			// Filter is being used now, so the result should be equal to the
+			// expected value.
+			add_filter( $filter_name, $callback_function );
+			self::assertSame(
+				$expected_value,
+				( new Parsely() )->get_options()[ $option_key ]
+			);
+
+			// Remove the last used filter for the next round.
+			remove_filter( $filter_name, $callback_function );
+		}
+	}
+
+	/**
+	 * Verifies that the full_metadata_in_non_posts option gets set to true when
+	 * it does not exist in the options array.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Parsely::get_options
+	 * @covers \Parsely\Parsely::set_default_full_metadata_in_non_posts
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::set_default_track_as_values
+	 * @uses \Parsely\Parsely::set_managed_options
+	 */
+	public function test_full_metadata_in_non_posts_gets_set_to_true_when_it_does_not_exist_in_options_array(): void {
+		$option_key = 'full_metadata_in_non_posts';
+		$options    = self::$parsely->get_options();
+		unset( $options[ $option_key ] );
+		self::assertSame( true, self::$parsely->get_options()[ $option_key ] );
+	}
+
+	/**
+	 * Verifies that the full_metadata_in_non_posts option gets set to false
+	 * when it does not exist in the options array and a metadata filter is in
+	 * use.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @covers \Parsely\Parsely::get_options
+	 * @covers \Parsely\Parsely::set_default_full_metadata_in_non_posts
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::set_default_track_as_values
+	 * @uses \Parsely\Parsely::set_managed_options
+	 */
+	public function test_full_metadata_in_non_posts_gets_set_to_false_when_it_does_not_exist_in_options_array_and_a_metadata_filter_is_used(): void {
+		$option_key = 'full_metadata_in_non_posts';
+		$options    = self::$parsely->get_options();
+		unset( $options[ $option_key ] );
+		add_filter( 'wp_parsely_metadata', '__return_true' );
+		self::assertSame( false, self::$parsely->get_options()[ $option_key ] );
+	}
+
+	/**
 	 * Verifies that managed options with a value different than null override
 	 * default and saved options.
 	 *
@@ -196,12 +396,13 @@ final class OptionsTest extends TestCase {
 	 * @covers \Parsely\Parsely::get_options
 	 * @covers \Parsely\Parsely::set_managed_options
 	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
 	 * @uses \Parsely\Parsely::are_credentials_managed
 	 * @uses \Parsely\Parsely::get_default_options
 	 * @uses \Parsely\Parsely::get_managed_credentials
 	 * @uses \Parsely\Parsely::sanitize_managed_option
+	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
-	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
 	 * @uses \Parsely\UI\Settings_Page::get_section_taxonomies
 	 */
 	public function test_set_managed_options_override_all_other_option_types(): void {
@@ -238,12 +439,13 @@ final class OptionsTest extends TestCase {
 	 * @covers \Parsely\Parsely::get_options
 	 * @covers \Parsely\Parsely::set_managed_options
 	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
 	 * @uses \Parsely\Parsely::are_credentials_managed
 	 * @uses \Parsely\Parsely::get_default_options
 	 * @uses \Parsely\Parsely::get_managed_credentials
 	 * @uses \Parsely\Parsely::sanitize_managed_option
+	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
-	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
 	 */
 	public function test_null_managed_options_get_their_value_from_the_database_or_defaults(): void {
 		$default_options = self::$parsely->get_default_options();
@@ -280,12 +482,13 @@ final class OptionsTest extends TestCase {
 	 * @covers \Parsely\Parsely::get_options
 	 * @covers \Parsely\Parsely::set_managed_options
 	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
 	 * @uses \Parsely\Parsely::are_credentials_managed
 	 * @uses \Parsely\Parsely::get_default_options
 	 * @uses \Parsely\Parsely::get_managed_credentials
 	 * @uses \Parsely\Parsely::sanitize_managed_option
+	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
-	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
 	 */
 	public function test_certain_options_cannot_be_set_as_managed(): void {
 		add_filter(
@@ -322,11 +525,12 @@ final class OptionsTest extends TestCase {
 	 * @covers \Parsely\Parsely::sanitize_managed_option
 	 * @covers \Parsely\Parsely::set_managed_options
 	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
 	 * @uses \Parsely\Parsely::are_credentials_managed
 	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\UI\Settings_Page::get_section_taxonomies
-	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
 	 *
 	 * @expectedIncorrectUsage sanitize_managed_option
 	 */


### PR DESCRIPTION
## Description
This PR adds a temporary `full_metadata_in_non_posts` option. When it is set to `true`, full metadata will be injected in any content that is being tracked as a non-post.

> This is a temporary measure so customers can upgrade their code to use the new metadata system and set the setting to being enabled. The option will be removed in the future, after which this behavior will be forcefully auto-enabled for all installations.

The reason for this intermediary step is that our testing indicated that adding full metadata to non-posts could result in unexpected metadata or even fatal errors if the metadata was being changed by a filter such as `wp_parsely_metadata`. For this reason, when upgrading to the 3.14 release, this option will be set to:

- `true` if we detect that no metadata-altering filters are called by customer code.
- `false` if we detect that any metadata-altering filters are called by customer code.

This operation will take place only once, when the plugin is upgraded to 3.14 from a prior version, or a new installation of 3.14 or newer is being made. Once this initial setup has been made, the setting is being remembered as any other regular setting, and it must be manually adjusted for its value to change.

The filters that are considered metadata-altering are the following:
- `wp_parsely_metadata`
- `wp_parsely_post_tags`
- `wp_parsely_permalink`
- `wp_parsely_post_category`
- `wp_parsely_pre_authors`
- `wp_parsely_post_authors`
- `wp_parsely_custom_taxonomies`
- `wp_parsely_post_type`

For most cases, the whole operation will be totally transparent, requiring no changes or setting adjustments. However, if any of the above filters are being called by customer code, the setting will need to be enabled manually and tested for any issues or incompatibilities.

## Motivation and context
Related to #1735.

## How has this been tested?
Added several integration tests.

## Screenshots
The following setting has been added to the settings page:
![image](https://github.com/Parsely/wp-parsely/assets/23142906/403ed584-0d89-4c3b-aecb-c43e75cc8a56)