### PR TITLE
Fix failing E2E tests

### DIFF
--- a/tests/e2e/specs/content-helper/top-bar-icon.spec.ts
+++ b/tests/e2e/specs/content-helper/top-bar-icon.spec.ts
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	createNewPost,
-	toggleMoreMenu,
-} from '@wordpress/e2e-test-utils';
+import { createNewPost } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
@@ -14,6 +11,7 @@ import {
 	VALID_SITE_ID,
 	setSidebarPanelExpanded,
 	setSiteKeys,
+	toggleMoreMenu,
 } from '../../utils';
 
 // Selectors.
@@ -84,7 +82,7 @@ describe( 'PCH Editor Sidebar top bar icon in the WordPress Post Editor', () => 
 		}
 
 		// Ensure that the menu opens without crashing the Post Editor.
-		await toggleMoreMenu();
+		await toggleMoreMenu( 'open' );
 		await page.waitForSelector( 'div.components-dropdown-menu__menu', { visible: true } );
 		const text = await page.$eval( 'div.components-dropdown-menu__menu', ( element: Element ) => element.textContent );
 		expect( await text ).toMatch( 'Parse.ly' );

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -4,6 +4,7 @@
 import {
 	createNewPost,
 	ensureSidebarOpened,
+	findSidebarPanelToggleButtonWithTitle,
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
@@ -242,23 +243,40 @@ export const setSidebarPanelExpanded = async (
 };
 
 /**
- * Overrides the findSidebarPanelToggleButtonWithTitle() function of the
- * wordpress/e2e-test-utils package, as we started having issues with it and
- * some tests were failing.
+ * Toggles the More Menu.
  *
- * @since 3.15.0
+ * This function overrides the toggleMoreMenu() function of the
+ * wordpress/e2e-test-utils package, as the original function contains erroneous
+ * selectors
  *
- * @param {string} title          The title of the element to find.
- * @param {string} containerClass The class of one of the element's containers.
+ * @since 3.16.0
  *
- * @return {Promise<Element>} The found element.
+ * @param {'open' | 'close' | undefined} waitFor Whether it should wait for the menu to open or close.
+ *                                               If `undefined`, it won't wait for anything.
  */
-const findSidebarPanelToggleButtonWithTitle = async (
-	title: string, containerClass: string = 'edit-post-sidebar'
-) => {
-	const [ button ] = await page.$x(
-		`//div[contains(@class,"${ containerClass }")]//button[@class="components-button components-panel__body-toggle"][contains(text(),"${ title }")]`
-	);
+export async function toggleMoreMenu(
+	waitFor: 'open' | 'close' | undefined = undefined
+): Promise<void> {
+	const menuSelector = 'button[aria-haspopup="true"][aria-label="Options"]';
+	const menuToggle = await page.waitForSelector( menuSelector );
+	const isOpen = await menuToggle.evaluate( ( el ) => el.getAttribute( 'aria-expanded' ) );
 
-	return button;
-};
+	// If opening and it's already open then exit early.
+	if ( isOpen === 'true' && waitFor === 'open' ) {
+		return;
+	}
+
+	// If closing and it's already closed then exit early.
+	if ( isOpen === 'false' && waitFor === 'close' ) {
+		return;
+	}
+	await page.click( menuSelector );
+	if ( waitFor ) {
+		const opts = waitFor === 'close' ? {
+			hidden: true,
+		} : {};
+		const menuContentSelector = 'div.components-dropdown-menu__menu[role="menu"][aria-label="Options"]';
+		await page.waitForSelector( menuContentSelector, opts );
+	}
+}
+


### PR DESCRIPTION
## Description
With this PR, we're fixing a couple of failing E2E tests after the release of WordPress 6.6.

## Motivation and context
Make all tests pass, no hindered workflow.

## How has this been tested?
Updated tests that were previously failing now pass.