### PR TITLE
bump @wordpress/edit-post from 8.3.0 to 8.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"@wordpress/core-data": "^7.5.0",
 				"@wordpress/data": "^10.5.0",
 				"@wordpress/e2e-test-utils": "^11.5.0",
-				"@wordpress/edit-post": "^8.3.0",
+				"@wordpress/edit-post": "^8.5.0",
 				"@wordpress/editor": "^14.5.0",
 				"@wordpress/element": "^6.5.0",
 				"@wordpress/env": "^10.5.0",
@@ -4159,6 +4159,7 @@
 			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.0.tgz",
 			"integrity": "sha512-EOMeg42SlLS72dhoq6Vjq08havnLseWmPQ8A0YsgIAqMgWgx7V1a39+Pxo6i7SY5NwJtH4849JogFq3M67AzWg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@preact/signals-core": "^1.7.0"
 			},
@@ -4171,10 +4172,11 @@
 			}
 		},
 		"node_modules/@preact/signals-core": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.7.0.tgz",
-			"integrity": "sha512-bEZLgmJGSBVP5PUPDowhPW3bVdMmp9Tr5OEl+SQK+8Tv9T7UsIfyN905cfkmmeqw8z4xp8T6zrl4M1uj9+HAfg==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.8.0.tgz",
+			"integrity": "sha512-OBvUsRZqNmjzCZXWLxkZfhcgT+Fk8DDcT/8vD6a1xhDemodyy87UJRJfASMuSD8FaAIeGgGm85ydXhm7lr4fyA==",
 			"dev": true,
+			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"
@@ -9534,45 +9536,46 @@
 			}
 		},
 		"node_modules/@wordpress/block-library": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.3.0.tgz",
