### PR TITLE
PCH Smart Linking: Remove feature filter

### DIFF
--- a/src/content-helper/common/class-content-helper-feature.php
+++ b/src/content-helper/common/class-content-helper-feature.php
@@ -91,8 +91,16 @@ abstract class Content_Helper_Feature {
 	 */
 	protected function can_enable_feature( bool ...$conditions ): bool {
 		// Get filter values.
-		$global  = apply_filters( self::get_global_filter_name(), null ); // phpcs:ignore
-		$feature = apply_filters( static::get_feature_filter_name(), null ); // phpcs:ignore
+		$global  = null;
+		$feature = null;
+
+		if ( '' !== self::get_global_filter_name() ) {
+			$global  = apply_filters( self::get_global_filter_name(), null ); // phpcs:ignore
+		}
+
+		if ( '' !== static::get_feature_filter_name() ) {
+			$feature = apply_filters( static::get_feature_filter_name(), null ); // phpcs:ignore
+		}
 
 		// If not set, the feature filter will get its value from the global
 		// filter.

--- a/src/content-helper/editor-sidebar/smart-linking/class-smart-linking.php
+++ b/src/content-helper/editor-sidebar/smart-linking/class-smart-linking.php
@@ -44,7 +44,7 @@ class Smart_Linking extends Content_Helper_Feature {
 	 * @return string The filter name.
 	 */
 	public static function get_feature_filter_name(): string {
-		return self::get_global_filter_name() . '_smart_linking';
+		return ''; // Not in use for this feature.
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR removes the feature filter - `wp_parsely_enable_content_helper_smart_linking` - from the Smart Linking feature. This filter was only disabling the Smart Linking on the server-side, and therefore the UI was still available.

Since enabling and disabling individual features is now supported in the settings page, this filter is not really required, as it never really worked correctly.

## Motivation and context
Improved codebase by avoiding having unused/non-functional filters available. 

## How has this been tested?
Tested manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved feature enablement logic to ensure correct initialization and application of filters.
  - Modified filter name handling to prevent errors by returning an empty string where necessary.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->