### PR TITLE
Update @wordpress/compose version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"@wordpress/block-editor": "^14.2.0",
 				"@wordpress/blocks": "^13.7.0",
 				"@wordpress/components": "^28.7.0",
-				"@wordpress/compose": "^7.5.0",
+				"@wordpress/compose": "^7.7.0",
 				"@wordpress/core-data": "^7.7.0",
 				"@wordpress/data": "^10.7.0",
 				"@wordpress/e2e-test-utils-playwright": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"@wordpress/block-editor": "^14.2.0",
 		"@wordpress/blocks": "^13.7.0",
 		"@wordpress/components": "^28.7.0",
-		"@wordpress/compose": "^7.5.0",
+		"@wordpress/compose": "^7.7.0",
 		"@wordpress/core-data": "^7.7.0",
 		"@wordpress/data": "^10.7.0",
 		"@wordpress/e2e-test-utils-playwright": "^1.7.0",


### PR DESCRIPTION
## Description
This PR updates the version number of the `@wordpress/compose` package. As can be seen in `package-lock.json`, tt doesn't really update anything besides version numbers.

## Motivation and context
`ncu` showed me this, so I updated it.

## How has this been tested?
Existing tests pass. This update doesn't bring any real changes to code, nor to does it change dependency structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the `@wordpress/compose` package to enhance performance and potentially introduce new features.
  
- **Bug Fixes**
	- The update may include various bug fixes improving overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->