-			"integrity": "sha512-ffm47zghDA0Un8poGN5wmj3Cz+TotC0bxtCB3IsxdWzloMEzrOYoAokAMeZunuJ63hciqI+K/Oiwzu7M+uAy/A==",
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.5.0.tgz",
+			"integrity": "sha512-GjZtQzSDZQDg14dJdgEzj7Y2i4xdhVyr/avaIKmecdoKBLT0wuStf83H7XBxuR+ijf0DXPel6fGce5KUEJ4SiQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.3.0",
-				"@wordpress/api-fetch": "^7.3.0",
-				"@wordpress/autop": "^4.3.0",
-				"@wordpress/blob": "^4.3.0",
-				"@wordpress/block-editor": "^13.3.0",
-				"@wordpress/blocks": "^13.3.0",
-				"@wordpress/components": "^28.3.0",
-				"@wordpress/compose": "^7.3.0",
-				"@wordpress/core-data": "^7.3.0",
-				"@wordpress/data": "^10.3.0",
-				"@wordpress/date": "^5.3.0",
-				"@wordpress/deprecated": "^4.3.0",
-				"@wordpress/dom": "^4.3.0",
-				"@wordpress/element": "^6.3.0",
-				"@wordpress/escape-html": "^3.3.0",
-				"@wordpress/hooks": "^4.3.0",
-				"@wordpress/html-entities": "^4.3.0",
-				"@wordpress/i18n": "^5.3.0",
-				"@wordpress/icons": "^10.3.0",
-				"@wordpress/interactivity": "^6.3.0",
-				"@wordpress/interactivity-router": "^2.3.0",
-				"@wordpress/keyboard-shortcuts": "^5.3.0",
-				"@wordpress/keycodes": "^4.3.0",
-				"@wordpress/notices": "^5.3.0",
-				"@wordpress/patterns": "^2.3.0",
-				"@wordpress/primitives": "^4.3.0",
-				"@wordpress/private-apis": "^1.3.0",
-				"@wordpress/reusable-blocks": "^5.3.0",
-				"@wordpress/rich-text": "^7.3.0",
-				"@wordpress/server-side-render": "^5.3.0",
-				"@wordpress/url": "^4.3.0",
-				"@wordpress/viewport": "^6.3.0",
-				"@wordpress/wordcount": "^4.3.0",
+				"@wordpress/a11y": "^4.5.0",
+				"@wordpress/api-fetch": "^7.5.0",
+				"@wordpress/autop": "^4.5.0",
+				"@wordpress/blob": "^4.5.0",
+				"@wordpress/block-editor": "^14.0.0",
+				"@wordpress/blocks": "^13.5.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/core-data": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/date": "^5.5.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/dom": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/escape-html": "^3.5.0",
+				"@wordpress/hooks": "^4.5.0",
+				"@wordpress/html-entities": "^4.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/interactivity": "^6.5.0",
+				"@wordpress/interactivity-router": "^2.5.0",
+				"@wordpress/keyboard-shortcuts": "^5.5.0",
+				"@wordpress/keycodes": "^4.5.0",
+				"@wordpress/notices": "^5.5.0",
+				"@wordpress/patterns": "^2.5.0",
+				"@wordpress/primitives": "^4.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/reusable-blocks": "^5.5.0",
+				"@wordpress/rich-text": "^7.5.0",
+				"@wordpress/server-side-render": "^5.5.0",
+				"@wordpress/url": "^4.5.0",
+				"@wordpress/viewport": "^6.5.0",
+				"@wordpress/wordcount": "^4.5.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -9582,69 +9585,6 @@
 				"memize": "^2.1.0",
 				"remove-accents": "^0.5.0",
 				"uuid": "^9.0.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/block-library/node_modules/@wordpress/block-editor": {
-			"version": "13.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-13.4.0.tgz",
-			"integrity": "sha512-J2XwsngpxLaue8EROloT6KyRFjCk8JCl/K9UalEkrpYFFj084z7/px6LT6300Maue0ejkN8I3X4/XOe0tgOdbQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@emotion/react": "^11.7.1",
-				"@emotion/styled": "^11.6.0",
-				"@react-spring/web": "^9.4.5",
-				"@wordpress/a11y": "^4.4.0",
-				"@wordpress/api-fetch": "^7.4.0",
-				"@wordpress/blob": "^4.4.0",
-				"@wordpress/blocks": "^13.4.0",
-				"@wordpress/commands": "^1.4.0",
-				"@wordpress/components": "^28.4.0",
-				"@wordpress/compose": "^7.4.0",
-				"@wordpress/data": "^10.4.0",
-				"@wordpress/date": "^5.4.0",
-				"@wordpress/deprecated": "^4.4.0",
-				"@wordpress/dom": "^4.4.0",
-				"@wordpress/element": "^6.4.0",
-				"@wordpress/escape-html": "^3.4.0",
-				"@wordpress/hooks": "^4.4.0",
-				"@wordpress/html-entities": "^4.4.0",
-				"@wordpress/i18n": "^5.4.0",
-				"@wordpress/icons": "^10.4.0",
-				"@wordpress/is-shallow-equal": "^5.4.0",
-				"@wordpress/keyboard-shortcuts": "^5.4.0",
-				"@wordpress/keycodes": "^4.4.0",
-				"@wordpress/notices": "^5.4.0",
-				"@wordpress/preferences": "^4.4.0",
-				"@wordpress/private-apis": "^1.4.0",
-				"@wordpress/rich-text": "^7.4.0",
-				"@wordpress/style-engine": "^2.4.0",
-				"@wordpress/token-list": "^3.4.0",
-				"@wordpress/url": "^4.4.0",
-				"@wordpress/warning": "^3.4.0",
-				"@wordpress/wordcount": "^4.4.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"deepmerge": "^4.3.0",
-				"diff": "^4.0.2",
-				"fast-deep-equal": "^3.1.3",
-				"memize": "^2.1.0",
-				"postcss": "^8.4.21",
-				"postcss-prefixwrap": "^1.41.0",
-				"postcss-urlrebase": "^1.4.0",
-				"react-autosize-textarea": "^7.1.0",
-				"react-easy-crop": "^5.0.6",
-				"remove-accents": "^0.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9665,17 +9605,6 @@
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/i18n": "^5.5.0"
 			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/block-library/node_modules/@wordpress/warning": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.5.0.tgz",
-			"integrity": "sha512-cYM2Vqf2EokJJoWHD5Ry15OUmdsKtDgR8/qxE0sWHUAdSQeoTuJZnqhgYI898cZGxHaZWX2xJCxQa7Qtwl8lqw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -10345,24 +10274,25 @@
 			}
 		},
 		"node_modules/@wordpress/core-commands": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/core-commands/-/core-commands-1.3.0.tgz",
