### PR TITLE
REST API Refactor: Apply fixes/suggestions from the other PRs

### DIFF
--- a/src/content-helper/dashboard-widget/class-dashboard-widget.php
+++ b/src/content-helper/dashboard-widget/class-dashboard-widget.php
@@ -13,6 +13,7 @@ namespace Parsely\Content_Helper;
 use Parsely\Parsely;
 use Parsely\RemoteAPI\Analytics_Posts_API;
 
+use Parsely\REST_API\Settings\Endpoint_Dashboard_Widget_Settings;
 use Parsely\Utils\Utils;
 
 use const Parsely\PARSELY_FILE;
@@ -135,7 +136,7 @@ class Dashboard_Widget extends Content_Helper_Feature {
 			true
 		);
 
-		$this->inject_inline_scripts( 'dashboard-widget' );
+		$this->inject_inline_scripts( Endpoint_Dashboard_Widget_Settings::get_endpoint_name() );
 
 		wp_enqueue_style(
 			static::get_style_id(),

--- a/src/content-helper/editor-sidebar/class-editor-sidebar.php
+++ b/src/content-helper/editor-sidebar/class-editor-sidebar.php
@@ -14,6 +14,7 @@ use Parsely\Content_Helper\Editor_Sidebar\Smart_Linking;
 use Parsely\Dashboard_Link;
 use Parsely\Parsely;
 
+use Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings;
 use Parsely\Utils\Utils;
 use WP_Post;
 
@@ -161,7 +162,7 @@ class Editor_Sidebar extends Content_Helper_Feature {
 			true
 		);
 
-		$this->inject_inline_scripts( 'editor-sidebar' );
+		$this->inject_inline_scripts( Endpoint_Editor_Sidebar_Settings::get_endpoint_name() );
 
 		// Inject inline variables for the editor sidebar, without UTM parameters.
 		$parsely_post_url = $this->get_parsely_post_url( null, false );

--- a/src/rest-api/class-base-api-controller.php
+++ b/src/rest-api/class-base-api-controller.php
@@ -96,7 +96,7 @@ abstract class Base_API_Controller {
 	 *
 	 * @return string The route prefix.
 	 */
-	public function get_route_prefix(): string {
+	public static function get_route_prefix(): string {
 		return '';
 	}
 
@@ -173,10 +173,10 @@ abstract class Base_API_Controller {
 	 * @return string The prefixed route.
 	 */
 	public function prefix_route( string $route ): string {
-		if ( '' === $this->get_route_prefix() ) {
+		if ( '' === static::get_route_prefix() ) {
 			return $route;
 		}
 
-		return $this->get_route_prefix() . '/' . $route;
+		return static::get_route_prefix() . '/' . $route;
 	}
 }

--- a/src/rest-api/class-base-endpoint.php
+++ b/src/rest-api/class-base-endpoint.php
@@ -78,7 +78,7 @@ abstract class Base_Endpoint {
 		 * @return bool
 		 */
 		$filter_name = 'wp_parsely_api_' .
-						Utils::convert_endpoint_to_filter_key( $this->get_endpoint_name() ) .
+						Utils::convert_endpoint_to_filter_key( static::get_endpoint_name() ) .
 						'_endpoint_enabled';
 		if ( ! apply_filters( $filter_name, true ) ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound
 			return;
@@ -98,7 +98,7 @@ abstract class Base_Endpoint {
 	 *
 	 * @return string
 	 */
-	abstract public function get_endpoint_name(): string;
+	abstract public static function get_endpoint_name(): string;
 
 	/**
 	 * Returns the default access capability for the endpoint.
@@ -142,7 +142,7 @@ abstract class Base_Endpoint {
 		$this->registered_routes[] = $route;
 
 		// Create the full route for the endpoint.
-		$route = $this->get_endpoint_name() . '/' . $route;
+		$route = static::get_endpoint_name() . '/' . $route;
 
 		// Register the route.
 		register_rest_route(
@@ -172,9 +172,9 @@ abstract class Base_Endpoint {
 		$route = trim( $route, '/' );
 
 		if ( '' !== $route ) {
-			$route = $this->get_endpoint_name() . '/' . $route;
+			$route = static::get_endpoint_name() . '/' . $route;
 		} else {
-			$route = $this->get_endpoint_name();
+			$route = static::get_endpoint_name();
 		}
 
 		return '/' .
@@ -251,7 +251,7 @@ abstract class Base_Endpoint {
 		 */
 		$endpoint_specific_user_capability = apply_filters(
 			'wp_parsely_user_capability_for_' .
-				Utils::convert_endpoint_to_filter_key( $this->get_endpoint_name() ) .
+				Utils::convert_endpoint_to_filter_key( static::get_endpoint_name() ) .
 			'_api',
 			$default_user_capability
 		);

--- a/src/rest-api/content-helper/class-content-helper-controller.php
+++ b/src/rest-api/content-helper/class-content-helper-controller.php
@@ -27,7 +27,7 @@ class Content_Helper_Controller extends REST_API_Controller {
 	 *
 	 * @return string The namespace.
 	 */
-	public function get_route_prefix(): string {
+	public static function get_route_prefix(): string {
 		return 'content-helper';
 	}
 

--- a/src/rest-api/content-helper/class-endpoint-excerpt-generator.php
+++ b/src/rest-api/content-helper/class-endpoint-excerpt-generator.php
@@ -96,13 +96,13 @@ class Endpoint_Excerpt_Generator extends Base_Endpoint {
 					'required'    => true,
 				),
 				'persona' => array(
-					'description' => __( 'The persona of the content.', 'wp-parsely' ),
+					'description' => __( 'The persona to use for the suggestion.', 'wp-parsely' ),
 					'type'        => 'string',
 					'required'    => false,
 					'default'     => 'journalist',
 				),
 				'style'   => array(
-					'description' => __( 'The style of the content.', 'wp-parsely' ),
+					'description' => __( 'The style to use for the suggestion.', 'wp-parsely' ),
 					'type'        => 'string',
 					'required'    => false,
 					'default'     => 'neutral',

--- a/src/rest-api/content-helper/class-endpoint-excerpt-generator.php
+++ b/src/rest-api/content-helper/class-endpoint-excerpt-generator.php
@@ -55,7 +55,7 @@ class Endpoint_Excerpt_Generator extends Base_Endpoint {
 	 *
 	 * @return string The endpoint name.
 	 */
-	public function get_endpoint_name(): string {
+	public static function get_endpoint_name(): string {
 		return 'excerpt-generator';
 	}
 

--- a/src/rest-api/content-helper/class-endpoint-smart-linking.php
+++ b/src/rest-api/content-helper/class-endpoint-smart-linking.php
@@ -59,7 +59,7 @@ class Endpoint_Smart_Linking extends Base_Endpoint {
 	 *
 	 * @return string The endpoint name.
 	 */
-	public function get_endpoint_name(): string {
+	public static function get_endpoint_name(): string {
 		return 'smart-linking';
 	}
 

--- a/src/rest-api/content-helper/class-endpoint-title-suggestions.php
+++ b/src/rest-api/content-helper/class-endpoint-title-suggestions.php
@@ -55,7 +55,7 @@ class Endpoint_Title_Suggestions extends Base_Endpoint {
 	 *
 	 * @return string The endpoint name.
 	 */
-	public function get_endpoint_name(): string {
+	public static function get_endpoint_name(): string {
 		return 'title-suggestions';
 	}
 

--- a/src/rest-api/content-helper/class-endpoint-title-suggestions.php
+++ b/src/rest-api/content-helper/class-endpoint-title-suggestions.php
@@ -91,19 +91,19 @@ class Endpoint_Title_Suggestions extends Base_Endpoint {
 					'type'        => 'string',
 				),
 				'limit'   => array(
-					'description' => __( 'The maximum number of titles to generate.', 'wp-parsely' ),
+					'description' => __( 'The maximum number of titles to be suggested.', 'wp-parsely' ),
 					'required'    => false,
 					'type'        => 'integer',
 					'default'     => 3,
 				),
 				'style'   => array(
-					'description' => __( 'The style  of the titles to generate.', 'wp-parsely' ),
+					'description' => __( 'The style of the titles to be suggested.', 'wp-parsely' ),
 					'required'    => false,
 					'type'        => 'string',
 					'default'     => 'neutral',
 				),
 				'persona' => array(
-					'description' => __( 'The persona of the titles to generate.', 'wp-parsely' ),
+					'description' => __( 'The persona of the titles to be suggested.', 'wp-parsely' ),
 					'required'    => false,
 					'type'        => 'string',
 					'default'     => 'journalist',

--- a/src/rest-api/settings/class-endpoint-dashboard-widget-settings.php
+++ b/src/rest-api/settings/class-endpoint-dashboard-widget-settings.php
@@ -25,7 +25,7 @@ class Endpoint_Dashboard_Widget_Settings extends Base_Settings_Endpoint {
 	 *
 	 * @return string
 	 */
-	public function get_endpoint_name(): string {
+	public static function get_endpoint_name(): string {
 		return 'dashboard-widget';
 	}
 

--- a/src/rest-api/settings/class-endpoint-editor-sidebar-settings.php
+++ b/src/rest-api/settings/class-endpoint-editor-sidebar-settings.php
@@ -25,7 +25,7 @@ class Endpoint_Editor_Sidebar_Settings extends Base_Settings_Endpoint {
 	 *
 	 * @return string
 	 */
-	public function get_endpoint_name(): string {
+	public static function get_endpoint_name(): string {
 		return 'editor-sidebar';
 	}
 

--- a/src/rest-api/settings/class-settings-controller.php
+++ b/src/rest-api/settings/class-settings-controller.php
@@ -27,7 +27,7 @@ class Settings_Controller extends REST_API_Controller {
 	 *
 	 * @return string The namespace.
 	 */
-	public function get_route_prefix(): string {
+	public static function get_route_prefix(): string {
 		return 'settings';
 	}
 

--- a/src/rest-api/stats/class-endpoint-post.php
+++ b/src/rest-api/stats/class-endpoint-post.php
@@ -83,7 +83,7 @@ class Endpoint_Post extends Base_Endpoint {
 	 *
 	 * @return string The endpoint name.
 	 */
-	public function get_endpoint_name(): string {
+	public static function get_endpoint_name(): string {
 		return 'post';
 	}
 

--- a/src/rest-api/stats/class-endpoint-posts.php
+++ b/src/rest-api/stats/class-endpoint-posts.php
@@ -89,7 +89,7 @@ class Endpoint_Posts extends Base_Endpoint {
 	 *
 	 * @return string
 	 */
-	public function get_endpoint_name(): string {
+	public static function get_endpoint_name(): string {
 		return 'posts';
 	}
 

--- a/src/rest-api/stats/class-endpoint-related.php
+++ b/src/rest-api/stats/class-endpoint-related.php
@@ -46,7 +46,7 @@ class Endpoint_Related extends Base_Endpoint {
 	 *
 	 * @return string
 	 */
-	public function get_endpoint_name(): string {
+	public static function get_endpoint_name(): string {
 		return 'related';
 	}
 

--- a/src/rest-api/stats/class-stats-controller.php
+++ b/src/rest-api/stats/class-stats-controller.php
@@ -27,7 +27,7 @@ class Stats_Controller extends REST_API_Controller {
 	 *
 	 * @return string The namespace.
 	 */
-	public function get_route_prefix(): string {
+	public static function get_route_prefix(): string {
 		return 'stats';
 	}
 

--- a/tests/Integration/RestAPI/BaseAPIControllerTest.php
+++ b/tests/Integration/RestAPI/BaseAPIControllerTest.php
@@ -141,7 +141,7 @@ class BaseAPIControllerTest extends TestCase {
 			 *
 			 * @return string The version.
 			 */
-			public function get_route_prefix(): string {
+			public static function get_route_prefix(): string {
 				return 'prefix';
 			}
 		};

--- a/tests/Integration/RestAPI/BaseEndpointTest.php
+++ b/tests/Integration/RestAPI/BaseEndpointTest.php
@@ -118,7 +118,7 @@ class BaseEndpointTest extends TestCase {
 			 *
 			 * @return string
 			 */
-			public function get_endpoint_name(): string {
+			public static function get_endpoint_name(): string {
 				return 'test';
 			}
 
@@ -258,7 +258,7 @@ class BaseEndpointTest extends TestCase {
 	 */
 	public function test_endpoint_is_registered_based_on_filter(): void {
 		$filter_name = 'wp_parsely_api_' .
-						\Parsely\Utils\Utils::convert_endpoint_to_filter_key( $this->get_endpoint()->get_endpoint_name() ) .
+						\Parsely\Utils\Utils::convert_endpoint_to_filter_key( $this->get_endpoint()::get_endpoint_name() ) .
 						'_endpoint_enabled';
 
 		// Test when the filter allows the endpoint to be enabled.

--- a/tests/Integration/RestAPI/ContentHelper/ContentHelperControllerTest.php
+++ b/tests/Integration/RestAPI/ContentHelper/ContentHelperControllerTest.php
@@ -69,7 +69,7 @@ class ContentHelperControllerTest extends RestAPIControllerTest {
 	 * @covers \Parsely\REST_API\Content_Helper\Content_Helper_Controller::ROUTE_PREFIX
 	 */
 	public function test_route_prefix(): void {
-		self::assertEquals( 'content-helper', $this->content_helper_controller->get_route_prefix() );
+		self::assertEquals( 'content-helper', $this->content_helper_controller::get_route_prefix() );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR applies the suggestions that have been added to both #2731 and #2735

#2731 

 * Changed the REST API description fields to be more descriptive of what they meant to do.

#2735 
* Converted `get_endpoint_name` and `get_route_prefix` to static methods
* Replaced `editor-sidebar` and `dashboard-widget` strings with the correct call to the static `get_endpoint_name` method.

## Motivation and context
* Apply pending feedback from #2731 and #2735

## How has this been tested?
Tested locally and validated that the tests still passing.