### PR TITLE
Update version number and changelog for 3.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.0](https://github.com/Parsely/wp-parsely/compare/3.15.0...3.16.0) - 2024-07-08
+
+### Added
+
+- Content Helper: Implement AI feature permissions ([#2604](https://github.com/Parsely/wp-parsely/pull/2604))
+- Settings page: Add "Content Helper" tab ([#2554](https://github.com/Parsely/wp-parsely/pull/2554))
+- PCH Smart Linking: Add Inbound Smart Links support  ([#2553](https://github.com/Parsely/wp-parsely/pull/2553))
+- PCH Smart Linking: Add Smart Linking back-end ([#2544](https://github.com/Parsely/wp-parsely/pull/2544))
+- PCH Smart Linking: Implement Smart Links Reviewing step ([#2507](https://github.com/Parsely/wp-parsely/pull/2507))
+
+### Changed
+
+- PCH: Initialize Content Helper features on 'rest_api_init' ([#2606](https://github.com/Parsely/wp-parsely/pull/2606))
+- PCH Sidebar: Move initialization to admin_init ([#2578](https://github.com/Parsely/wp-parsely/pull/2578))
+- PCH Excerpt Suggestions: Allow editing when reviewing ([#2506](https://github.com/Parsely/wp-parsely/pull/2506))
+
+### Removed
+
+- PCH Smart Linking: Remove Link Length option from the UI ([#2508](https://github.com/Parsely/wp-parsely/pull/2508))
+
+### Fixed
+
+- Fix some untranslatable strings ([#2612](https://github.com/Parsely/wp-parsely/pull/2612))
+- PCH: Fix potential fatal with 'enqueue_settings_assets' strict parameter ([#2610](https://github.com/Parsely/wp-parsely/pull/2610))
+- PCH Excerpt Suggestions: Improve error handling ([#2609](https://github.com/Parsely/wp-parsely/pull/2609))
+- Content Helper: Fix non-dismissible Notices ([#2600](https://github.com/Parsely/wp-parsely/pull/2600))
+- ContentHelperError: Avoid double prefix in error messages ([#2580](https://github.com/Parsely/wp-parsely/pull/2580))
+- PCH Sidebar: Show detailed error messages in Snackbar Notices ([#2579](https://github.com/Parsely/wp-parsely/pull/2579))
+- PCH Smart Linking: Prevent duplicate Smart Links ([#2571](https://github.com/Parsely/wp-parsely/pull/2571))
+- PCH Smart Linking: Prevent Smart Linking from running on Freeform (Classic) blocks ([#2570](https://github.com/Parsely/wp-parsely/pull/2570))
+- PCH Smart Linking: Fix issue when processing a single block ([#2547](https://github.com/Parsely/wp-parsely/pull/2547))
+
+### Dependency Updates
+
+- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.16.0+label%3A%22Component%3A+Dependencies%22).
+
 ## [3.15.0](https://github.com/Parsely/wp-parsely/compare/3.14.5...3.15.0) - 2024-05-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.15.0  
+Stable tag: 3.16.0  
 Requires at least: 5.2  
 Tested up to: 6.5  
 Requires PHP: 7.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.15.0",
+	"version": "3.16.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.15.0",
+			"version": "3.16.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.15.0",
+	"version": "3.16.0",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -7,7 +7,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.15.0';
+export const PLUGIN_VERSION = '3.16.0';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.15.0
+ * Version:           3.16.0
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -70,7 +70,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.15.0';
+const PARSELY_VERSION = '3.16.0';
 const PARSELY_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/Models/class-base-model.php';


### PR DESCRIPTION
This PR updates the plugin's version number and changelog in preparation for the 3.16.0 release.

## Added

- Content Helper: Implement AI feature permissions ([#2604](https://github.com/Parsely/wp-parsely/pull/2604))
- Settings page: Add "Content Helper" tab ([#2554](https://github.com/Parsely/wp-parsely/pull/2554))
- PCH Smart Linking: Add Inbound Smart Links support  ([#2553](https://github.com/Parsely/wp-parsely/pull/2553))
- PCH Smart Linking: Add Smart Linking back-end ([#2544](https://github.com/Parsely/wp-parsely/pull/2544))
- PCH Smart Linking: Implement Smart Links Reviewing step ([#2507](https://github.com/Parsely/wp-parsely/pull/2507))

## Changed

- PCH: Initialize Content Helper features on 'rest_api_init' ([#2606](https://github.com/Parsely/wp-parsely/pull/2606))
- PCH Sidebar: Move initialization to admin_init ([#2578](https://github.com/Parsely/wp-parsely/pull/2578))
- PCH Excerpt Suggestions: Allow editing when reviewing ([#2506](https://github.com/Parsely/wp-parsely/pull/2506))

## Removed

- PCH Smart Linking: Remove Link Length option from the UI ([#2508](https://github.com/Parsely/wp-parsely/pull/2508))

## Fixed

- Fix some untranslatable strings ([#2612](https://github.com/Parsely/wp-parsely/pull/2612))
- PCH: Fix potential fatal with 'enqueue_settings_assets' strict parameter ([#2610](https://github.com/Parsely/wp-parsely/pull/2610))
- PCH Excerpt Suggestions: Improve error handling ([#2609](https://github.com/Parsely/wp-parsely/pull/2609))
- Content Helper: Fix non-dismissible Notices ([#2600](https://github.com/Parsely/wp-parsely/pull/2600))
- ContentHelperError: Avoid double prefix in error messages ([#2580](https://github.com/Parsely/wp-parsely/pull/2580))
- PCH Sidebar: Show detailed error messages in Snackbar Notices ([#2579](https://github.com/Parsely/wp-parsely/pull/2579))
- PCH Smart Linking: Prevent duplicate Smart Links ([#2571](https://github.com/Parsely/wp-parsely/pull/2571))
- PCH Smart Linking: Prevent Smart Linking from running on Freeform (Classic) blocks ([#2570](https://github.com/Parsely/wp-parsely/pull/2570))
- PCH Smart Linking: Fix issue when processing a single block ([#2547](https://github.com/Parsely/wp-parsely/pull/2547))

## Dependency Updates

- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.16.0+label%3A%22Component%3A+Dependencies%22).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added AI feature permissions.
  - Introduced a "Content Helper" tab in the settings page.
  - Added support for Smart Linking.

- **Changes**
  - Initialized Content Helper features differently.
  - Moved initialization for the PCH Sidebar.
  - Allowed editing during Smart Links Reviewing.
  - Removed the Link Length option from the UI.

- **Bug Fixes**
  - Fixed non-dismissible notices.
  - Improved error message handling.
  - Prevented duplicate Smart Links.
  - Fixed issues with Smart Linking in specific blocks.

- **Version Updates**
  - Updated version to 3.16.0 across various files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->