-			"integrity": "sha512-Tc9w07UgyFKT6fq0UUxsTmXmRGsULiV25YtAwqxF52XtYxfo+mPMDJgYpNA2l3eKL6EuWR6AzNl8f9pank55oA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/core-commands/-/core-commands-1.5.0.tgz",
+			"integrity": "sha512-KS3LJzdfiGxrlUmYHpojThp/hKIbg2Eqb57AVFdx4CXepQuuicrtbfMzWKl5p4ziKN/oi42diLBlWDsBv99NNA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/block-editor": "^13.3.0",
-				"@wordpress/commands": "^1.3.0",
-				"@wordpress/compose": "^7.3.0",
-				"@wordpress/core-data": "^7.3.0",
-				"@wordpress/data": "^10.3.0",
-				"@wordpress/element": "^6.3.0",
-				"@wordpress/html-entities": "^4.3.0",
-				"@wordpress/i18n": "^5.3.0",
-				"@wordpress/icons": "^10.3.0",
-				"@wordpress/private-apis": "^1.3.0",
-				"@wordpress/router": "^1.3.0",
-				"@wordpress/url": "^4.3.0"
+				"@wordpress/block-editor": "^14.0.0",
+				"@wordpress/commands": "^1.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/core-data": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/html-entities": "^4.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/router": "^1.5.0",
+				"@wordpress/url": "^4.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10371,95 +10301,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/core-commands/node_modules/@wordpress/block-editor": {
-			"version": "13.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-13.4.0.tgz",
-			"integrity": "sha512-J2XwsngpxLaue8EROloT6KyRFjCk8JCl/K9UalEkrpYFFj084z7/px6LT6300Maue0ejkN8I3X4/XOe0tgOdbQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@emotion/react": "^11.7.1",
-				"@emotion/styled": "^11.6.0",
-				"@react-spring/web": "^9.4.5",
-				"@wordpress/a11y": "^4.4.0",
-				"@wordpress/api-fetch": "^7.4.0",
-				"@wordpress/blob": "^4.4.0",
-				"@wordpress/blocks": "^13.4.0",
-				"@wordpress/commands": "^1.4.0",
-				"@wordpress/components": "^28.4.0",
-				"@wordpress/compose": "^7.4.0",
-				"@wordpress/data": "^10.4.0",
-				"@wordpress/date": "^5.4.0",
-				"@wordpress/deprecated": "^4.4.0",
-				"@wordpress/dom": "^4.4.0",
-				"@wordpress/element": "^6.4.0",
-				"@wordpress/escape-html": "^3.4.0",
-				"@wordpress/hooks": "^4.4.0",
-				"@wordpress/html-entities": "^4.4.0",
-				"@wordpress/i18n": "^5.4.0",
-				"@wordpress/icons": "^10.4.0",
-				"@wordpress/is-shallow-equal": "^5.4.0",
-				"@wordpress/keyboard-shortcuts": "^5.4.0",
-				"@wordpress/keycodes": "^4.4.0",
-				"@wordpress/notices": "^5.4.0",
-				"@wordpress/preferences": "^4.4.0",
-				"@wordpress/private-apis": "^1.4.0",
-				"@wordpress/rich-text": "^7.4.0",
-				"@wordpress/style-engine": "^2.4.0",
-				"@wordpress/token-list": "^3.4.0",
-				"@wordpress/url": "^4.4.0",
-				"@wordpress/warning": "^3.4.0",
-				"@wordpress/wordcount": "^4.4.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"deepmerge": "^4.3.0",
-				"diff": "^4.0.2",
-				"fast-deep-equal": "^3.1.3",
-				"memize": "^2.1.0",
-				"postcss": "^8.4.21",
-				"postcss-prefixwrap": "^1.41.0",
-				"postcss-urlrebase": "^1.4.0",
-				"react-autosize-textarea": "^7.1.0",
-				"react-easy-crop": "^5.0.6",
-				"remove-accents": "^0.5.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/core-commands/node_modules/@wordpress/keycodes": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.5.0.tgz",
-			"integrity": "sha512-5kCxbP+xqAr0pwftdvnM+oAqGa6r0IQoct9TyvqXE2hdE9Cnu5RlnVG30Ki7/3d1KoMRBh00nFoS2RzpWbOq+A==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.5.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/core-commands/node_modules/@wordpress/warning": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.5.0.tgz",
-			"integrity": "sha512-cYM2Vqf2EokJJoWHD5Ry15OUmdsKtDgR8/qxE0sWHUAdSQeoTuJZnqhgYI898cZGxHaZWX2xJCxQa7Qtwl8lqw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/core-data": {
@@ -10814,106 +10655,44 @@
 			}
 		},
 		"node_modules/@wordpress/edit-post": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-8.3.0.tgz",
