### PR TITLE
PCH: Strip all tags from the content sent to the API

### DIFF
--- a/src/RemoteAPI/content-suggestions/class-suggest-brief-api.php
+++ b/src/RemoteAPI/content-suggestions/class-suggest-brief-api.php
@@ -51,7 +51,7 @@ class Suggest_Brief_API extends Content_Suggestions_Base_API {
 				'style'   => $style,
 			),
 			'title'         => $title,
-			'text'          => $content,
+			'text'          => wp_strip_all_tags( $content ),
 		);
 
 		$decoded = $this->post_request( array(), $body );

--- a/src/RemoteAPI/content-suggestions/class-suggest-headline-api.php
+++ b/src/RemoteAPI/content-suggestions/class-suggest-headline-api.php
@@ -48,7 +48,7 @@ class Suggest_Headline_API extends Content_Suggestions_Base_API {
 				'style'     => $tone,
 				'max_items' => $limit,
 			),
-			'text'          => $content,
+			'text'          => wp_strip_all_tags( $content ),
 		);
 
 		$decoded = $this->post_request( array(), $body );

--- a/src/RemoteAPI/content-suggestions/class-suggest-linked-reference-api.php
+++ b/src/RemoteAPI/content-suggestions/class-suggest-linked-reference-api.php
@@ -50,7 +50,7 @@ class Suggest_Linked_Reference_API extends Content_Suggestions_Base_API {
 				'max_link_words' => $max_link_words,
 				'max_items'      => $max_links,
 			),
-			'text'          => $content,
+			'text'          => wp_strip_all_tags( $content ),
 		);
 
 		if ( count( $url_exclusion_list ) > 0 ) {


### PR DESCRIPTION
## Description

The Content Suggestions API expects plain text on its requests, and we're currently sending the full HTML content. This PR strips all the tags from the content right before sending the API request to the API.

## Motivation and context

Improve the reliability of the Parse.ly plugin and make sure that we follow the API recommendations.

## How has this been tested?
Tested locally all the PCH features, and added some extra edge cases to make sure that the returned results are still reliable and returning what's expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced content suggestion features across various APIs to ensure text input is stripped of all HTML tags for cleaner and more secure data handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->