### PR TITLE
Update version number and changelog for 3.14.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.3](https://github.com/Parsely/wp-parsely/compare/3.14.2...3.14.3) - 2024-04-03
+
+### Added
+
+- PCH Smart Linking: Show "No Block Selected" hint when needed ([#2324](https://github.com/Parsely/wp-parsely/pull/2324))
+
+### Changed
+
+- PCH: Update Settings API structure ([#2351](https://github.com/Parsely/wp-parsely/pull/2351))
+- PCH Smart Linking: Update link setting labels for accuracy ([#2349](https://github.com/Parsely/wp-parsely/pull/2349))
+
+### Fixed
+
+- PCH Smart Linking: Escape API response fields ([#2348](https://github.com/Parsely/wp-parsely/pull/2348))
+- Fix isSmall deprecation ([#2326](https://github.com/Parsely/wp-parsely/pull/2326))
+- PCH Smart Linking: Prevent self-linking ([#2325](https://github.com/Parsely/wp-parsely/pull/2325))
+- PCH: Fix some untranslatable strings ([#2323](https://github.com/Parsely/wp-parsely/pull/2323))
+- PCH Smart Linking: Fix issues with undo functionality and link offsets ([#2315](https://github.com/Parsely/wp-parsely/pull/2315))
+
+### Dependency Updates
+
+- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.14.3+label%3A%22Component%3A+Dependencies%22).
+
 ## [3.14.2](https://github.com/Parsely/wp-parsely/compare/3.14.1...3.14.2) - 2024-03-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.14.2  
+Stable tag: 3.14.3  
 Requires at least: 5.2  
 Tested up to: 6.5  
 Requires PHP: 7.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.14.2",
+	"version": "3.14.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.14.2",
+			"version": "3.14.3",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.14.2",
+	"version": "3.14.3",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.14.2';
+export const PLUGIN_VERSION = '3.14.3';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.14.2
+ * Version:           3.14.3
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -69,7 +69,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.14.2';
+const PARSELY_VERSION = '3.14.3';
 const PARSELY_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
This PR updates the plugin's version number and changelog in preparation for the 3.14.3 release.

## Added

- PCH Smart Linking: Show "No Block Selected" hint when needed ([#2324](https://github.com/Parsely/wp-parsely/pull/2324))

## Changed

- PCH: Update Settings API structure ([#2351](https://github.com/Parsely/wp-parsely/pull/2351))
- PCH Smart Linking: Update link setting labels for accuracy ([#2349](https://github.com/Parsely/wp-parsely/pull/2349))

## Fixed

- PCH Smart Linking: Escape API response fields ([#2348](https://github.com/Parsely/wp-parsely/pull/2348))
- Fix isSmall deprecation ([#2326](https://github.com/Parsely/wp-parsely/pull/2326))
- PCH Smart Linking: Prevent self-linking ([#2325](https://github.com/Parsely/wp-parsely/pull/2325))
- PCH: Fix some untranslatable strings ([#2323](https://github.com/Parsely/wp-parsely/pull/2323))
- PCH Smart Linking: Fix issues with undo functionality and link offsets ([#2315](https://github.com/Parsely/wp-parsely/pull/2315))

## Dependency Updates

- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.14.3+label%3A%22Component%3A+Dependencies%22).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced PCH Smart Linking feature with improved Settings API structure and link setting labels.
- **Bug Fixes**
	- Fixed issues in PCH Smart Linking related to escaping API response fields, self-linking prevention, undo functionality, and link offset problems.
	- Addressed the deprecation of `isSmall` and corrected untranslatable strings in PCH.
- **Documentation**
	- Updated README and CHANGELOG for version 3.14.3.
- **Chores**
	- Updated version number to 3.14.3 across various files for consistency.
	- Included dependency updates in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->