### PR TITLE
Update version number and changelog for 3.14.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix: Make PCH Related Posts filters work for non-admins ([#2467](https://github.com/Parsely/wp-parsely/pull/2467))
 
-
 ## [3.14.4](https://github.com/Parsely/wp-parsely/compare/3.14.3...3.14.4) - 2024-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.5](https://github.com/Parsely/wp-parsely/compare/3.14.4...3.14.5) - 2024-05-09
+
+### Fixed
+
+- Fix: Make PCH Related Posts filters work for non-admins ([#2467](https://github.com/Parsely/wp-parsely/pull/2467))
+
+
 ## [3.14.4](https://github.com/Parsely/wp-parsely/compare/3.14.3...3.14.4) - 2024-05-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.14.4  
+Stable tag: 3.14.5  
 Requires at least: 5.2  
 Tested up to: 6.5  
 Requires PHP: 7.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.14.4",
+	"version": "3.14.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.14.4",
+			"version": "3.14.5",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.14.4",
+	"version": "3.14.5",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.14.4';
+export const PLUGIN_VERSION = '3.14.5';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.14.4
+ * Version:           3.14.5
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -69,7 +69,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.14.4';
+const PARSELY_VERSION = '3.14.5';
 const PARSELY_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
This PR updates the plugin's version number and changelog in preparation for the 3.14.5 release.

## Fixed

- Fix: Make PCH Related Posts filters work for non-admins ([#2467](https://github.com/Parsely/wp-parsely/pull/2467))



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the related posts panel to include author availability checks, improving content filtering for users.
  
- **Bug Fixes**
  - Fixed an issue allowing non-admin users to use PCH Related Posts filters.

- **Documentation**
  - Updated documentation and version references across various files to reflect the new version 3.14.5.

- **Tests**
  - Updated end-to-end tests to use the new plugin version 3.14.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->