### PR TITLE
Add .stylelintrc

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,22 @@
+{
+	"extends": [
+		"@wordpress/stylelint-config/scss"
+	],
+	"reportInvalidScopeDisables": true,
+	"reportNeedlessDisables": true,
+	"rules": {
+		"media-feature-parentheses-space-inside": "never",
+		"rule-empty-line-before": [
+			"always-multi-line",
+			{
+				"except": [
+					"first-nested"
+				],
+				"ignore": [
+					"after-comment"
+				]
+			}
+		],
+		"selector-class-pattern": null
+	}
+}

--- a/src/content-helper/common/css/common.scss
+++ b/src/content-helper/common/css/common.scss
@@ -118,7 +118,6 @@
 	}
 
 	.components-panel__body {
-
 		&.is-opened {
 			padding: 0;
 		}

--- a/src/content-helper/dashboard-widget/dashboard-widget.scss
+++ b/src/content-helper/dashboard-widget/dashboard-widget.scss
@@ -66,7 +66,6 @@
 		}
 
 		@media only screen and (max-width: 380px) {
-
 			&::before {
 				content: "";
 				padding-right: 0;

--- a/src/content-helper/editor-sidebar/editor-sidebar.scss
+++ b/src/content-helper/editor-sidebar/editor-sidebar.scss
@@ -4,7 +4,6 @@
 
 // Set the colors of the sidebar icon.
 .components-button[aria-controls="wp-parsely-block-editor-sidebar:wp-parsely-content-helper"] {
-
 	&:hover {
 		background-color: #fff;
 	}
@@ -38,7 +37,6 @@ p.content-helper-error-message-hint {
 
 // Notice components with errors that appear within Sidebar panels.
 .wp-parsely-content-helper-error.components-notice {
-
 	.components-notice__content {
 		margin: 0;
 
@@ -53,7 +51,6 @@ p.content-helper-error-message-hint {
 }
 
 .wp-parsely-content-helper {
-
 	.wp-parsely-sidebar-header {
 		display: flex;
 		flex-direction: column;
@@ -70,7 +67,6 @@ p.content-helper-error-message-hint {
 	}
 
 	.wp-parsely-sidebar-main-panel {
-
 		// Settings button for panels.
 		.components-panel button.panel-settings-button,
 		.components-panel .panel-settings-button > button {
@@ -86,7 +82,6 @@ p.content-helper-error-message-hint {
 			}
 
 			.components-tab-panel__tabs {
-
 				// Individual tab.
 				button {
 					display: flex;

--- a/src/content-helper/editor-sidebar/performance-stats/performance-stats.scss
+++ b/src/content-helper/editor-sidebar/performance-stats/performance-stats.scss
@@ -49,7 +49,6 @@
 
 			/** Level 3 heading */
 			&.level-3 {
-
 				h3 {
 					margin-bottom: 0;
 					line-height: to_rem(16px);

--- a/src/content-helper/editor-sidebar/related-posts/related-posts.scss
+++ b/src/content-helper/editor-sidebar/related-posts/related-posts.scss
@@ -106,7 +106,6 @@
 		}
 
 		.related-posts-wrapper {
-
 			.related-posts-descr {
 				font-size: to_rem(13px);
 				font-style: normal;
@@ -203,13 +202,11 @@
 						}
 
 						.wp-parsely-icon {
-
 							path {
 								fill: #1e1e1e;
 							}
 
 							&:hover {
-
 								path {
 									fill: #0073aa;
 								}

--- a/src/content-helper/editor-sidebar/smart-linking/smart-linking.scss
+++ b/src/content-helper/editor-sidebar/smart-linking/smart-linking.scss
@@ -269,7 +269,6 @@
 		align-self: stretch;
 
 		.smart-linking-review-sidebar-tabs {
-
 			.components-tab-panel__tabs {
 				margin-bottom: var(--grid-unit-20);
 
@@ -488,7 +487,6 @@
 }
 
 .wp-parsely-preview-editor {
-
 	.editor-styles-wrapper {
 		padding-bottom: 0;
 		font-size: var(--font-size--medium);

--- a/src/content-helper/editor-sidebar/title-suggestions/title-suggestions.scss
+++ b/src/content-helper/editor-sidebar/title-suggestions/title-suggestions.scss
@@ -7,7 +7,6 @@
 	flex-direction: column;
 
 	.title-suggestions-settings {
-
 		display: flex;
 		padding: to_rem(6px) 0 var(--grid-unit-20) 0;
 		flex-direction: column;
@@ -69,7 +68,6 @@
 	// Accepted Title view.
 	// TODO: Remove, unused?
 	.parsely-write-titles-accepted-title-container {
-
 		.parsely-write-titles-accepted-title {
 			font-weight: 600;
 			font-size: to_rem(16px);

--- a/src/css/admin-settings.scss
+++ b/src/css/admin-settings.scss
@@ -5,7 +5,6 @@
 	--padding-default: 15px;
 
 	fieldset.user-role-permissions {
-
 		label {
 			margin-right: to_rem(16px) !important;
 		}
@@ -14,7 +13,6 @@
 	.disabled-before-posting,
 	fieldset:disabled,
 	tr:has(fieldset:disabled) {
-
 		label:not(.prevent-disable),
 		p,
 		th {
@@ -75,9 +73,7 @@
 	}
 
 	@media only screen and (max-width: 380px) {
-
 		#track-post-types {
-
 			th,
 			td {
 				padding-left: 10px;

--- a/src/css/recommended-widget.scss
+++ b/src/css/recommended-widget.scss
@@ -56,7 +56,6 @@
 }
 
 @supports (display: grid) {
-
 	.parsely-recommended-widget-entry::after {
 		display: none;
 		clear: initial;


### PR DESCRIPTION
## Description
With this PR, we're adding a `.stylelintrc` file, which currently deals mostly with unneeded whitespace. We use the `"selector-class-pattern"` to ignore some errors. In the future, we can see if these are solvable or if they are WordPress classes we cannot change.

## Motivation and context
Improve whitespace in our SCSS files, and lay the groundwork in case we want more SCSS linting rules in the future.

## How has this been tested?
Added the file, added the rules and took care of any errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration file for improved SCSS coding standards, enhancing code readability and maintainability.
- **Style**
	- Removed unnecessary whitespace in various CSS files to streamline code without impacting functionality or visual output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->