### PR TITLE
E2E tests: Remove import *

### DIFF
--- a/tests/e2e/specs/browse-logo-button.spec.ts
+++ b/tests/e2e/specs/browse-logo-button.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as path from 'path';
+import { resolve } from 'path';
 
 /**
  * WordPress dependencies
@@ -56,7 +56,7 @@ test.describe( 'Browse for logo button', () => {
 	 * @since 3.17.0 Migrated to Playwright.
 	 */
 	test( 'Should set the file path when a new image is uploaded and confirmed', async ( { page } ) => {
-		const imageLocalPath: string = path.resolve(
+		const imageLocalPath: string = resolve(
 			__dirname, '../../../.wordpress-org/icon-256x256.png'
 		);
 

--- a/tests/e2e/specs/front-end-tracker.spec.ts
+++ b/tests/e2e/specs/front-end-tracker.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as fs from 'fs';
+import { readFile } from 'fs/promises';
 
 /**
  * WordPress dependencies
@@ -86,7 +86,7 @@ class Utils {
 	 * @return {string} The version of the loader asset.
 	 */
 	async getAssetVersion(): Promise<string> {
-		const data = await fs.promises.readFile(
+		const data = await readFile(
 			'build/loader.asset.php', { encoding: 'utf8', flag: 'r' }
 		);
 


### PR DESCRIPTION
## Description
This PR removes a couple of `import *` we had in our E2E tests.

## Motivation and context
Prefer using specific imports.

## How has this been tested?
E2E tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified file path resolution in the logo button test, enhancing code clarity without altering functionality.
	- Streamlined file reading in the front-end tracker test, improving performance while maintaining existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->