### PR TITLE
Bump @wordpress/editor from 14.5.0 to 14.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"@wordpress/data": "^10.7.0",
 				"@wordpress/e2e-test-utils-playwright": "^1.7.0",
 				"@wordpress/edit-post": "^8.5.0",
-				"@wordpress/editor": "^14.5.0",
+				"@wordpress/editor": "^14.7.0",
 				"@wordpress/element": "^6.7.0",
 				"@wordpress/env": "^10.7.0",
 				"@wordpress/eslint-plugin": "^21.0.0",
@@ -2683,34 +2683,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@jest/console/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/console/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
 		"node_modules/@jest/console/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2835,34 +2807,6 @@
 				}
 			}
 		},
-		"node_modules/@jest/core/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/core/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
 		"node_modules/@jest/core/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2983,110 +2927,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@jest/environment/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@jest/environment/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/@jest/expect": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
@@ -3132,110 +2972,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@jest/fake-timers/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@jest/fake-timers/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/@jest/globals": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -3250,110 +2986,6 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@jest/globals/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/@jest/reporters": {
@@ -3398,34 +3030,6 @@
 				"node-notifier": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
 			}
 		},
 		"node_modules/@jest/reporters/node_modules/ansi-styles": {
@@ -3492,9 +3096,9 @@
 			}
 		},
 		"node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
-			"integrity": "sha512-1WUsZ9R1lA0HtBSohTkm39WTPlNKSJ5iFk7UwqXkBLoHQT+hfqPsfsTDVuZdKGaBwn7din9bS7SsnoAr943hvw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+			"integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -3509,9 +3113,9 @@
 			}
 		},
 		"node_modules/@jest/reporters/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -3578,110 +3182,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@jest/test-result/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/test-result/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
-		"node_modules/@jest/test-result/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/test-result/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@jest/test-result/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/@jest/test-result/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@jest/test-result/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@jest/test-result/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/@jest/test-sequencer": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
@@ -3723,34 +3223,6 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/transform/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/transform/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
 			}
 		},
 		"node_modules/@jest/transform/node_modules/ansi-styles": {
@@ -3817,6 +3289,100 @@
 			}
 		},
 		"node_modules/@jest/transform/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/types": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "^29.6.3",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.8",
