### PR TITLE
Revert to using babel-preset-default v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"@types/wordpress__wordcount": "^2.4.5",
 				"@typescript-eslint/eslint-plugin": "^6.21.0",
 				"@wordpress/api-fetch": "^7.0.0",
-				"@wordpress/babel-preset-default": "^8.0.0",
+				"@wordpress/babel-preset-default": "^7.42.0",
 				"@wordpress/block-editor": "^13.0.0",
 				"@wordpress/blocks": "^13.0.0",
 				"@wordpress/components": "^28.0.0",
@@ -7363,9 +7363,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.0.0.tgz",
-			"integrity": "sha512-0/UBnS9I9gYfhMgB6wsKgvLG8oCdTLVeyqNHtlarjt0q5jVMEI1keXfVbkgxtXwg3KAr49DwLx0dc8PzU0HhAw==",
+			"version": "7.42.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.42.0.tgz",
+			"integrity": "sha512-AWSxWuEuzazt/nWomKiaVhYQeXuqxTniPCKhvks58wB3P4UXvSe3hRnO+nujz20IuxIk2xHT6x47HgpDZy30jw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.16.0",
@@ -7374,35 +7374,15 @@
 				"@babel/preset-env": "^7.16.0",
 				"@babel/preset-typescript": "^7.16.0",
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/browserslist-config": "^6.0.0",
-				"@wordpress/warning": "^3.0.0",
+				"@wordpress/babel-plugin-import-jsx-pragma": "^4.41.0",
+				"@wordpress/browserslist-config": "^5.41.0",
+				"@wordpress/warning": "^2.58.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
 			},
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/babel-preset-default/node_modules/@wordpress/browserslist-config": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.0.0.tgz",
-			"integrity": "sha512-7MGNySnaDpM+w/Wld4agavDKTOqDM1+fs5eUVmFNfkdfz8MLRukhiFhMt/iJLsmj1wEdUv1/LcDfz9uWUqvc6g==",
-			"dev": true,
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/babel-preset-default/node_modules/@wordpress/warning": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.0.0.tgz",
-			"integrity": "sha512-vZ7SH4lwnwglsZC+5dmrMJS/9lZXn7BvADC+ZHzrRM0s6Ufumi1RdG0QJr/HJuTRY9fX5bbPNdUQVyrv+weSEg==",
-			"dev": true,
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": ">=14"
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
@@ -11543,6 +11523,39 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/babel-preset-default": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.0.0.tgz",
+			"integrity": "sha512-0/UBnS9I9gYfhMgB6wsKgvLG8oCdTLVeyqNHtlarjt0q5jVMEI1keXfVbkgxtXwg3KAr49DwLx0dc8PzU0HhAw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.16.0",
+				"@babel/plugin-transform-react-jsx": "^7.16.0",
+				"@babel/plugin-transform-runtime": "^7.16.0",
+				"@babel/preset-env": "^7.16.0",
+				"@babel/preset-typescript": "^7.16.0",
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/browserslist-config": "^6.0.0",
+				"@wordpress/warning": "^3.0.0",
+				"browserslist": "^4.21.10",
+				"core-js": "^3.31.0",
+				"react": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/browserslist-config": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.0.0.tgz",
+			"integrity": "sha512-7MGNySnaDpM+w/Wld4agavDKTOqDM1+fs5eUVmFNfkdfz8MLRukhiFhMt/iJLsmj1wEdUv1/LcDfz9uWUqvc6g==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/prettier-config": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.0.0.tgz",
@@ -11554,6 +11567,16 @@
 			},
 			"peerDependencies": {
 				"prettier": ">=3"
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/warning": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.0.0.tgz",
+			"integrity": "sha512-vZ7SH4lwnwglsZC+5dmrMJS/9lZXn7BvADC+ZHzrRM0s6Ufumi1RdG0QJr/HJuTRY9fX5bbPNdUQVyrv+weSEg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-jest": {
@@ -13535,29 +13558,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/@wordpress/babel-preset-default": {
-			"version": "7.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.42.0.tgz",
-			"integrity": "sha512-AWSxWuEuzazt/nWomKiaVhYQeXuqxTniPCKhvks58wB3P4UXvSe3hRnO+nujz20IuxIk2xHT6x47HgpDZy30jw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.16.0",
-				"@babel/plugin-transform-react-jsx": "^7.16.0",
-				"@babel/plugin-transform-runtime": "^7.16.0",
-				"@babel/preset-env": "^7.16.0",
-				"@babel/preset-typescript": "^7.16.0",
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/babel-plugin-import-jsx-pragma": "^4.41.0",
-				"@wordpress/browserslist-config": "^5.41.0",
-				"@wordpress/warning": "^2.58.0",
-				"browserslist": "^4.21.10",
-				"core-js": "^3.31.0",
-				"react": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"@types/wordpress__wordcount": "^2.4.5",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",
 		"@wordpress/api-fetch": "^7.0.0",
-		"@wordpress/babel-preset-default": "^8.0.0",
+		"@wordpress/babel-preset-default": "^7.42.0",
 		"@wordpress/block-editor": "^13.0.0",
 		"@wordpress/blocks": "^13.0.0",
 		"@wordpress/components": "^28.0.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,10 @@
 		"ts-loader": "^9.5.1",
 		"typescript": "^5.4.5"
 	},
+	"devDependenciesComments": {
+		"@wordpress/babel-preset-default": "Don't upgrade to v8 or greater until the plugin requires WordPress 6.6. See https://github.com/WordPress/gutenberg/pull/62265/files",
+		"@wordpress/scripts": "Don't upgrade to v28 or greater until the plugin requires WordPress 6.6. See https://github.com/WordPress/gutenberg/pull/62265/files"
+	},
 	"scripts": {
 		"build": "wp-scripts build",
 		"dev:logs": "wp-env logs",


### PR DESCRIPTION
We're reverting to the previously used version of `babel-preset-default` because of certain issues. See https://github.com/WordPress/gutenberg/pull/62265/files for related information.

Effectively, we cannot use `@wordpress/babel-preset-default` v8 or greater and `@wordpress/scrips` v28 or greater until we require WordPress 6.6 as the minimum version in the plugin.

This PR reverts Parsely/wp-parsely#2532 and adds a couple of related comments in `package.json` for future reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of `@wordpress/babel-preset-default` to `^7.42.0`.
  - Added comments to clarify version constraints for `@wordpress/babel-preset-default` and `@wordpress/scripts` until WordPress 6.6 is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->