### PR TITLE
Settings_Page: Remove duplicate phpstan-import-type declaration

### DIFF
--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -23,8 +23,6 @@ use const Parsely\PARSELY_FILE;
  *
  * @since 3.0.0
  *
- * @phpstan-import-type Parsely_Options from Parsely
- *
  * @phpstan-type Setting_Arguments array{
  *   add_fieldset?: bool,
  *   legend?: string,


### PR DESCRIPTION
## Description
With this PR, we're removing a duplicate `phpstan-import-type` declaration in the `Settings_Page` class.

## Motivation and context
Remove unneeded code.

## How has this been tested?
PHPStan doesn't complain after removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Streamlined documentation comments by removing unnecessary type imports, enhancing clarity and relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->