+				"chalk": "^4.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/types/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@jest/types/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@jest/types/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@jest/types/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@jest/types/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/types/node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -5680,9 +5246,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"version": "18.3.5",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.5.tgz",
+			"integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8614,6 +8180,16 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/yargs": {
+			"version": "17.0.33",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+			"integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
 		"node_modules/@types/yargs-parser": {
 			"version": "21.0.3",
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
@@ -8669,9 +8245,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -8800,9 +8376,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -8839,9 +8415,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -9353,14 +8929,14 @@
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/keycodes": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.5.0.tgz",
-			"integrity": "sha512-5kCxbP+xqAr0pwftdvnM+oAqGa6r0IQoct9TyvqXE2hdE9Cnu5RlnVG30Ki7/3d1KoMRBh00nFoS2RzpWbOq+A==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.7.0.tgz",
+			"integrity": "sha512-x8I0xjRM8U0RnpFHWN9mA+x3MqjhJNBldiCpb59GTi3BIzPeDPgxbosAsAAgF0pYdDtGyiRkrOZA23NTia63TA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.5.0"
+				"@wordpress/i18n": "^5.7.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10139,22 +9715,23 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-4.1.0.tgz",
-			"integrity": "sha512-8lumuvMiVZgz4cYRv3hY4kmVeG7cNk+JtvRoEb0ysre0k6QEl/SZFinEge0eMfpsdvCdagFv4le/n7CXidEB2g==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-4.3.0.tgz",
+			"integrity": "sha512-ZAKgac4sFINnAKABhf4/0qAEm1LTTRDJGd8+qfi6mbiQr42BoNVIKtFw8o5uOL4cOEF01wdoUDaCZv6oP9e+eA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.7",
+				"@ariakit/react": "^0.4.10",
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/components": "^28.5.0",
-				"@wordpress/compose": "^7.5.0",
-				"@wordpress/data": "^10.5.0",
-				"@wordpress/element": "^6.5.0",
-				"@wordpress/i18n": "^5.5.0",
-				"@wordpress/icons": "^10.5.0",
-				"@wordpress/primitives": "^4.5.0",
-				"@wordpress/private-apis": "^1.5.0",
-				"@wordpress/warning": "^3.5.0",
+				"@wordpress/components": "^28.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/primitives": "^4.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/warning": "^3.7.0",
 				"clsx": "^2.1.1",
 				"remove-accents": "^0.5.0"
 			},
@@ -10167,18 +9744,20 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@ariakit/core": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.8.tgz",
-			"integrity": "sha512-HQS+9CI7pMqqVlAt5bPGenT0/e65UxXY+PKtgU7Y+0UToBDBRolO5S9+UUSDm8OmJHSnq24owEGm1Mv28l5XCQ==",
-			"dev": true
+			"version": "0.4.10",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.10.tgz",
+			"integrity": "sha512-mX3EabQbfVh5uTjsTJ3+gjj7KGdTNhIN0qZHJd5Z2iPUnKl9NBy23Lgu6PEskpVsKAZ3proirjguD7U9fKMs/A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@ariakit/react": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.8.tgz",
-			"integrity": "sha512-Bb1vOrp0X52hxi1wE9TEHjjZ/Y08tVq2ZH+RFDwRQB3g04uVwrrhnTccHepC6rsObrDpAOV3/YlJCi4k/lSUaQ==",
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.11.tgz",
+			"integrity": "sha512-nLpPrmNcspqNhk4o+epsgeZfP1+Fkh4uIzNe5yrFkXolRkqHGKAxl4Hi82e0yxIBUbYbZIEwsZQQVceF1L6xrw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@ariakit/react-core": "0.4.8"
+				"@ariakit/react-core": "0.4.11"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -10190,12 +9769,13 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@ariakit/react-core": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.8.tgz",
-			"integrity": "sha512-TzsddUWQwWYhrEVWHA/Gf7KCGx8rwFohAHfuljjqidKeZi2kUmuRAImCTG9oga34FWHFf4AdXQbBKclMNt0nrQ==",
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.11.tgz",
+			"integrity": "sha512-i6KedWhjZkNC7tMEKO0eNjjq2HRPiHyGaBS2x2VaWwzBepoYtjyvxRXyqLJ3gaiNdlwckN1TZsRDfD+viy13IQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@ariakit/core": "0.4.8",
+				"@ariakit/core": "0.4.10",
 				"@floating-ui/dom": "^1.0.0",
 				"use-sync-external-store": "^1.2.0"
 			},
@@ -10205,10 +9785,11 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/warning": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.5.0.tgz",
-			"integrity": "sha512-cYM2Vqf2EokJJoWHD5Ry15OUmdsKtDgR8/qxE0sWHUAdSQeoTuJZnqhgYI898cZGxHaZWX2xJCxQa7Qtwl8lqw==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.7.0.tgz",
+			"integrity": "sha512-wGbQfPlf8YV6gGhcGPYWUhHORct4xaBQSaDTJrwzlgHYyrrJUVXXgZxaM4+Aa23zQoA13nvFQHvfssOkwdh65g==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -10357,14 +9938,14 @@
 			}
 		},
 		"node_modules/@wordpress/edit-post/node_modules/@wordpress/keycodes": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.5.0.tgz",
-			"integrity": "sha512-5kCxbP+xqAr0pwftdvnM+oAqGa6r0IQoct9TyvqXE2hdE9Cnu5RlnVG30Ki7/3d1KoMRBh00nFoS2RzpWbOq+A==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.7.0.tgz",
+			"integrity": "sha512-x8I0xjRM8U0RnpFHWN9mA+x3MqjhJNBldiCpb59GTi3BIzPeDPgxbosAsAAgF0pYdDtGyiRkrOZA23NTia63TA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.5.0"
+				"@wordpress/i18n": "^5.7.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10372,9 +9953,9 @@
 			}
 		},
 		"node_modules/@wordpress/edit-post/node_modules/@wordpress/warning": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.5.0.tgz",
