### PR TITLE
PCH Performance Stats: Remove UTM parameters from the 'View in Parse.ly' button

### DIFF
--- a/src/class-dashboard-link.php
+++ b/src/class-dashboard-link.php
@@ -25,6 +25,7 @@ class Dashboard_Link {
 	 *
 	 * @since 2.6.0
 	 * @since 3.1.0 Moved to class-dashboard-link.php. Added source parameter.
+	 * @since 3.16.1 Made the $campaign and $source parameters optional.
 	 *
 	 * @param WP_Post $post   Which post object or ID to check.
 	 * @param string  $site_id Site ID or empty string.
@@ -32,7 +33,7 @@ class Dashboard_Link {
 	 * @param string  $source Source name for the `utm_source` URL parameter.
 	 * @return string
 	 */
-	public static function generate_url( WP_Post $post, string $site_id, string $campaign, string $source ): string {
+	public static function generate_url( WP_Post $post, string $site_id, string $campaign = '', string $source = '' ): string {
 		/**
 		 * Internal variable.
 		 *
@@ -49,6 +50,18 @@ class Dashboard_Link {
 			'utm_source'   => $source,
 			'utm_medium'   => 'wp-parsely',
 		);
+
+		if ( '' === $campaign ) {
+			unset( $query_args['utm_campaign'] );
+		}
+
+		if ( '' === $source ) {
+			unset( $query_args['utm_source'] );
+		}
+
+		if ( ! isset( $query_args['utm_campaign'] ) && ! isset( $query_args['utm_source'] ) ) {
+			unset( $query_args['utm_medium'] );
+		}
 
 		return add_query_arg( $query_args, Parsely::get_dash_url( $site_id ) );
 	}

--- a/src/content-helper/editor-sidebar/class-editor-sidebar.php
+++ b/src/content-helper/editor-sidebar/class-editor-sidebar.php
@@ -95,11 +95,13 @@ class Editor_Sidebar extends Content_Helper_Feature {
 	 * Returns the Parse.ly post dashboard URL for the current post.
 	 *
 	 * @since 3.14.0
+	 * @since 3.16.1 Added the $show_utm_params parameter.
 	 *
 	 * @param int|null|WP_Post $post_id The post ID or post object. Default is the current post.
+	 * @param bool             $show_utm_params Whether to show UTM parameters in the URL.
 	 * @return string|null The Parse.ly post dashboard URL, or false if the post ID is invalid.
 	 */
-	private function get_parsely_post_url( $post_id = null ): ?string {
+	private function get_parsely_post_url( $post_id = null, bool $show_utm_params = true ): ?string {
 		// Get permalink for the post.
 		$post_id = $post_id ?? get_the_ID();
 		if ( false === $post_id ) {
@@ -115,6 +117,10 @@ class Editor_Sidebar extends Content_Helper_Feature {
 
 		if ( ! Dashboard_Link::can_show_link( $post, $this->parsely ) ) {
 			return null;
+		}
+
+		if ( ! $show_utm_params ) {
+			return Dashboard_Link::generate_url( $post, $this->parsely->get_site_id() );
 		}
 
 		return Dashboard_Link::generate_url( $post, $this->parsely->get_site_id(), 'wp-page-single', 'editor-sidebar' );
@@ -159,8 +165,8 @@ class Editor_Sidebar extends Content_Helper_Feature {
 
 		$this->inject_inline_scripts( Editor_Sidebar_Settings_Endpoint::get_route() );
 
-		// Inject inline variables for the editor sidebar.
-		$parsely_post_url = $this->get_parsely_post_url();
+		// Inject inline variables for the editor sidebar, without UTM parameters.
+		$parsely_post_url = $this->get_parsely_post_url( null, false );
 		if ( null !== $parsely_post_url ) {
 			wp_add_inline_script(
 				static::get_script_id(),

--- a/src/content-helper/editor-sidebar/class-editor-sidebar.php
+++ b/src/content-helper/editor-sidebar/class-editor-sidebar.php
@@ -98,10 +98,10 @@ class Editor_Sidebar extends Content_Helper_Feature {
 	 * @since 3.16.1 Added the $show_utm_params parameter.
 	 *
 	 * @param int|null|WP_Post $post_id The post ID or post object. Default is the current post.
-	 * @param bool             $show_utm_params Whether to show UTM parameters in the URL.
+	 * @param bool             $add_utm_params Whether to add UTM parameters in the URL.
 	 * @return string|null The Parse.ly post dashboard URL, or false if the post ID is invalid.
 	 */
-	private function get_parsely_post_url( $post_id = null, bool $show_utm_params = true ): ?string {
+	private function get_parsely_post_url( $post_id = null, bool $add_utm_params = true ): ?string {
 		// Get permalink for the post.
 		$post_id = $post_id ?? get_the_ID();
 		if ( false === $post_id ) {
@@ -119,7 +119,7 @@ class Editor_Sidebar extends Content_Helper_Feature {
 			return null;
 		}
 
-		if ( ! $show_utm_params ) {
+		if ( ! $add_utm_params ) {
 			return Dashboard_Link::generate_url( $post, $this->parsely->get_site_id() );
 		}
 


### PR DESCRIPTION
## Description

As reported in #2653, the UTM parameters that are passed through the "View this in Parse.ly" button on the Performance Stats tab of the Content Helper sidebar, is preventing the data exporter in the Parse.ly Dashboard from function properly. 

This PR removes those UTM parameters from the URL.

## Motivation and context
* Improve the UX of the Content Helper
* Closes #2653 

## How has this been tested?
Tested locally.