### PR TITLE
PCH Smart Linking: Use the post title as the Smart Link title.

### DIFF
--- a/src/Models/class-smart-link.php
+++ b/src/Models/class-smart-link.php
@@ -128,7 +128,14 @@ class Smart_Link extends Base_Model {
 		int $post_id = 0
 	) {
 		$this->set_href( $href );
-		$this->title          = $title;
+
+		// Set the title to be the destination post title if the destination post ID is set.
+		if ( 0 !== $this->destination_post_id ) {
+			$this->title = get_the_title( $this->destination_post_id );
+		} else {
+			$this->title = $title;
+		}
+
 		$this->text           = $text;
 		$this->offset         = $offset;
 		$this->source_post_id = $post_id;


### PR DESCRIPTION
## Description

This PR improves the Smart Link title returned by the Content Suggestions API. Previously, the title was retrieved from the post title stored in the vector database, which is in lowercase. Now, the Smart Link will use the destination post title if a valid post object is found using the canonical URL/permalink.

## Motivation and context

Improve the quality of the Smart Links attributes.

## How has this been tested?
Tested locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved title setting for smart links to ensure accurate display based on the destination post ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->