-			"integrity": "sha512-cYM2Vqf2EokJJoWHD5Ry15OUmdsKtDgR8/qxE0sWHUAdSQeoTuJZnqhgYI898cZGxHaZWX2xJCxQa7Qtwl8lqw==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.7.0.tgz",
+			"integrity": "sha512-wGbQfPlf8YV6gGhcGPYWUhHORct4xaBQSaDTJrwzlgHYyrrJUVXXgZxaM4+Aa23zQoA13nvFQHvfssOkwdh65g==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10383,46 +9964,47 @@
 			}
 		},
 		"node_modules/@wordpress/editor": {
-			"version": "14.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.5.0.tgz",
-			"integrity": "sha512-6fsUiaTrluTiq403OZkaeHj8thclgrOYB2cQ/BoHg9OkUFOAae4cns0+LU+o8BobSY4KGX99v/WT4SMtg4h3TQ==",
+			"version": "14.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.7.0.tgz",
+			"integrity": "sha512-kpDgRAh5FfxmDfyhaVchXRmM5ueQfcYGqyKdXExe1Mt/Anw8IxHcz7/YqtE+L8BakDsS/A7OudlBiLANjrhUVw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.5.0",
-				"@wordpress/api-fetch": "^7.5.0",
-				"@wordpress/blob": "^4.5.0",
-				"@wordpress/block-editor": "^14.0.0",
-				"@wordpress/blocks": "^13.5.0",
-				"@wordpress/commands": "^1.5.0",
-				"@wordpress/components": "^28.5.0",
-				"@wordpress/compose": "^7.5.0",
-				"@wordpress/core-data": "^7.5.0",
-				"@wordpress/data": "^10.5.0",
-				"@wordpress/dataviews": "^4.1.0",
-				"@wordpress/date": "^5.5.0",
-				"@wordpress/deprecated": "^4.5.0",
-				"@wordpress/dom": "^4.5.0",
-				"@wordpress/element": "^6.5.0",
-				"@wordpress/hooks": "^4.5.0",
-				"@wordpress/html-entities": "^4.5.0",
-				"@wordpress/i18n": "^5.5.0",
-				"@wordpress/icons": "^10.5.0",
-				"@wordpress/interface": "^6.5.0",
-				"@wordpress/keyboard-shortcuts": "^5.5.0",
-				"@wordpress/keycodes": "^4.5.0",
-				"@wordpress/media-utils": "^5.5.0",
-				"@wordpress/notices": "^5.5.0",
-				"@wordpress/patterns": "^2.5.0",
-				"@wordpress/plugins": "^7.5.0",
-				"@wordpress/preferences": "^4.5.0",
-				"@wordpress/private-apis": "^1.5.0",
-				"@wordpress/reusable-blocks": "^5.5.0",
-				"@wordpress/rich-text": "^7.5.0",
-				"@wordpress/server-side-render": "^5.5.0",
-				"@wordpress/url": "^4.5.0",
-				"@wordpress/warning": "^3.5.0",
-				"@wordpress/wordcount": "^4.5.0",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/api-fetch": "^7.7.0",
+				"@wordpress/blob": "^4.7.0",
+				"@wordpress/block-editor": "^14.2.0",
+				"@wordpress/blocks": "^13.7.0",
+				"@wordpress/commands": "^1.7.0",
+				"@wordpress/components": "^28.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/core-data": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/dataviews": "^4.3.0",
+				"@wordpress/date": "^5.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/dom": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/hooks": "^4.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/interface": "^6.7.0",
+				"@wordpress/keyboard-shortcuts": "^5.7.0",
+				"@wordpress/keycodes": "^4.7.0",
+				"@wordpress/media-utils": "^5.7.0",
+				"@wordpress/notices": "^5.7.0",
+				"@wordpress/patterns": "^2.7.0",
+				"@wordpress/plugins": "^7.7.0",
+				"@wordpress/preferences": "^4.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/reusable-blocks": "^5.7.0",
+				"@wordpress/rich-text": "^7.7.0",
+				"@wordpress/server-side-render": "^5.7.0",
+				"@wordpress/url": "^4.7.0",
+				"@wordpress/warning": "^3.7.0",
+				"@wordpress/wordcount": "^4.7.0",
 				"change-case": "^4.1.2",
 				"client-zip": "^2.4.5",
 				"clsx": "^2.1.1",
@@ -10445,13 +10027,14 @@
 			}
 		},
 		"node_modules/@wordpress/editor/node_modules/@wordpress/keycodes": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.5.0.tgz",