-			"integrity": "sha512-wCmxUfa2NeE60O8fGWFEcp7SKXVdgBBxVlbUdiB8UWiDpC6k/o2Fvvwniwgk7gmYzPbB5OrKgbYb7W+VDS3QaQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.3.0",
-				"@wordpress/api-fetch": "^7.3.0",
-				"@wordpress/block-editor": "^13.3.0",
-				"@wordpress/block-library": "^9.3.0",
-				"@wordpress/blocks": "^13.3.0",
-				"@wordpress/commands": "^1.3.0",
-				"@wordpress/components": "^28.3.0",
-				"@wordpress/compose": "^7.3.0",
-				"@wordpress/core-commands": "^1.3.0",
-				"@wordpress/core-data": "^7.3.0",
-				"@wordpress/data": "^10.3.0",
-				"@wordpress/deprecated": "^4.3.0",
-				"@wordpress/dom": "^4.3.0",
-				"@wordpress/editor": "^14.3.0",
-				"@wordpress/element": "^6.3.0",
-				"@wordpress/hooks": "^4.3.0",
-				"@wordpress/html-entities": "^4.3.0",
-				"@wordpress/i18n": "^5.3.0",
-				"@wordpress/icons": "^10.3.0",
-				"@wordpress/keyboard-shortcuts": "^5.3.0",
-				"@wordpress/keycodes": "^4.3.0",
-				"@wordpress/notices": "^5.3.0",
-				"@wordpress/plugins": "^7.3.0",
-				"@wordpress/preferences": "^4.3.0",
-				"@wordpress/private-apis": "^1.3.0",
-				"@wordpress/url": "^4.3.0",
-				"@wordpress/viewport": "^6.3.0",
-				"@wordpress/warning": "^3.3.0",
-				"@wordpress/widgets": "^4.3.0",
-				"clsx": "^2.1.1",
-				"memize": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/edit-post/node_modules/@wordpress/block-editor": {
-			"version": "13.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-13.4.0.tgz",
-			"integrity": "sha512-J2XwsngpxLaue8EROloT6KyRFjCk8JCl/K9UalEkrpYFFj084z7/px6LT6300Maue0ejkN8I3X4/XOe0tgOdbQ==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-8.5.0.tgz",
+			"integrity": "sha512-u0LWFT5iTXz4U0bTUvSMIQP3+BjUN7Sf36XRDzmyKkTeQC8vz0Lw/I4A6CeTJFhjhLNPzahBW5TXUj1Y26XRGA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@emotion/react": "^11.7.1",
-				"@emotion/styled": "^11.6.0",
-				"@react-spring/web": "^9.4.5",
-				"@wordpress/a11y": "^4.4.0",
-				"@wordpress/api-fetch": "^7.4.0",
-				"@wordpress/blob": "^4.4.0",
-				"@wordpress/blocks": "^13.4.0",
-				"@wordpress/commands": "^1.4.0",
-				"@wordpress/components": "^28.4.0",
-				"@wordpress/compose": "^7.4.0",
-				"@wordpress/data": "^10.4.0",
-				"@wordpress/date": "^5.4.0",
-				"@wordpress/deprecated": "^4.4.0",
-				"@wordpress/dom": "^4.4.0",
-				"@wordpress/element": "^6.4.0",
-				"@wordpress/escape-html": "^3.4.0",
-				"@wordpress/hooks": "^4.4.0",
-				"@wordpress/html-entities": "^4.4.0",
-				"@wordpress/i18n": "^5.4.0",
-				"@wordpress/icons": "^10.4.0",
-				"@wordpress/is-shallow-equal": "^5.4.0",
-				"@wordpress/keyboard-shortcuts": "^5.4.0",
-				"@wordpress/keycodes": "^4.4.0",
-				"@wordpress/notices": "^5.4.0",
-				"@wordpress/preferences": "^4.4.0",
-				"@wordpress/private-apis": "^1.4.0",
-				"@wordpress/rich-text": "^7.4.0",
-				"@wordpress/style-engine": "^2.4.0",
-				"@wordpress/token-list": "^3.4.0",
-				"@wordpress/url": "^4.4.0",
-				"@wordpress/warning": "^3.4.0",
-				"@wordpress/wordcount": "^4.4.0",
-				"change-case": "^4.1.2",
+				"@wordpress/a11y": "^4.5.0",
+				"@wordpress/api-fetch": "^7.5.0",
+				"@wordpress/block-editor": "^14.0.0",
+				"@wordpress/block-library": "^9.5.0",
+				"@wordpress/blocks": "^13.5.0",
+				"@wordpress/commands": "^1.5.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/core-commands": "^1.5.0",
+				"@wordpress/core-data": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/dom": "^4.5.0",
+				"@wordpress/editor": "^14.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/hooks": "^4.5.0",
+				"@wordpress/html-entities": "^4.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/keyboard-shortcuts": "^5.5.0",
+				"@wordpress/keycodes": "^4.5.0",
+				"@wordpress/notices": "^5.5.0",
+				"@wordpress/plugins": "^7.5.0",
+				"@wordpress/preferences": "^4.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/url": "^4.5.0",
+				"@wordpress/viewport": "^6.5.0",
+				"@wordpress/warning": "^3.5.0",
+				"@wordpress/widgets": "^4.5.0",
 				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"deepmerge": "^4.3.0",
