### PR TITLE
Merge trunk into develop after the wp-parsely 3.16.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.4](https://github.com/Parsely/wp-parsely/compare/3.16.3...3.16.4) - 2024-08-21
+
+### Fixed
+
+- Fix current_user_can_use_pch_feature() issues ([#2723](https://github.com/Parsely/wp-parsely/pull/2723))
+
+### Dependency Updates
+
+- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.16.4+label%3A%22Component%3A+Dependencies%22).
+
 ## [3.16.3](https://github.com/Parsely/wp-parsely/compare/3.16.2...3.16.3) - 2024-08-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.16.3  
+Stable tag: 3.16.4  
 Requires at least: 5.2  
 Tested up to: 6.5  
 Requires PHP: 7.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.16.3",
+	"version": "3.16.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.16.3",
+			"version": "3.16.4",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12694,11 +12694,10 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-			"integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+			"integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
 				"form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.16.3",
+	"version": "3.16.4",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/src/class-permissions.php
+++ b/src/class-permissions.php
@@ -70,16 +70,6 @@ class Permissions {
 			return false;
 		}
 
-		// All AI features are disabled.
-		if ( true !== $pch_options['ai_features_enabled'] ) {
-			return false;
-		}
-
-		// The specific AI feature is disabled.
-		if ( true !== $feature_options['enabled'] ) {
-			return false;
-		}
-
 		$current_user = wp_get_current_user();
 		$user_roles   = $current_user->roles;
 
@@ -91,21 +81,38 @@ class Permissions {
 		 *
 		 * @since 3.16.2
 		 *
-		 * @param bool   $current_user_can_use_pch_feature Whether the current user can use the feature.
+		 * @param ?bool   $current_user_can_use_pch_feature Whether the current user can use the feature.
+		 *                                                  Is null when the filter isn't being used.
 		 * @param string $feature_name The feature's name.
 		 * @param \WP_User $current_user The current user object.
 		 * @param int|false $post_id The post ID, if the check is for a specific post.
 		 */
 		$filtered_current_user_can_use_pch_feature = apply_filters(
 			'wp_parsely_current_user_can_use_pch_feature',
-			false,
+			null,
 			$feature_name,
 			$current_user,
 			$post_id
 		);
 
-		if ( true === $filtered_current_user_can_use_pch_feature ) {
-			return true;
+		// When $wp_parsely_current_user_can_use_pch_feature's value is set,
+		// return it without further processing.
+		if ( null !== $filtered_current_user_can_use_pch_feature ) {
+			if ( true === $filtered_current_user_can_use_pch_feature ) {
+				return true;
+			}
+
+			return false;
+		}
+
+		// All AI features are disabled.
+		if ( true !== $pch_options['ai_features_enabled'] ) {
+			return false;
+		}
+
+		// The specific AI feature is disabled.
+		if ( true !== $feature_options['enabled'] ) {
+			return false;
 		}
 
 		// Current user's role is not yet set.

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-export const PLUGIN_VERSION = '3.16.3';
+export const PLUGIN_VERSION = '3.16.4';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.16.3
+ * Version:           3.16.4
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -70,7 +70,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION = '3.16.3';
+const PARSELY_VERSION = '3.16.4';
 const PARSELY_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/Models/class-base-model.php';


### PR DESCRIPTION
This PR merges the `trunk` branch into the `develop` branch after the release of wp-parsely 3.16.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced version 3.16.4 of the plugin, signaling potential improvements and fixes.
	
- **Bug Fixes**
	- Resolved issues related to user permissions for AI features, improving adaptability to various configurations.
	
- **Documentation**
	- Updated the README and CHANGELOG to reflect the new version and improvements made in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->