-			"integrity": "sha512-5kCxbP+xqAr0pwftdvnM+oAqGa6r0IQoct9TyvqXE2hdE9Cnu5RlnVG30Ki7/3d1KoMRBh00nFoS2RzpWbOq+A==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.7.0.tgz",
+			"integrity": "sha512-x8I0xjRM8U0RnpFHWN9mA+x3MqjhJNBldiCpb59GTi3BIzPeDPgxbosAsAAgF0pYdDtGyiRkrOZA23NTia63TA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.5.0"
+				"@wordpress/i18n": "^5.7.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10459,10 +10042,11 @@
 			}
 		},
 		"node_modules/@wordpress/editor/node_modules/@wordpress/warning": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.5.0.tgz",
-			"integrity": "sha512-cYM2Vqf2EokJJoWHD5Ry15OUmdsKtDgR8/qxE0sWHUAdSQeoTuJZnqhgYI898cZGxHaZWX2xJCxQa7Qtwl8lqw==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.7.0.tgz",
+			"integrity": "sha512-wGbQfPlf8YV6gGhcGPYWUhHORct4xaBQSaDTJrwzlgHYyrrJUVXXgZxaM4+Aa23zQoA13nvFQHvfssOkwdh65g==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -10838,9 +10422,9 @@
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -10955,24 +10539,25 @@
 			}
 		},
 		"node_modules/@wordpress/interface": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-6.5.0.tgz",
-			"integrity": "sha512-FLvXDb7namO6yCc/OipcEHauqCq1MKWSSLbnVBPlXDaTvoaw9LkU5JACI//yFemIe4v5RjKQ7fdXouccixosng==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-6.7.0.tgz",
+			"integrity": "sha512-Me6EaNHNPcI9hiX97hYC2f7Y5PnuQ/HN3yo1DB4/+AAW/71Gl9oGKebGujivchl7RJ3a7Ztg/PJYIDFA+B/XEA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.5.0",
-				"@wordpress/components": "^28.5.0",
-				"@wordpress/compose": "^7.5.0",
-				"@wordpress/data": "^10.5.0",
-				"@wordpress/deprecated": "^4.5.0",
-				"@wordpress/element": "^6.5.0",
-				"@wordpress/i18n": "^5.5.0",
-				"@wordpress/icons": "^10.5.0",
-				"@wordpress/plugins": "^7.5.0",
-				"@wordpress/preferences": "^4.5.0",
-				"@wordpress/private-apis": "^1.5.0",
-				"@wordpress/viewport": "^6.5.0",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/components": "^28.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/plugins": "^7.7.0",
+				"@wordpress/preferences": "^4.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/viewport": "^6.7.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -11114,16 +10699,17 @@
 			}
 		},
 		"node_modules/@wordpress/media-utils": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.5.0.tgz",