-				"diff": "^4.0.2",
-				"fast-deep-equal": "^3.1.3",
-				"memize": "^2.1.0",
-				"postcss": "^8.4.21",
-				"postcss-prefixwrap": "^1.41.0",
-				"postcss-urlrebase": "^1.4.0",
-				"react-autosize-textarea": "^7.1.0",
-				"react-easy-crop": "^5.0.6",
-				"remove-accents": "^0.5.0"
+				"memize": "^2.1.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -11494,13 +11273,13 @@
 			}
 		},
 		"node_modules/@wordpress/interactivity": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.3.0.tgz",
-			"integrity": "sha512-zlDsgMUAx6pPm04mEL98IhjNd82jisAeOO1jRejJfXFii+HJNC3GAbqTvoYVI0NhprvAOwYsn6ABrEERyPWt0w==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.5.0.tgz",
+			"integrity": "sha512-njxbzxBFfNDhiob0UKGTNvJAyKNEmHcZ9eN7Fb1Gl8jAFnMHWbG3D6dJt7Z/E8/W7aMOjRJn/OmNhhupNHkuMw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@preact/signals": "^1.2.2",
-				"deepsignal": "^1.4.0",
 				"preact": "^10.19.3"
 			},
 			"engines": {
@@ -11509,12 +11288,13 @@
 			}
 		},
 		"node_modules/@wordpress/interactivity-router": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.3.0.tgz",
-			"integrity": "sha512-YgRqGfOGfNdYEKS5pk4gb8LbsNKImPsb3T+b2UnonRvamhZZhosPAGyJrToXXWq5HKzgBpqgAnRiJ7dmR4eG4A==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.5.0.tgz",
+			"integrity": "sha512-8IukvNdtdHG3Dyzv9epfi6ZKg+Lv5W1a9wT6ueIRYHpmKY0Zvcsq/Oy0RnnsDFIBLNlsz6HTaVwNwPzOWwJEBA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/interactivity": "^6.3.0"
+				"@wordpress/interactivity": "^6.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -11972,15 +11752,16 @@
 			}
 		},
 		"node_modules/@wordpress/router": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.3.0.tgz",
