### PR TITLE
ESLint: Use method-signature-style rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,10 +42,11 @@
 			}
 		],
 		"@typescript-eslint/ban-ts-comment": "off",
-		"@typescript-eslint/prefer-nullish-coalescing": ["error"],
+		"@typescript-eslint/method-signature-style": "error", // Can be removed after we've updated to wp-scripts v28 or greater.
+		"@typescript-eslint/prefer-nullish-coalescing": "error",
 		// Enabling TS rule and disabling Base rule as it can report incorrect errors.
 		"no-shadow": "off",
-		"@typescript-eslint/no-shadow": ["error"],
+		"@typescript-eslint/no-shadow": "error",
 		// Allow usage of Gutenberg experimental components.
 		"@wordpress/no-unsafe-wp-apis": "off",
 		// Allow link tag in JSDocs.

--- a/src/@types/gutenberg/types.ts
+++ b/src/@types/gutenberg/types.ts
@@ -11,27 +11,26 @@ import { dispatch } from '@wordpress/data';
  * @since 3.12.0
  */
 export interface GutenbergFunction {
-	editPost( edits: Record<string, unknown> ): void;
-	getBlock( clientId: string ): BlockInstance | null;
-	getBlockParents( clientId: string ): string[];
-	getBlocks(): BlockInstance[];
-	getCurrentPostAttribute( attribute: string ): string;
-	getCurrentPostId(): number | undefined;
-	getEditedPostAttribute( attribute: string ): string;
-	getEditedPostContent(): string;
-	getPermalink(): string | null;
-	getPermalink(): string | null;
-	getSelectedBlock(): BlockInstance | null;
-	hasMetaBoxes(): boolean;
-	isAutosavingPost(): boolean;
-	isSavingPost(): boolean;
-	lockPostSaving( lockName: string ): void;
-	lockPostAutosaving( lockName: string ): void;
-	unlockPostAutosaving( lockName: string ): void;
-	removeEditorPanel( panelName: string ): void;
-	selectBlock( clientId: string, initialPosition?: number ): void;
-	unlockPostSaving( lockName: string ): void;
-	updateBlockAttributes( clientId: string, attributes: Record<string, unknown> ): void;
+	editPost: ( edits: Record<string, unknown> ) => void;
+	getBlock: ( clientId: string ) => BlockInstance | null;
+	getBlockParents: ( clientId: string ) => string[];
+	getBlocks: () => BlockInstance[];
+	getCurrentPostAttribute: ( attribute: string ) => string;
+	getCurrentPostId: () => number | undefined;
+	getEditedPostAttribute: ( attribute: string ) => string;
+	getEditedPostContent: () => string;
+	getPermalink: () => string | null;
+	getSelectedBlock: () => BlockInstance | null;
+	hasMetaBoxes: () => boolean;
+	isAutosavingPost: () => boolean;
+	isSavingPost: () => boolean;
+	lockPostSaving: ( lockName: string ) => void;
+	lockPostAutosaving: ( lockName: string ) => void;
+	unlockPostAutosaving: ( lockName: string ) => void;
+	removeEditorPanel: ( panelName: string ) => void;
+	selectBlock: ( clientId: string, initialPosition?: number ) => void;
+	unlockPostSaving: ( lockName: string ) => void;
+	updateBlockAttributes: ( clientId: string, attributes: Record<string, unknown> ) => void;
 }
 
 /**


### PR DESCRIPTION
## Description
See https://github.com/Parsely/wp-parsely/issues/2618

## Motivation and context
Closes https://github.com/Parsely/wp-parsely/issues/2618.

## How has this been tested?
No functionality changes, linting passes after failing syntax has been updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated ESLint configuration to enforce a consistent coding style in TypeScript.
	- Enhanced method signatures in the GutenbergFunction interface for improved clarity and maintainability.

- **Bug Fixes**
	- Adjusted TypeScript rules and syntax to align with modern standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->