### PR TITLE
Update version number and changelog for 3.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.15.0](https://github.com/Parsely/wp-parsely/compare/3.14.5...3.15.0) - 2024-05-14
+
+### Changed
+
+- Update minimum node and npm versions ([#2475](https://github.com/Parsely/wp-parsely/pull/2475))
+- PCH: Strip all tags from the content sent to the API ([#2431](https://github.com/Parsely/wp-parsely/pull/2431))
+- PCH Editor Sidebar: Update isDismissible in Notices ([#2428](https://github.com/Parsely/wp-parsely/pull/2428))
+- PCH: Enhance Request Handling in Provider Classes ([#2401](https://github.com/Parsely/wp-parsely/pull/2401))
+- PCH Smart Linking: Allow API retry when there are upstream errors ([#2386](https://github.com/Parsely/wp-parsely/pull/2386))
+
+### Fixed
+
+- Fix removeEditorPanel() deprecation message in WordPress 6.5 ([#2398](https://github.com/Parsely/wp-parsely/pull/2398))
+- EmptyCredentialsMessage: Fix empty error ([#2397](https://github.com/Parsely/wp-parsely/pull/2397))
+
+### Dependency Updates
+
+- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.15.0+label%3A%22Component%3A+Dependencies%22).
+
 ## [3.14.5](https://github.com/Parsely/wp-parsely/compare/3.14.4...3.14.5) - 2024-05-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.14.5  
+Stable tag: 3.15.0  
 Requires at least: 5.2  
 Tested up to: 6.5  
 Requires PHP: 7.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.14.5",
+	"version": "3.15.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.14.5",
+			"version": "3.15.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.14.5",
+	"version": "3.15.0",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -7,7 +7,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.14.5';
+export const PLUGIN_VERSION = '3.15.0';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.14.5
+ * Version:           3.15.0
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -69,7 +69,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.14.5';
+const PARSELY_VERSION = '3.15.0';
 const PARSELY_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/class-parsely.php';


### PR DESCRIPTION
This PR updates the plugin's version number and changelog in preparation for the 3.15.0 release.

## Changed

- Update minimum node and npm versions ([#2475](https://github.com/Parsely/wp-parsely/pull/2475))
- PCH: Strip all tags from the content sent to the API ([#2431](https://github.com/Parsely/wp-parsely/pull/2431))
- PCH Editor Sidebar: Update isDismissible in Notices ([#2428](https://github.com/Parsely/wp-parsely/pull/2428))
- PCH: Enhance Request Handling in Provider Classes ([#2401](https://github.com/Parsely/wp-parsely/pull/2401))
- PCH Smart Linking: Allow API retry when there are upstream errors ([#2386](https://github.com/Parsely/wp-parsely/pull/2386))

## Fixed

- Fix removeEditorPanel() deprecation message in WordPress 6.5 ([#2398](https://github.com/Parsely/wp-parsely/pull/2398))
- EmptyCredentialsMessage: Fix empty error ([#2397](https://github.com/Parsely/wp-parsely/pull/2397))

## Dependency Updates

- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.15.0+label%3A%22Component%3A+Dependencies%22).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced request handling in provider classes.
  - API retry mechanism for upstream errors.

- **Bug Fixes**
  - Fixed deprecation messages in WordPress 6.5.
  - Addressed issue with empty error in `EmptyCredentialsMessage`.

- **Improvements**
  - Stripped all tags from content sent to the API.
  - Updated minimum Node.js and npm versions.

- **Version Updates**
  - Updated version to 3.15.0 across various files and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->