### PR TITLE
Update version number and changelog for 3.14.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.2](https://github.com/Parsely/wp-parsely/compare/3.14.1...3.14.2) - 2024-03-19
+
+### Changed
+
+- PCH Related Posts: Don't show "Filter By" when not needed ([#2299](https://github.com/Parsely/wp-parsely/pull/2299))
+
+### Fixed
+
+- PCH: Resolve cursor jump to start in Paragraph Blocks upon selection ([#2305](https://github.com/Parsely/wp-parsely/pull/2305))
+- PCH: Fix issue with common styles not being correctly bundled ([#2302](https://github.com/Parsely/wp-parsely/pull/2302))
+- PCH Excerpt Generator: Fix missing styling ([#2300](https://github.com/Parsely/wp-parsely/pull/2300))
+- PCH Editor Sidebar: Fix incorrect AI opt-in message ([#2296](https://github.com/Parsely/wp-parsely/pull/2296))
+
+### Dependency Updates
+
+- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.14.2+label%3A%22Component%3A+Dependencies%22).
+
 ## [3.14.1](https://github.com/Parsely/wp-parsely/compare/3.14.0...3.14.1) - 2024-03-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.14.1  
+Stable tag: 3.14.2  
 Requires at least: 5.2  
 Tested up to: 6.4  
 Requires PHP: 7.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.14.1",
+	"version": "3.14.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.14.1",
+			"version": "3.14.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.14.1",
+	"version": "3.14.2",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.14.1';
+export const PLUGIN_VERSION = '3.14.2';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.14.1
+ * Version:           3.14.2
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -69,7 +69,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.14.1';
+const PARSELY_VERSION = '3.14.2';
 const PARSELY_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
This PR updates the plugin's version number and changelog in preparation for the 3.14.2 release.

## Changed

- PCH Related Posts: Don't show "Filter By" when not needed ([#2299](https://github.com/Parsely/wp-parsely/pull/2299))

## Fixed

- PCH: Resolve cursor jump to start in Paragraph Blocks upon selection ([#2305](https://github.com/Parsely/wp-parsely/pull/2305))
- PCH: Fix issue with common styles not being correctly bundled ([#2302](https://github.com/Parsely/wp-parsely/pull/2302))
- PCH Excerpt Generator: Fix missing styling ([#2300](https://github.com/Parsely/wp-parsely/pull/2300))
- PCH Editor Sidebar: Fix incorrect AI opt-in message ([#2296](https://github.com/Parsely/wp-parsely/pull/2296))

## Dependency Updates

- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.14.2+label%3A%22Component%3A+Dependencies%22).
