### PR TITLE
Fix PHPStan error

### DIFF
--- a/src/Endpoints/class-base-api-proxy.php
+++ b/src/Endpoints/class-base-api-proxy.php
@@ -155,7 +155,7 @@ abstract class Base_API_Proxy {
 		}
 
 		// A proxy with caching behavior is used here.
-		$response = $this->api->get_items( $params ); // @phpstan-ignore-line.
+		$response = $this->api->get_items( $params );
 
 		if ( is_wp_error( $response ) ) {
 			return $response;


### PR DESCRIPTION
## Description
This PR fixes the following error that appeared after my latest `composer update`:

```shell
 ------ --------------------------------------------- 
  Line   src/Endpoints/class-base-api-proxy.php       
 ------ --------------------------------------------- 
  158    No error to ignore is reported on line 158.  
 ------ --------------------------------------------- 
```

## Motivation and context
Have no PHPStan errors.

## How has this been tested?
`composer static-analysis` returns without errors after the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved code quality by removing unnecessary comments, enhancing maintainability without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->