### PR TITLE
Complete metadata parity between Posts and Non-Posts

### DIFF
--- a/src/Metadata/class-page-builder.php
+++ b/src/Metadata/class-page-builder.php
@@ -52,10 +52,13 @@ class Page_Builder extends Metadata_Builder {
 		$this->build_url();
 
 		if ( true === $this->parsely->get_options()['full_metadata_in_non_posts'] ) {
+			$this->build_type( $this->post, 'non-post' );
+			$this->build_main_entity( 'post' );
 			$this->build_thumbnail_url( $this->post );
 			$this->build_image( $this->post );
 			$this->build_article_section( $this->post );
 			$this->build_author( $this->post );
+			$this->build_publisher();
 			$this->build_keywords( $this->post );
 			$this->build_metadata_post_times( $this->post );
 		}

--- a/src/Metadata/class-post-builder.php
+++ b/src/Metadata/class-post-builder.php
@@ -51,8 +51,8 @@ class Post_Builder extends Metadata_Builder {
 		$this->build_headline();
 		$this->build_url();
 
-		$this->build_type();
-		$this->build_main_entity();
+		$this->build_type( $this->post, 'post' );
+		$this->build_main_entity( 'post' );
 		$this->build_thumbnail_url( $this->post );
 		$this->build_image( $this->post );
 		$this->build_article_section( $this->post );
@@ -80,64 +80,5 @@ class Post_Builder extends Metadata_Builder {
 	 */
 	protected function build_url(): void {
 		$this->metadata['url'] = $this->get_current_url( 'post', $this->post->ID );
-	}
-
-	/**
-	 * Populates the @type field in the metadata object.
-	 *
-	 * @since 3.4.0
-	 */
-	private function build_type(): void {
-		/**
-		 * Filters the JSON-LD @type.
-		 *
-		 * @since 2.5.0
-		 *
-		 * @param string $jsonld_type JSON-LD @type value, default is NewsArticle.
-		 * @param int $id Post ID.
-		 * @param string $post_type The Post type in WordPress.
-		 */
-		$type            = apply_filters( 'wp_parsely_post_type', 'NewsArticle', $this->post->ID, $this->post->post_type );
-		$supported_types = $this->parsely->get_all_supported_types();
-
-		// Validate type before passing it further as an invalid type will not be recognized by Parse.ly.
-		if ( ! in_array( $type, $supported_types, true ) ) {
-			$error = sprintf(
-			/* translators: 1: JSON @type like NewsArticle, 2: URL */
-				__( '@type %1$s is not supported by Parse.ly. Please use a type mentioned in %2$s', 'wp-parsely' ),
-				$type,
-				'https://docs.parse.ly/metadata-jsonld/#distinguishing-between-posts-and-non-posts-pages'
-			);
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-			trigger_error( esc_html( $error ), E_USER_WARNING );
-			$type = 'NewsArticle';
-		}
-
-		$this->metadata['@type'] = $type;
-	}
-
-	/**
-	 * Populates the mainEntityOfPage field in the metadata object.
-	 *
-	 * @since 3.4.0
-	 */
-	private function build_main_entity(): void {
-		$this->metadata['mainEntityOfPage'] = array(
-			'@type' => 'WebPage',
-			'@id'   => $this->get_current_url( 'post' ),
-		);
-	}
-
-	/**
-	 * Populates the publisher field in the metadata object.
-	 *
-	 * @since 3.4.0
-	 */
-	private function build_publisher(): void {
-		$this->metadata['publisher'] = array(
-			'@type' => 'Organization',
-			'name'  => get_bloginfo( 'name' ),
-			'logo'  => $this->parsely->get_options()['logo'],
-		);
 	}
 }

--- a/tests/e2e/specs/front-end-metadata.spec.ts
+++ b/tests/e2e/specs/front-end-metadata.spec.ts
@@ -82,7 +82,7 @@ describe( 'Front end metadata insertion', () => {
 		const content = await page.content();
 
 		expect( content ).toContain( '<script type="application/ld+json">' );
-		expect( content ).toContain( '{"@context":"https:\\/\\/schema.org","@type":"WebPage","headline":"Sample Page","url":"http:\\/\\/localhost:8889\\/?page_id=2","thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"articleSection":"Uncategorized","author":[{"@type":"Person","name":"admin"}],"creator":["admin"],"keywords":[],"' );
+		expect( content ).toContain( '{"@context":"https:\\/\\/schema.org","@type":"WebPage","headline":"Sample Page","url":"http:\\/\\/localhost:8889\\/?page_id=2","mainEntityOfPage":{"@type":"WebPage","@id":"http:\\/\\/localhost:8889\\/?page_id=2"},"thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"articleSection":"Uncategorized","author":[{"@type":"Person","name":"admin"}],"creator":["admin"],"publisher":{"@type":"Organization","name":"wp-parsely","logo":""},"keywords":[],"' );
 
 		expect( content ).not.toContain( '<meta name="parsely-title" ' );
 	} );


### PR DESCRIPTION
## Description
This PR completes the metadata parity project between Posts and Non-Posts. This feature request was reported in #1735 and implementation started in #2220.

## Motivation and context
Non-posts needed to support metadata that was only available for Posts. Full context can be found in #1735.

## How has this been tested?
Existing tests pass and we updated a test that started failing as a result of the changes.