-			"integrity": "sha512-jrbM+lw6s2b5+CAOXs6K+NYGoZY0Yggu4X73RrKeYG9Vwmg23oMP742nZwztVGMuyr06Yh/1Ym7Amgfrd3cKqA==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.7.0.tgz",
+			"integrity": "sha512-uWaU/El9f58fdj9gYWqlTvH2m+5MmV2SKl0jsQhJXL+NEBY8KWsXwAWJyNJ6LyAQztoU1evHIB7a07GJp7gksg==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "^7.5.0",
-				"@wordpress/blob": "^4.5.0",
-				"@wordpress/element": "^6.5.0",
-				"@wordpress/i18n": "^5.5.0"
+				"@wordpress/api-fetch": "^7.7.0",
+				"@wordpress/blob": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/i18n": "^5.7.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -11162,26 +10748,27 @@
 			}
 		},
 		"node_modules/@wordpress/patterns": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.5.0.tgz",
-			"integrity": "sha512-jL41tCIShAUg017kGLSpD39L9zSWyepIiWZe+U0gD9FZo42c8aAMUmKTy4pwUI3hv67x0ZpvtcR5KegOJlZKfw==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.7.0.tgz",
+			"integrity": "sha512-6aE/+bSsAqffzqWLKReN9o5Szk4zMyNzkCsclSPjNp/hBCY7HYKfqlD6TNqLWKLlHgw+mYmtw5gZho6U3hRO9Q==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.5.0",
-				"@wordpress/block-editor": "^14.0.0",
-				"@wordpress/blocks": "^13.5.0",
-				"@wordpress/components": "^28.5.0",
-				"@wordpress/compose": "^7.5.0",
-				"@wordpress/core-data": "^7.5.0",
-				"@wordpress/data": "^10.5.0",
-				"@wordpress/element": "^6.5.0",
-				"@wordpress/html-entities": "^4.5.0",
-				"@wordpress/i18n": "^5.5.0",
-				"@wordpress/icons": "^10.5.0",
-				"@wordpress/notices": "^5.5.0",
-				"@wordpress/private-apis": "^1.5.0",
-				"@wordpress/url": "^4.5.0"
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/block-editor": "^14.2.0",
+				"@wordpress/blocks": "^13.7.0",
+				"@wordpress/components": "^28.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/core-data": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/notices": "^5.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/url": "^4.7.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -11338,23 +10925,24 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.5.0.tgz",
-			"integrity": "sha512-lpin5UU7+RpgrpKjG65LHJWfbPWWDXdDDFsAkB6yNbbVamR0R9BMeFKzjPxKSfue7bRrmq2L7l9g9HneZcuvEQ==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.7.0.tgz",
+			"integrity": "sha512-F4CPUtLMKPSDK+OdrJRRBFlA6yBHpfV2tfcrqpo95l06GskIrgr1IQpyLiFnVKZPhO82K5Y/R3NS0xwD2NxuRQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/block-editor": "^14.0.0",
-				"@wordpress/blocks": "^13.5.0",
-				"@wordpress/components": "^28.5.0",
-				"@wordpress/core-data": "^7.5.0",
-				"@wordpress/data": "^10.5.0",
-				"@wordpress/element": "^6.5.0",
-				"@wordpress/i18n": "^5.5.0",
-				"@wordpress/icons": "^10.5.0",
-				"@wordpress/notices": "^5.5.0",
-				"@wordpress/private-apis": "^1.5.0",
-				"@wordpress/url": "^4.5.0"
+				"@wordpress/block-editor": "^14.2.0",
+				"@wordpress/blocks": "^13.7.0",
+				"@wordpress/components": "^28.7.0",
+				"@wordpress/core-data": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/notices": "^5.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/url": "^4.7.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -11502,34 +11090,6 @@
 				"@playwright/test": "^1.43.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/@typescript-eslint/scope-manager": {
@@ -11834,31 +11394,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@wordpress/scripts/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/devtools-protocol": {
-			"version": "0.0.981744",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.981744.tgz",
-			"integrity": "sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/@wordpress/scripts/node_modules/eslint-plugin-jest": {
 			"version": "27.9.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
@@ -11883,27 +11418,6 @@
 				"jest": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/extract-zip": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"get-stream": "^5.1.0",
-				"yauzl": "^2.10.0"
-			},
-			"bin": {
-				"extract-zip": "cli.js"
-			},
-			"engines": {
-				"node": ">= 10.17.0"
-			},
-			"optionalDependencies": {
-				"@types/yauzl": "^2.9.1"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/globals": {
@@ -11932,24 +11446,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/jest-environment-node": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/@wordpress/scripts/node_modules/prettier": {
 			"name": "wp-prettier",
 			"version": "3.0.3",
@@ -11967,49 +11463,10 @@
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/puppeteer-core": {
-			"version": "13.7.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-13.7.0.tgz",
-			"integrity": "sha512-rXja4vcnAzFAP1OVLq/5dWNfwBGuzcOARJ6qGV7oAZhnLmVRU8G5MsdeQEAOy332ZhkIOnn9jp15R89LKHyp2Q==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"cross-fetch": "3.1.5",
-				"debug": "4.3.4",
-				"devtools-protocol": "0.0.981744",
-				"extract-zip": "2.0.1",
-				"https-proxy-agent": "5.0.1",
-				"pkg-dir": "4.2.0",
-				"progress": "2.0.3",
-				"proxy-from-env": "1.1.0",
-				"rimraf": "3.0.2",
-				"tar-fs": "2.1.1",
-				"unbzip2-stream": "1.4.3",
-				"ws": "8.5.0"
-			},
-			"engines": {
-				"node": ">=10.18.1"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/@wordpress/scripts/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -12032,36 +11489,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/tar-fs": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chownr": "^1.1.1",
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.1.4"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/tar-stream": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bl": "^4.0.3",
-				"end-of-stream": "^1.4.1",
-				"fs-constants": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/@wordpress/scripts/node_modules/type-fest": {
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -12082,44 +11509,23 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
-		"node_modules/@wordpress/scripts/node_modules/ws": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-			"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@wordpress/server-side-render": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-5.5.0.tgz",
-			"integrity": "sha512-k+ns+sQE6xJhoJ9mxwEmCTPVAedvPh1l1gkS0IlG8ST+cZbDiAPerfvVtlywrhsKz65w2VHK9HEBf7nkg1ivSA==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-5.7.0.tgz",
+			"integrity": "sha512-VXBluHj/WICCx4OcjZrcrBg+YxXbah1YL4n2yLWhDMENAL0p4Ne67EqrQjCGbIfpGUpNDCQhIXXzSJ3gNiuCMg==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "^7.5.0",
-				"@wordpress/blocks": "^13.5.0",
-				"@wordpress/components": "^28.5.0",
-				"@wordpress/compose": "^7.5.0",
-				"@wordpress/data": "^10.5.0",
-				"@wordpress/deprecated": "^4.5.0",
-				"@wordpress/element": "^6.5.0",
-				"@wordpress/i18n": "^5.5.0",
-				"@wordpress/url": "^4.5.0",
+				"@wordpress/api-fetch": "^7.7.0",
+				"@wordpress/blocks": "^13.7.0",
+				"@wordpress/components": "^28.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/url": "^4.7.0",
 				"fast-deep-equal": "^3.1.3"
 			},
 			"engines": {
@@ -12240,15 +11646,16 @@
 			}
 		},
 		"node_modules/@wordpress/viewport": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.5.0.tgz",
-			"integrity": "sha512-kIBe26eQI1kcVF1kR983qX0P4r+NAO0yuiyLQcfqPc04P74icWiIbqnHWnKXJIxRIrM3UQBX0cvvhntQbjR8fg==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.7.0.tgz",
+			"integrity": "sha512-T05rktsX+xOgTekKKRIAwuK+FdtmOMQVfbkxtGW2RtfwBWc161ZdgXT0C3x+LWwzhocYg2ymwkM9Mm8/MBhgFw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^7.5.0",
-				"@wordpress/data": "^10.5.0",
-				"@wordpress/element": "^6.5.0"
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/element": "^6.7.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12469,16 +11876,16 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-			"integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.4.1"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -14696,9 +14103,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.37.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
-			"integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
+			"version": "3.38.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+			"integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -14777,34 +14184,6 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
 			}
 		},
 		"node_modules/create-jest/node_modules/ansi-styles": {
@@ -15046,9 +14425,9 @@
 			}
 		},
 		"node_modules/css-loader/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -15390,9 +14769,9 @@
 			"license": "MIT"
 		},
 		"node_modules/debug": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -15831,9 +15210,9 @@
 			}
 		},
 		"node_modules/docker-compose/node_modules/yaml": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.3.tgz",
