### PR TITLE
Permissions: Fix PHP Warning when the user role is invalid

### DIFF
--- a/src/class-permissions.php
+++ b/src/class-permissions.php
@@ -86,6 +86,11 @@ class Permissions {
 			return false;
 		}
 
+		// Current user's role is not set correctly.
+		if ( ! isset( $current_user->roles[0] ) ) {
+			return false;
+		}
+
 		// Check that the user's role has the capability to edit posts.
 		$current_user_role = $current_user->roles[0];
 		$valid_roles       = array_keys( self::get_user_roles_with_edit_posts_cap() );

--- a/src/class-permissions.php
+++ b/src/class-permissions.php
@@ -80,32 +80,31 @@ class Permissions {
 			return false;
 		}
 
-		// Current user's role is not yet set.
 		$current_user = wp_get_current_user();
-		if ( 0 === count( $current_user->roles ) ) {
+		$user_roles   = $current_user->roles;
+
+		// Current user's role is not yet set.
+		if ( 0 === count( $user_roles ) ) {
 			return false;
 		}
 
-		// Current user's role is not set correctly.
-		if ( ! isset( $current_user->roles[0] ) ) {
+		// Get the roles with the capability to edit posts.
+		$valid_roles = array_keys( self::get_user_roles_with_edit_posts_cap() );
+
+		// Check that at least one of the user's roles has the capability to edit posts.
+		if ( 0 === count( array_intersect( $user_roles, $valid_roles ) ) ) {
 			return false;
 		}
 
-		// Check that the user's role has the capability to edit posts.
-		$current_user_role = $current_user->roles[0];
-		$valid_roles       = array_keys( self::get_user_roles_with_edit_posts_cap() );
-		if ( ! in_array( $current_user_role, $valid_roles, true ) ) {
-			return false;
-		}
-
-		// Check that the user's role has access to the specific feature/post.
+		// Check that at least one of the user's roles has access to the specific feature/post.
 		$allowed_roles = $feature_options['allowed_user_roles'];
-		if ( in_array( $current_user_role, $allowed_roles, true ) ) {
-			if ( (int) $post_id > 0 ) {
-				return current_user_can( 'edit_post', $post_id );
-			}
+		if ( 0 === count( array_intersect( $user_roles, $allowed_roles ) ) ) {
+			return false;
+		}
 
-			return true;
+		// Check if the user can edit the post.
+		if ( (int) $post_id > 0 ) {
+			return current_user_can( 'edit_post', $post_id );
 		}
 
 		return false;


### PR DESCRIPTION
## Description

There are certain scenarios where the user role might be invalid - the role has been deleted, for example - and therefore, the roles array in the `WP_User` object might not have any data on the `0` index.

This PR adds an additional validation that checks if this array key is set, and if not, returns false.

This prevents an issue where a `Warning: Undefined array key 0` warning can be thrown if there is no valid role associated with the user.

## Motivation and context
Improve the reliability of the plugin's codebase and prevent PHP errors and warnings from filling the logs.

## How has this been tested?
Manually tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the user role setting check before verifying post edit capabilities, ensuring proper permission handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->