### PR TITLE
Update version number and changelog for 3.16.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.1](https://github.com/Parsely/wp-parsely/compare/3.16.0...3.16.1) - 2024-07-18
+
+### Fixed
+
+- PCH Performance Stats: Remove UTM parameters from the 'View in Parse.ly' button ([#2655](https://github.com/Parsely/wp-parsely/pull/2655))
+- PCH Smart Linking: Show error when API returns empty list of Smart Link suggestions ([#2654](https://github.com/Parsely/wp-parsely/pull/2654))
+- PCH Smart Linking: Fix CSS leaking from the Block Preview ([#2652](https://github.com/Parsely/wp-parsely/pull/2652))
+- PCH Smart Linking: Use the post title as the Smart Link title. ([#2650](https://github.com/Parsely/wp-parsely/pull/2650))
+- Permissions: Fix PHP Warning when the user role is invalid ([#2649](https://github.com/Parsely/wp-parsely/pull/2649))
+
+
 ## [3.16.0](https://github.com/Parsely/wp-parsely/compare/3.15.0...3.16.0) - 2024-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.16.0  
+Stable tag: 3.16.1  
 Requires at least: 5.2  
 Tested up to: 6.5  
 Requires PHP: 7.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.16.0",
+	"version": "3.16.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.16.0",
+			"version": "3.16.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.16.0",
+	"version": "3.16.1",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.16.0';
+export const PLUGIN_VERSION = '3.16.1';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.16.0
+ * Version:           3.16.1
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -70,7 +70,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.16.0';
+const PARSELY_VERSION = '3.16.1';
 const PARSELY_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/Models/class-base-model.php';


### PR DESCRIPTION
This PR updates the plugin's version number and changelog in preparation for the 3.16.1 release.

## Fixed

- PCH Performance Stats: Remove UTM parameters from the 'View in Parse.ly' button ([#2655](https://github.com/Parsely/wp-parsely/pull/2655))
- PCH Smart Linking: Show error when API returns empty list of Smart Link suggestions ([#2654](https://github.com/Parsely/wp-parsely/pull/2654))
- PCH Smart Linking: Fix CSS leaking from the Block Preview ([#2652](https://github.com/Parsely/wp-parsely/pull/2652))
- PCH Smart Linking: Use the post title as the Smart Link title. ([#2650](https://github.com/Parsely/wp-parsely/pull/2650))
- Permissions: Fix PHP Warning when the user role is invalid ([#2649](https://github.com/Parsely/wp-parsely/pull/2649))



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new parameters to existing methods for better customization and functionality (e.g., `get_parsely_post_url`).
  
- **Bug Fixes**
  - Improved error handling and JSX structure in the Smart Linking review modal.
  - Fixed issues related to performance stats, smart linking, and permissions.

- **Documentation**
  - Updated README with new version, PHP requirements, and compatibility details.
  - Fixed various issues in the CHANGELOG.

- **Chores**
  - Updated plugin version to 3.16.1 in multiple files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->