-			"integrity": "sha512-NJGdPrxJWdP00Iv6sFBdNS5ZuPbC76gxpiS75BWYeEr9Wd2MxiF4yVpIZUFkHdit7Hr9Rhah7HOsqp4T4qdIPg==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.5.0.tgz",
+			"integrity": "sha512-ckCStZLGLP3HpEaquOJTup3E9KngFbBj98tjNjtj6lL+dZnC0dwG59FPfN3tGNksbE9kVCRArMqojIPXHfEIlg==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/element": "^6.3.0",
-				"@wordpress/private-apis": "^1.3.0",
-				"@wordpress/url": "^4.3.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/url": "^4.5.0",
 				"history": "^5.3.0"
 			},
 			"engines": {
@@ -12741,23 +12522,24 @@
 			}
 		},
 		"node_modules/@wordpress/widgets": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/widgets/-/widgets-4.3.0.tgz",
-			"integrity": "sha512-x61x5m3mMeD4/KN9grfswiYbpp/SKKn0Q5ci8lI3bdGXuKIaUPqcon0D55F1n+58P4+FvlGLefFEuNOf/Ls2Ug==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/widgets/-/widgets-4.5.0.tgz",
+			"integrity": "sha512-8HLny/s1UEeeE25t07mQrrYan56L854Q8ZZPJ2P+8Rmb98J+yy/bvrTtFVm4MFFFFY7fCEoylltEPXPzITgEEQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "^7.3.0",
-				"@wordpress/block-editor": "^13.3.0",
-				"@wordpress/blocks": "^13.3.0",
-				"@wordpress/components": "^28.3.0",
-				"@wordpress/compose": "^7.3.0",
-				"@wordpress/core-data": "^7.3.0",
-				"@wordpress/data": "^10.3.0",
-				"@wordpress/element": "^6.3.0",
-				"@wordpress/i18n": "^5.3.0",
-				"@wordpress/icons": "^10.3.0",
-				"@wordpress/notices": "^5.3.0",
+				"@wordpress/api-fetch": "^7.5.0",
+				"@wordpress/block-editor": "^14.0.0",
+				"@wordpress/blocks": "^13.5.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/core-data": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/notices": "^5.5.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -12767,95 +12549,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/widgets/node_modules/@wordpress/block-editor": {
-			"version": "13.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-13.4.0.tgz",
-			"integrity": "sha512-J2XwsngpxLaue8EROloT6KyRFjCk8JCl/K9UalEkrpYFFj084z7/px6LT6300Maue0ejkN8I3X4/XOe0tgOdbQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@emotion/react": "^11.7.1",
-				"@emotion/styled": "^11.6.0",
-				"@react-spring/web": "^9.4.5",
-				"@wordpress/a11y": "^4.4.0",
-				"@wordpress/api-fetch": "^7.4.0",
-				"@wordpress/blob": "^4.4.0",
-				"@wordpress/blocks": "^13.4.0",
-				"@wordpress/commands": "^1.4.0",
-				"@wordpress/components": "^28.4.0",
-				"@wordpress/compose": "^7.4.0",
-				"@wordpress/data": "^10.4.0",
-				"@wordpress/date": "^5.4.0",
-				"@wordpress/deprecated": "^4.4.0",
-				"@wordpress/dom": "^4.4.0",
-				"@wordpress/element": "^6.4.0",
-				"@wordpress/escape-html": "^3.4.0",
-				"@wordpress/hooks": "^4.4.0",
-				"@wordpress/html-entities": "^4.4.0",
-				"@wordpress/i18n": "^5.4.0",
-				"@wordpress/icons": "^10.4.0",
-				"@wordpress/is-shallow-equal": "^5.4.0",
-				"@wordpress/keyboard-shortcuts": "^5.4.0",
-				"@wordpress/keycodes": "^4.4.0",
-				"@wordpress/notices": "^5.4.0",
-				"@wordpress/preferences": "^4.4.0",
-				"@wordpress/private-apis": "^1.4.0",
-				"@wordpress/rich-text": "^7.4.0",
-				"@wordpress/style-engine": "^2.4.0",
-				"@wordpress/token-list": "^3.4.0",
-				"@wordpress/url": "^4.4.0",
-				"@wordpress/warning": "^3.4.0",
-				"@wordpress/wordcount": "^4.4.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"deepmerge": "^4.3.0",
-				"diff": "^4.0.2",
-				"fast-deep-equal": "^3.1.3",
-				"memize": "^2.1.0",
-				"postcss": "^8.4.21",
-				"postcss-prefixwrap": "^1.41.0",
-				"postcss-urlrebase": "^1.4.0",
-				"react-autosize-textarea": "^7.1.0",
-				"react-easy-crop": "^5.0.6",
-				"remove-accents": "^0.5.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/widgets/node_modules/@wordpress/keycodes": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.5.0.tgz",
-			"integrity": "sha512-5kCxbP+xqAr0pwftdvnM+oAqGa6r0IQoct9TyvqXE2hdE9Cnu5RlnVG30Ki7/3d1KoMRBh00nFoS2RzpWbOq+A==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.5.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/widgets/node_modules/@wordpress/warning": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.5.0.tgz",
-			"integrity": "sha512-cYM2Vqf2EokJJoWHD5Ry15OUmdsKtDgR8/qxE0sWHUAdSQeoTuJZnqhgYI898cZGxHaZWX2xJCxQa7Qtwl8lqw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/wordcount": {
@@ -16167,32 +15860,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/deepsignal": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.5.0.tgz",
-			"integrity": "sha512-bFywDpBUUWMs576H2dgLFLLFuQ/UWXbzHfKD98MZTfGsl7+twIzvz4ihCNrRrZ/Emz3kqJaNIAp5eBWUEWhnAw==",
-			"dev": true,
-			"peerDependencies": {
-				"@preact/signals": "^1.1.4",
-				"@preact/signals-core": "^1.5.1",
-				"@preact/signals-react": "^1.3.8 || ^2.0.0",
-				"preact": "^10.16.0"
-			},
-			"peerDependenciesMeta": {
-				"@preact/signals": {
-					"optional": true
-				},
-				"@preact/signals-core": {
-					"optional": true
-				},
-				"@preact/signals-react": {
-					"optional": true
-				},
-				"preact": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/default-gateway": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -18215,6 +17882,7 @@
 			"resolved": "https://registry.npmjs.org/fast-average-color/-/fast-average-color-9.4.0.tgz",
 			"integrity": "sha512-bvM8vV6YwK07dPbzFz77zJaBcfF6ABVfgNwaxVgXc2G+o0e/tzLCF9WU8Ryp1r0Nkk6JuJNsWCzbb4cLOMlB+Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 12"
 			}
@@ -19399,6 +19067,7 @@
 			"resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
 			"integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.7.6"
 			}