-			"integrity": "sha512-sntgmxj8o7DE7g/Qi60cqpLBA3HG3STcDA0kO+WfB05jEKhZMbY7umNm2rBpQvsmZ16/lPXCJGW2672dgOUkrg==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
+			"integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -16637,9 +16016,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -17613,6 +16992,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-uri": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
+			"integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/fastest-levenshtein": {
 			"version": "1.0.16",
 			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -18154,9 +17540,9 @@
 			"license": "ISC"
 		},
 		"node_modules/fsevents": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -19070,9 +18456,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -20162,9 +19548,9 @@
 			}
 		},
 		"node_modules/istanbul-lib-report/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -20314,34 +19700,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-circus/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
 		"node_modules/jest-circus/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -20480,34 +19838,6 @@
 				}
 			}
 		},
-		"node_modules/jest-cli/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
 		"node_modules/jest-cli/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -20630,34 +19960,6 @@
 				}
 			}
 		},
-		"node_modules/jest-config/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-config/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
 		"node_modules/jest-config/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -20719,24 +20021,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/jest-config/node_modules/jest-environment-node": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/jest-config/node_modules/pretty-format": {
@@ -21024,34 +20308,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-each/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-each/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
 		"node_modules/jest-each/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -21184,108 +20440,22 @@
 				}
 			}
 		},
