### PR TITLE
CSS: Remove unneeded gaps

### DIFF
--- a/src/content-helper/common/components/persona-selector/style.scss
+++ b/src/content-helper/common/components/persona-selector/style.scss
@@ -7,7 +7,6 @@
 	word-break: break-word;
 	height: to_rem(36px);
 	align-items: center;
-	// gap: var(--grid-unit-5);
 	align-self: stretch;
 	border-radius: 2px;
 	border: 1px solid var(--Gutenberg-Gray-600, #949494);
@@ -51,7 +50,6 @@
 		height: to_rem(40px);
 		padding: var(--grid-unit-15) var(--grid-unit-20);
 		align-items: center;
-		// gap: var(--grid-unit-5;
 		align-self: stretch;
 		border-radius: 2px;
 		border: 1px solid var(--Gutenberg-Gray-600, #949494);

--- a/src/content-helper/common/components/tone-selector/style.scss
+++ b/src/content-helper/common/components/tone-selector/style.scss
@@ -6,7 +6,6 @@
 	word-break: break-word;
 	height: to_rem(36px);
 	align-items: center;
-	// gap: var(--grid-unit-5);
 	align-self: stretch;
 	border-radius: 2px;
 	border: 1px solid var(--Gutenberg-Gray-600, #949494);
@@ -55,7 +54,6 @@
 		height: to_rem(40px);
 		padding: var(--grid-unit-15) var(--grid-unit-20);
 		align-items: center;
-		// gap: var(--grid-unit-5);
 		align-self: stretch;
 		border-radius: 2px;
 		border: 1px solid var(--Gutenberg-Gray-600, #949494);

--- a/src/content-helper/common/css/common.scss
+++ b/src/content-helper/common/css/common.scss
@@ -74,12 +74,6 @@
 	.components-panel__body-title {
 		display: flex;
 		align-items: center;
-
-		/**
-		 * TODO: If no UI glitches are observed, remove commented gaps in all
-		 * SCSS files.
-		 */
-		// gap: var(--grid-unit-10);
 		align-self: stretch;
 		margin: 0 to_rem(-16px) to_rem(6px);
 		padding: 0;

--- a/src/content-helper/editor-sidebar/related-posts/related-posts.scss
+++ b/src/content-helper/editor-sidebar/related-posts/related-posts.scss
@@ -164,7 +164,6 @@
 					display: flex;
 					padding: 0 var(--grid-unit-10);
 					align-items: center;
-					// gap: var(--grid-unit-20);
 					align-self: stretch;
 					flex-wrap: wrap;
 					border-top: 1px solid var(--gray-400);

--- a/src/content-helper/editor-sidebar/title-suggestions/title-suggestions.scss
+++ b/src/content-helper/editor-sidebar/title-suggestions/title-suggestions.scss
@@ -128,7 +128,6 @@
 			display: flex;
 			padding: 0 var(--grid-unit-10);
 			align-items: center;
-			// gap: var(--grid-unit-20);
 			align-self: stretch;
 			flex-wrap: wrap;
 			border-top: 1px solid var(--Gutenberg-Gray-400, #ccc);


### PR DESCRIPTION
## Description
In https://github.com/Parsely/wp-parsely/pull/2314, we commented some gaps in our CSS, which had no apparent visual impact. We commented them instead of outright deleting them just in case we needed to restore any of them later.

So far we haven't noticed any visual glitches, so I'm assuming they can be removed. We can always look into this PR if we notice anything strange, to see what should be restored.

## Motivation and context
- Remove unneeded code.
- Closes #2399.

## How has this been tested?
As stated before, no visual glitches have been noticed while using PCH features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved visual consistency and spacing across various components by cleaning up unused CSS properties in the style sheets for persona selector, tone selector, common styles, related posts, and title suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->