### PR TITLE
Inject post ID into LD-JSON metadata

### DIFF
--- a/src/Metadata/class-metadata-builder.php
+++ b/src/Metadata/class-metadata-builder.php
@@ -688,4 +688,15 @@ abstract class Metadata_Builder {
 
 		return $all_values;
 	}
+
+	/**
+	 * Populates all the fields related to post ID.
+	 *
+	 * @param WP_Post $post The post/page for which to populate the field.
+	 *
+	 * @since 3.0.x
+	 */
+	protected function build_post_ids( WP_Post $post ): void {
+		$this->metadata['postID']   = $post->ID;
+	}
 }

--- a/src/Metadata/class-metadata-builder.php
+++ b/src/Metadata/class-metadata-builder.php
@@ -697,6 +697,6 @@ abstract class Metadata_Builder {
 	 * @since 3.0.x
 	 */
 	protected function build_post_ids( WP_Post $post ): void {
-		$this->metadata['postID']   = $post->ID;
+		$this->metadata['postID'] = $post->ID;
 	}
 }

--- a/src/Metadata/class-post-builder.php
+++ b/src/Metadata/class-post-builder.php
@@ -60,6 +60,7 @@ class Post_Builder extends Metadata_Builder {
 		$this->build_publisher();
 		$this->build_keywords( $this->post );
 		$this->build_metadata_post_times( $this->post );
+		$this->build_post_ids( $this->post );
 
 		return $this->metadata;
 	}

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -404,7 +404,7 @@ final class RestMetadataTest extends TestCase {
 		$this->go_to( (string) $this->get_permalink( $post_id ) );
 
 		$meta_string = self::$rest->get_rendered_meta( 'json_ld' );
-		$expected    = '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"NewsArticle","headline":"My test_get_rendered_meta_json_ld title","url":"http:\/\/example.org\/?p=' . $post_id . '","mainEntityOfPage":{"@type":"WebPage","@id":"http:\/\/example.org\/?p=' . $post_id . '"},"thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"articleSection":"Uncategorized","author":[],"creator":[],"publisher":{"@type":"Organization","name":"Test Blog","logo":""},"keywords":[],"dateCreated":"' . $date . '","datePublished":"' . $date . '","dateModified":"' . $date . '","postID":"' . $post_id . '"}</script>';
+		$expected    = '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"NewsArticle","headline":"My test_get_rendered_meta_json_ld title","url":"http:\/\/example.org\/?p=' . $post_id . '","mainEntityOfPage":{"@type":"WebPage","@id":"http:\/\/example.org\/?p=' . $post_id . '"},"thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"articleSection":"Uncategorized","author":[],"creator":[],"publisher":{"@type":"Organization","name":"Test Blog","logo":""},"keywords":[],"dateCreated":"' . $date . '","datePublished":"' . $date . '","dateModified":"' . $date . '","postID":' . $post_id . '}</script>';
 		self::assertSame( $expected, $meta_string );
 	}
 

--- a/tests/Integration/Endpoints/RestMetadataTest.php
+++ b/tests/Integration/Endpoints/RestMetadataTest.php
@@ -404,7 +404,7 @@ final class RestMetadataTest extends TestCase {
 		$this->go_to( (string) $this->get_permalink( $post_id ) );
 
 		$meta_string = self::$rest->get_rendered_meta( 'json_ld' );
-		$expected    = '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"NewsArticle","headline":"My test_get_rendered_meta_json_ld title","url":"http:\/\/example.org\/?p=' . $post_id . '","mainEntityOfPage":{"@type":"WebPage","@id":"http:\/\/example.org\/?p=' . $post_id . '"},"thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"articleSection":"Uncategorized","author":[],"creator":[],"publisher":{"@type":"Organization","name":"Test Blog","logo":""},"keywords":[],"dateCreated":"' . $date . '","datePublished":"' . $date . '","dateModified":"' . $date . '"}</script>';
+		$expected    = '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"NewsArticle","headline":"My test_get_rendered_meta_json_ld title","url":"http:\/\/example.org\/?p=' . $post_id . '","mainEntityOfPage":{"@type":"WebPage","@id":"http:\/\/example.org\/?p=' . $post_id . '"},"thumbnailUrl":"","image":{"@type":"ImageObject","url":""},"articleSection":"Uncategorized","author":[],"creator":[],"publisher":{"@type":"Organization","name":"Test Blog","logo":""},"keywords":[],"dateCreated":"' . $date . '","datePublished":"' . $date . '","dateModified":"' . $date . '","postID":"' . $post_id . '"}</script>';
 		self::assertSame( $expected, $meta_string );
 	}
 


### PR DESCRIPTION
<!--
Hello! Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!
-->

## Description
Injecting post IDs will let Parsely link back to the edit form of the post.

<!-- Describe your changes in detail. -->

## Motivation and context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran too. -->
<!-- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)
<!-- Any screenshot(s) demonstrating the result of this PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added post ID field to metadata for better identification and tracking of posts.

- **Bug Fixes**
  - Ensured post IDs are correctly populated in metadata.

- **Tests**
  - Updated integration tests to verify the inclusion of post ID in the metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->