### PR TITLE
Update version number and changelog for 3.14.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.1](https://github.com/Parsely/wp-parsely/compare/3.14.0...3.14.1) - 2024-03-14
+
+### Changed
+
+- PCH Related Posts: Move action icons to the left ([#2291](https://github.com/Parsely/wp-parsely/pull/2291))
+- PCH Related Posts: Check for links in the content by looking for hyperlinks instead ([#2290](https://github.com/Parsely/wp-parsely/pull/2290))
+- PCH Smart Linking: Remove Beta Badge ([#2289](https://github.com/Parsely/wp-parsely/pull/2289))
+- Content Suggestions API: Truncate very large strings on the body params ([#2286](https://github.com/Parsely/wp-parsely/pull/2286))
+
+### Fixed
+
+- PCH Editor Sidebar: Fix some UI glitches ([#2288](https://github.com/Parsely/wp-parsely/pull/2288))
+- PCH Related Posts: Use HTTPS URLs when the site is using HTTPS ([#2287](https://github.com/Parsely/wp-parsely/pull/2287))
+- PCH Smart Linking: Fix issues applying Smart Links ([#2285](https://github.com/Parsely/wp-parsely/pull/2285))
+
+
 ## [3.14.0](https://github.com/Parsely/wp-parsely/compare/3.13.3...3.14.0) - 2024-03-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PCH Related Posts: Use HTTPS URLs when the site is using HTTPS ([#2287](https://github.com/Parsely/wp-parsely/pull/2287))
 - PCH Smart Linking: Fix issues applying Smart Links ([#2285](https://github.com/Parsely/wp-parsely/pull/2285))
 
-
 ## [3.14.0](https://github.com/Parsely/wp-parsely/compare/3.13.3...3.14.0) - 2024-03-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.14.0  
+Stable tag: 3.14.1  
 Requires at least: 5.2  
 Tested up to: 6.4  
 Requires PHP: 7.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.14.0",
+	"version": "3.14.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.14.0",
+			"version": "3.14.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.14.0",
+	"version": "3.14.1",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.14.0';
+export const PLUGIN_VERSION = '3.14.1';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.14.0
+ * Version:           3.14.1
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -69,7 +69,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.14.0';
+const PARSELY_VERSION = '3.14.1';
 const PARSELY_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
This PR updates the plugin's version number and changelog in preparation for the 3.14.1 release.

## Changed

- PCH Related Posts: Move action icons to the left ([#2291](https://github.com/Parsely/wp-parsely/pull/2291))
- PCH Related Posts: Check for links in the content by looking for hyperlinks instead ([#2290](https://github.com/Parsely/wp-parsely/pull/2290))
- PCH Smart Linking: Remove Beta Badge ([#2289](https://github.com/Parsely/wp-parsely/pull/2289))
- Content Suggestions API: Truncate very large strings on the body params ([#2286](https://github.com/Parsely/wp-parsely/pull/2286))

## Fixed

- PCH Editor Sidebar: Fix some UI glitches ([#2288](https://github.com/Parsely/wp-parsely/pull/2288))
- PCH Related Posts: Use HTTPS URLs when the site is using HTTPS ([#2287](https://github.com/Parsely/wp-parsely/pull/2287))
- PCH Smart Linking: Fix issues applying Smart Links ([#2285](https://github.com/Parsely/wp-parsely/pull/2285))