-		"node_modules/jest-environment-jsdom/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+		"node_modules/jest-environment-node": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/jest-environment-jsdom/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/jest-get-type": {
@@ -21322,110 +20492,6 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "^2.3.2"
-			}
-		},
-		"node_modules/jest-haste-map/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-haste-map/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
-		"node_modules/jest-haste-map/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-haste-map/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/jest-haste-map/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/jest-haste-map/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/jest-haste-map/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest-haste-map/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/jest-leak-detector": {
@@ -21611,34 +20677,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-message-util/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-message-util/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
 		"node_modules/jest-message-util/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -21756,110 +20794,6 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-mock/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-mock/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
-		"node_modules/jest-mock/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-mock/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/jest-mock/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/jest-mock/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/jest-mock/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest-mock/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/jest-pnp-resolver": {
@@ -22034,34 +20968,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-runner/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-runner/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
 		"node_modules/jest-runner/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -22125,24 +21031,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/jest-runner/node_modules/jest-environment-node": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/jest-runner/node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -22188,34 +21076,6 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
 			}
 		},
 		"node_modules/jest-runtime/node_modules/ansi-styles": {
@@ -22326,34 +21186,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-snapshot/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
 		"node_modules/jest-snapshot/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -22446,9 +21278,9 @@
 			}
 		},
 		"node_modules/jest-snapshot/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -22487,34 +21319,6 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-util/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-util/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
 			}
 		},
 		"node_modules/jest-util/node_modules/ansi-styles": {
@@ -22609,34 +21413,6 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-validate/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-validate/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
 			}
 		},
 		"node_modules/jest-validate/node_modules/ansi-styles": {
@@ -22763,34 +21539,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-watcher/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-watcher/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
 		"node_modules/jest-watcher/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -22907,110 +21655,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
-		"node_modules/jest/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
-		"node_modules/jest/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/jest/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/jest/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/jest/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/joi": {
@@ -23513,24 +22157,6 @@
 				"node-fetch": "^2.6.12"
 			}
 		},
