### PR TITLE
Make the Suggest Brief API work with array responses

### DIFF
--- a/src/RemoteAPI/content-suggestions/class-suggest-brief-api.php
+++ b/src/RemoteAPI/content-suggestions/class-suggest-brief-api.php
@@ -27,8 +27,8 @@ class Suggest_Brief_API extends Content_Suggestions_Base_API {
 	protected const QUERY_FILTER = 'wp_parsely_suggest_brief_endpoint_args';
 
 	/**
-	 * Gets the brief (meta description) for a given content using the Parse.ly
-	 * Content Suggestion API.
+	 * Gets the first brief (meta description) for a given content using the
+	 * Parse.ly Content Suggestion API.
 	 *
 	 * @since 3.13.0
 	 *
@@ -61,13 +61,13 @@ class Suggest_Brief_API extends Content_Suggestions_Base_API {
 		}
 
 		if ( ! property_exists( $decoded, 'result' ) ||
-			! is_string( $decoded->result ) ) {
+			! is_string( $decoded->result[0] ) ) {
 			return new WP_Error(
 				400,
 				__( 'Unable to parse meta description from upstream API', 'wp-parsely' )
 			);
 		}
 
-		return $decoded->result;
+		return $decoded->result[0];
 	}
 }

--- a/tests/Integration/RemoteAPI/content-suggestions/SuggestBriefAPITest.php
+++ b/tests/Integration/RemoteAPI/content-suggestions/SuggestBriefAPITest.php
@@ -80,7 +80,9 @@ final class SuggestBriefAPITest extends BaseContentSuggestionsAPITest {
 		}
 
 		$response = array(
-			'result' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+			'result' => array(
+				'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+			),
 		);
 
 		return array(


### PR DESCRIPTION
## Description
This PR makes our Suggest Brief API implementation work with the updated response format which returns arrays. `get_suggestion()` still only returns one result and has not be patched to return multiple ones, as this would demand more extensive changes for something we're not using yet.

## Motivation and context
Maintain compatibility and keep the Excerpt Generator working.

## How has this been tested?
- Updated an integration test to return an array instead of a string.
- Manually verified that the Excerpt Generator didn't work when the fix wasn't present, and vice versa.