@@ -27611,10 +27280,11 @@
 			"license": "MIT"
 		},
 		"node_modules/preact": {
-			"version": "10.22.1",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.22.1.tgz",
-			"integrity": "sha512-jRYbDDgMpIb5LHq3hkI0bbl+l/TQ9UnkdQ0ww+lp+4MMOdqaUYdFc5qeyP+IV8FAd/2Em7drVPeKdQxsiWCf/A==",
+			"version": "10.23.2",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.23.2.tgz",
+			"integrity": "sha512-kKYfePf9rzKnxOAKDpsWhg/ysrHPqT+yQ7UW4JjdnqjFIeNUnNcEJvhuA8fDenxAGWzUqtd51DfVg7xp/8T9NA==",
 			"dev": true,
+			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"@wordpress/core-data": "^7.5.0",
 		"@wordpress/data": "^10.5.0",
 		"@wordpress/e2e-test-utils": "^11.5.0",
-		"@wordpress/edit-post": "^8.3.0",
+		"@wordpress/edit-post": "^8.5.0",
 		"@wordpress/editor": "^14.5.0",
 		"@wordpress/element": "^6.5.0",
 		"@wordpress/env": "^10.5.0",


### PR DESCRIPTION
dependabot PR #2702 was getting hard to handle, so this PR supersedes it by manually updating `@wordpress/edit-post` using the following command:

```shell
npm install @wordpress/edit-post@8.5.0 --save-dev
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Upgraded the `@wordpress/edit-post` package to version `8.5.0`, enhancing functionality and performance with potential new features and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->