### PR TITLE
PCH Smart Linking: Fix permission check typo

### DIFF
--- a/src/class-permissions.php
+++ b/src/class-permissions.php
@@ -107,7 +107,7 @@ class Permissions {
 			return current_user_can( 'edit_post', $post_id );
 		}
 
-		return false;
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR fixes a typo from #2649, where the last return value is `false`, where it should be `true`.

## Motivation and context
Fix the Smart Linking functionality

## How has this been tested?
Tested locally, with a user with two roles.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the `SmartLink` class to dynamically set the `title` based on the `destination_post_id`.

- **Refactor**
  - Improved code readability and maintainability in the `current_user_can_use_pch_feature` function by restructuring user role and capability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->