### PR TITLE
PCH: Set some props params as Readonly

### DIFF
--- a/src/content-helper/common/settings/provider.tsx
+++ b/src/content-helper/common/settings/provider.tsx
@@ -127,7 +127,9 @@ interface SettingsProviderProps {
  *
  * @param {SettingsProviderProps} props The component's props.
  */
-export const SettingsProvider = ( { children, endpoint, defaultSettings }: SettingsProviderProps ) => {
+export const SettingsProvider = (
+	{ children, endpoint, defaultSettings }: Readonly<SettingsProviderProps>
+) => {
 	// Get the current settings from the store.
 	const { storedSettings } = useSelect( ( select ) => {
 		let settings = select( SettingsStore ).getSettings( endpoint );

--- a/src/content-helper/common/settings/provider.tsx
+++ b/src/content-helper/common/settings/provider.tsx
@@ -79,15 +79,13 @@ type ReactDeps = React.DependencyList | undefined;
  * @since 3.13.0
  * @since 3.14.0 Moved from `content-helper/common/hooks/useSaveSettings.ts`.
  *
- * @param {string}    endpoint The settings endpoint to send the data to.
- * @param {Settings}  data     The data to send.
- * @param {ReactDeps} deps     The deps array that triggers saving.
+ * @param { string }    endpoint The settings endpoint to send the data to.
+ * @param { Settings }  data     The data to send.
+ * @param { ReactDeps } deps     The deps array that triggers saving.
  */
 const useSaveSettings = (
-	endpoint: string,
-	data: Settings,
-	deps: ReactDeps
-) => {
+	endpoint: string, data: Settings, deps: ReactDeps
+): void => {
 	const isFirstRender = useRef( true );
 
 	useEffect( () => {
@@ -125,11 +123,13 @@ interface SettingsProviderProps {
  *
  * @since 3.14.0
  *
- * @param {SettingsProviderProps} props The component's props.
+ * @param { SettingsProviderProps } props The component's props.
+ *
+ * @return { JSX.Element } The SettingsProvider component.
  */
 export const SettingsProvider = (
 	{ children, endpoint, defaultSettings }: Readonly<SettingsProviderProps>
-) => {
+): JSX.Element => {
 	// Get the current settings from the store.
 	const { storedSettings } = useSelect( ( select ) => {
 		let settings = select( SettingsStore ).getSettings( endpoint );

--- a/src/content-helper/editor-sidebar/tabs/sidebar-tools-tab.tsx
+++ b/src/content-helper/editor-sidebar/tabs/sidebar-tools-tab.tsx
@@ -37,7 +37,9 @@ type SidebarToolsTabProps = {
  *
  * @param { SidebarToolsTabProps } props The component's props.
  */
-export const SidebarToolsTab = ( { trackToggle }: SidebarToolsTabProps ) => {
+export const SidebarToolsTab = (
+	{ trackToggle }: Readonly<SidebarToolsTabProps>
+): JSX.Element => {
 	const { settings, setSettings } = useSettings<SidebarSettings>();
 
 	const [ postData, setPostData ] = useState<SidebarPostData>( {


### PR DESCRIPTION
## Description
This sets a couple of props params as `Readonly`.

## Motivation and context
- Consistency with our other function declarations.
- To be merged into #2238.

## How has this been tested?
No functionality changes, existing tests pass.