### PR TITLE
Permissions: Allow overriding of PCH feature permissions

### DIFF
--- a/src/class-permissions.php
+++ b/src/class-permissions.php
@@ -104,7 +104,7 @@ class Permissions {
 			$post_id
 		);
 
-		if ( $filtered_current_user_can_use_pch_feature ) {
+		if ( true === $filtered_current_user_can_use_pch_feature ) {
 			return true;
 		}
 

--- a/src/class-permissions.php
+++ b/src/class-permissions.php
@@ -83,6 +83,31 @@ class Permissions {
 		$current_user = wp_get_current_user();
 		$user_roles   = $current_user->roles;
 
+		/**
+		 * Filters whether the current user can use the specified Content Helper
+		 * feature.
+		 *
+		 * This filter can be used to override the default permissions check.
+		 *
+		 * @since 3.16.2
+		 *
+		 * @param bool   $current_user_can_use_pch_feature Whether the current user can use the feature.
+		 * @param string $feature_name The feature's name.
+		 * @param \WP_User $current_user The current user object.
+		 * @param int|false $post_id The post ID, if the check is for a specific post.
+		 */
+		$filtered_current_user_can_use_pch_feature = apply_filters(
+			'wp_parsely_current_user_can_use_pch_feature',
+			false,
+			$feature_name,
+			$current_user,
+			$post_id
+		);
+
+		if ( $filtered_current_user_can_use_pch_feature ) {
+			return true;
+		}
+
 		// Current user's role is not yet set.
 		if ( 0 === count( $user_roles ) ) {
 			return false;


### PR DESCRIPTION
## Description

We got reports that VIP support users were unable to access PCH features after the introduction of PCH permissions.

This PR gives a pathway to fix this. It introduces a new filter, `wp_parsely_current_user_can_use_pch_feature`, to the `current_user_can_use_pch_feature` function in the `class-permissions.php` file. This filter allows developers to override the default permissions check for specific Content Helper features.

By using the filter, we'll now be able to grant PCH feature access to VIP support users.

The filter provides several parameters:
* `$current_user_can_use_pch_feature` (bool) to indicate whether the current user can use the feature
* `$feature_name` (string) for the feature's name
* `$current_user` (\WP_User) representing the current user object
*  `$post_id` (int|false) for the post ID if the check is for a specific post. If the filter returns `true`, the function immediately grants permission, bypassing the default role-based check.

This change allows more flexibility for customizing each feature permission based on specific requirements. Here's an example on how you could use to allow a specific role to have access to the Smart Linking feature.

```php
function allow_example_role_to_use_smart_linking( $current_user_can_use_pch_feature, $feature_name, $current_user, $post_id ) {
    // Check if the feature is 'smart-linking'
    if ( $feature_name === 'smart-linking' ) {
        // Check if the current user has the 'example-role' role
        if ( in_array( 'example-role', $current_user->roles, true ) ) {
            return true;
        }
    }
    
    // Return the original permission check result if conditions are not met
    return $current_user_can_use_pch_feature;
}
add_filter( 'wp_parsely_current_user_can_use_pch_feature', 'allow_example_role_to_use_smart_linking', 10, 4 );
```

## Motivation and context
Improve the flexibility and extensibility of PCH access control.

## How has this been tested?
Tested locally. 
