### PR TITLE
PCH Smart Linking: Escape API response fields

### DIFF
--- a/src/RemoteAPI/content-suggestions/class-suggest-linked-reference-api.php
+++ b/src/RemoteAPI/content-suggestions/class-suggest-linked-reference-api.php
@@ -75,9 +75,9 @@ class Suggest_Linked_Reference_API extends Content_Suggestions_Base_API {
 		$links = array();
 		foreach ( $decoded->result as $link ) {
 			$link_obj         = new Link_Suggestion();
-			$link_obj->href   = $link->canonical_url;
-			$link_obj->title  = $link->title;
-			$link_obj->text   = $link->text;
+			$link_obj->href   = esc_url( $link->canonical_url );
+			$link_obj->title  = esc_attr( $link->title );
+			$link_obj->text   = wp_kses_post( $link->text );
 			$link_obj->offset = $link->offset;
 			$links[]          = $link_obj;
 		}


### PR DESCRIPTION
## Description
This PR adds some additional escaping to the Content Suggestions API responses, when creating the `Link_Suggestion` object. 

## Motivation and context
Improve the security of the Parse.ly plugin. 

## How has this been tested?
Tested locally, by generating Smart Links on a test post. The output was the same, as expected.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Updates**
	- Enhanced security for content suggestions by sanitizing links, titles, and text to prevent potential vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->