-		"node_modules/lighthouse/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/lighthouse/node_modules/extract-zip": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -23567,9 +22193,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/https-proxy-agent": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-			"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+			"integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -23708,9 +22334,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"version": "7.5.10",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -24175,16 +22801,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || >=14"
-			}
-		},
-		"node_modules/markdownlint-cli/node_modules/ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/js-yaml": {
@@ -24820,9 +23436,9 @@
 			}
 		},
 		"node_modules/normalize-package-data/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -25033,16 +23649,16 @@
 			}
 		},
 		"node_modules/npm-package-json-lint/node_modules/jsonc-parser": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
-			"integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/npm-package-json-lint/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -25717,9 +24333,9 @@
 			}
 		},
 		"node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-			"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+			"integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -26028,20 +24644,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/playwright/node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
 		"node_modules/plur": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
@@ -26226,9 +24828,9 @@
 			}
 		},
 		"node_modules/postcss-loader/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -26954,6 +25556,80 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/puppeteer-core": {
+			"version": "13.7.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-13.7.0.tgz",
+			"integrity": "sha512-rXja4vcnAzFAP1OVLq/5dWNfwBGuzcOARJ6qGV7oAZhnLmVRU8G5MsdeQEAOy332ZhkIOnn9jp15R89LKHyp2Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"cross-fetch": "3.1.5",
+				"debug": "4.3.4",
+				"devtools-protocol": "0.0.981744",
+				"extract-zip": "2.0.1",
+				"https-proxy-agent": "5.0.1",
+				"pkg-dir": "4.2.0",
+				"progress": "2.0.3",
+				"proxy-from-env": "1.1.0",
+				"rimraf": "3.0.2",
+				"tar-fs": "2.1.1",
+				"unbzip2-stream": "1.4.3",
+				"ws": "8.5.0"
+			},
+			"engines": {
+				"node": ">=10.18.1"
+			}
+		},
+		"node_modules/puppeteer-core/node_modules/devtools-protocol": {
+			"version": "0.0.981744",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.981744.tgz",
+			"integrity": "sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/puppeteer-core/node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
+		},
+		"node_modules/puppeteer-core/node_modules/ws": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+			"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/pure-rand": {
@@ -28088,16 +26764,16 @@
 			}
 		},
 		"node_modules/schema-utils/node_modules/ajv": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-			"integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.4.1"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -29746,16 +28422,16 @@
 			}
 		},
 		"node_modules/table/node_modules/ajv": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-			"integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.4.1"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -29785,6 +28461,51 @@
 			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true,
 			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tar-fs": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"node_modules/tar-fs/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/tar-fs/node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
 			"engines": {
 				"node": ">=6"
 			}
@@ -30287,9 +29008,9 @@
 			}
 		},
 		"node_modules/ts-loader/node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -30359,9 +29080,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"dev": true,
 			"license": "0BSD"
 		},
@@ -31166,9 +29887,9 @@
 			}
 		},
 		"node_modules/webpack-bundle-analyzer/node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"version": "7.5.10",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -31741,9 +30462,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.17.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-			"integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"@wordpress/data": "^10.7.0",
 		"@wordpress/e2e-test-utils-playwright": "^1.7.0",
 		"@wordpress/edit-post": "^8.5.0",
-		"@wordpress/editor": "^14.5.0",
+		"@wordpress/editor": "^14.7.0",
 		"@wordpress/element": "^6.7.0",
 		"@wordpress/env": "^10.7.0",
 		"@wordpress/eslint-plugin": "^21.0.0",


### PR DESCRIPTION
## Description
Updates `@wordpress/editor` from 14.5.0 to 14.7.0. Replaces #2745 as the update of `@types/wordpress__editor` was causing issues.

## Motivation and context
Update dependencies while keeping our sanity.

## How has this been tested?
The builds that fail in #2745 succeed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the WordPress editor package, potentially introducing new features and improvements for enhanced editing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->