### PR TITLE
Update version number and changelog for 3.16.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.2](https://github.com/Parsely/wp-parsely/compare/3.16.1...3.16.2) - 2024-07-30
+
+### Fixed
+
+- PCH Smart Linking: Prevent suggesting links in unexpected blocks ([#2673](https://github.com/Parsely/wp-parsely/pull/2673))
+- PCH Related Posts: Prevent Related Posts indefinite loading ([#2666](https://github.com/Parsely/wp-parsely/pull/2666))
+- Permissions: Allow overriding of PCH feature permissions ([#2663](https://github.com/Parsely/wp-parsely/pull/2663))
+- PCH Smart Linking: Fix bug causing ‘No smart links’ error despite valid API response ([#2662](https://github.com/Parsely/wp-parsely/pull/2662))
+
+
 ## [3.16.1](https://github.com/Parsely/wp-parsely/compare/3.16.0...3.16.1) - 2024-07-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Permissions: Allow overriding of PCH feature permissions ([#2663](https://github.com/Parsely/wp-parsely/pull/2663))
 - PCH Smart Linking: Fix bug causing ‘No smart links’ error despite valid API response ([#2662](https://github.com/Parsely/wp-parsely/pull/2662))
 
-
 ## [3.16.1](https://github.com/Parsely/wp-parsely/compare/3.16.0...3.16.1) - 2024-07-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.16.1  
+Stable tag: 3.16.2  
 Requires at least: 5.2  
 Tested up to: 6.5  
 Requires PHP: 7.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.16.1",
+	"version": "3.16.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.16.1",
+			"version": "3.16.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.16.1",
+	"version": "3.16.2",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/src/content-helper/editor-sidebar/smart-linking/smart-linking.tsx
+++ b/src/content-helper/editor-sidebar/smart-linking/smart-linking.tsx
@@ -33,7 +33,7 @@ export const DEFAULT_MAX_LINKS = 10;
 /**
  * The allowed blocks for Smart Linking.
  *
- * @since 3.16.0
+ * @since 3.16.2
  */
 export const ALLOWED_BLOCKS = window.wpParselySmartLinkingAllowedBlocks;
 

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.16.1';
+export const PLUGIN_VERSION = '3.16.2';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.16.1
+ * Version:           3.16.2
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -70,7 +70,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.16.1';
+const PARSELY_VERSION = '3.16.2';
 const PARSELY_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/Models/class-base-model.php';


### PR DESCRIPTION
This PR updates the plugin's version number and changelog in preparation for the 3.16.2 release.

## Fixed

- PCH Smart Linking: Prevent suggesting links in unexpected blocks ([#2673](https://github.com/Parsely/wp-parsely/pull/2673))
- PCH Related Posts: Prevent Related Posts indefinite loading ([#2666](https://github.com/Parsely/wp-parsely/pull/2666))
- Permissions: Allow overriding of PCH feature permissions ([#2663](https://github.com/Parsely/wp-parsely/pull/2663))
- PCH Smart Linking: Fix bug causing ‘No smart links’ error despite valid API response ([#2662](https://github.com/Parsely/wp-parsely/pull/2662))



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Smart Linking functionality to prevent unexpected link suggestions.
	- Improved Related Posts feature to eliminate indefinite loading issues.
	- Added customizable permissions for PCH features.
	- New setting for allowed blocks in Smart Linking.
  
- **Bug Fixes**
	- Resolved 'No smart links' error when valid API responses are received.

- **Versioning**
	- Updated project version from 3.16.1 to 3.16.2 in multiple places.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->