### PR TITLE
Bump @wordpress/editor from 14.7.0 to 14.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"@wordpress/data": "^10.8.0",
 				"@wordpress/e2e-test-utils-playwright": "^1.8.0",
 				"@wordpress/edit-post": "^8.7.0",
-				"@wordpress/editor": "^14.7.0",
+				"@wordpress/editor": "^14.8.3",
 				"@wordpress/element": "^6.8.0",
 				"@wordpress/env": "^10.8.0",
 				"@wordpress/eslint-plugin": "^21.1.2",
@@ -5399,9 +5399,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "18.3.7",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.7.tgz",
-			"integrity": "sha512-KUnDCJF5+AiZd8owLIeVHqmW9yM4sqmDVf2JRJiBMFkGvkoZ4/WyV2lL4zVsoinmRS/W3FeEdZLEWFRofnT2FQ==",
+			"version": "18.3.10",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.10.tgz",
+			"integrity": "sha512-02sAAlBnP39JgXwkAq3PeU9DVaaGpZyF3MGcC0MKgQVkZor5IiiDAipVaxQHtDJAmO4GIy/rVBy/LzVj76Cyqg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8189,9 +8189,9 @@
 			}
 		},
 		"node_modules/@types/wordpress__media-utils/node_modules/@wordpress/blocks/node_modules/@types/react": {
-			"version": "17.0.82",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.82.tgz",
-			"integrity": "sha512-wTW8Lu/PARGPFE8tOZqCvprOKg5sen/2uS03yKn2xbCDFP9oLncm7vMDQ2+dEQXHVIXrOpW6u72xUXEXO0ypSw==",
+			"version": "17.0.83",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.83.tgz",
+			"integrity": "sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8287,9 +8287,9 @@
 			}
 		},
 		"node_modules/@types/wordpress__media-utils/node_modules/@wordpress/compose/node_modules/@types/react": {
-			"version": "17.0.82",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.82.tgz",
-			"integrity": "sha512-wTW8Lu/PARGPFE8tOZqCvprOKg5sen/2uS03yKn2xbCDFP9oLncm7vMDQ2+dEQXHVIXrOpW6u72xUXEXO0ypSw==",
+			"version": "17.0.83",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.83.tgz",
+			"integrity": "sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8376,9 +8376,9 @@
 			}
 		},
 		"node_modules/@types/wordpress__media-utils/node_modules/@wordpress/core-data/node_modules/@types/react": {
-			"version": "17.0.82",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.82.tgz",
-			"integrity": "sha512-wTW8Lu/PARGPFE8tOZqCvprOKg5sen/2uS03yKn2xbCDFP9oLncm7vMDQ2+dEQXHVIXrOpW6u72xUXEXO0ypSw==",
+			"version": "17.0.83",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.83.tgz",
+			"integrity": "sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8469,9 +8469,9 @@
 			}
 		},
 		"node_modules/@types/wordpress__media-utils/node_modules/@wordpress/data/node_modules/@types/react": {
-			"version": "17.0.82",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.82.tgz",
-			"integrity": "sha512-wTW8Lu/PARGPFE8tOZqCvprOKg5sen/2uS03yKn2xbCDFP9oLncm7vMDQ2+dEQXHVIXrOpW6u72xUXEXO0ypSw==",
+			"version": "17.0.83",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.83.tgz",
+			"integrity": "sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9280,14 +9280,15 @@
 			}
 		},
 		"node_modules/@wordpress/a11y": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.8.0.tgz",
-			"integrity": "sha512-AdcTPpiwpD7PEG3f8viremRGN5517+jEJ/vhgs8VFb3uJ11enrNyk7T4aNX7MLP4sF5S1nTsuioEM2ZjkfJTXA==",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.8.2.tgz",
+			"integrity": "sha512-eILr2ZYK5FYSlx18rnP06qKyPELxEyDcnosSOsjskPGw5gYT01sUf0fkAebliuG88VppT+bgI008TRo3dvtZzQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/dom-ready": "^4.8.0",
-				"@wordpress/i18n": "^5.8.0"
+				"@wordpress/dom-ready": "^4.8.1",
+				"@wordpress/i18n": "^5.8.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9295,14 +9296,15 @@
 			}
 		},
 		"node_modules/@wordpress/api-fetch": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.8.0.tgz",
-			"integrity": "sha512-yQx/zoM9e1vNWHSJVPvvspqGap/JMwtnxAvMDqUVUEETXwwGqaBffJCxVyGOfPhx/3cIw2T88xVxz0dgZ76a1w==",
+			"version": "7.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.8.2.tgz",
+			"integrity": "sha512-6jiodZD4+5lIelb/E6FHMa6xuldcoIkQ5vWtvHpoB30++7eOgYi0tl5b1NlzGqfReIcl9oO+Wwp5V9mRE+mJoA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.8.0",
-				"@wordpress/url": "^4.8.0"
+				"@wordpress/i18n": "^5.8.2",
+				"@wordpress/url": "^4.8.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9310,10 +9312,11 @@
 			}
 		},
 		"node_modules/@wordpress/autop": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.8.0.tgz",
-			"integrity": "sha512-/i3xDSBhuDOm0f1xdbmsT0r+J5e75KW9uEBv3M4Ax3XkO1WJV78H6OQakMxV3oL6SkVUStIB9b9xDEv1X+fcOQ==",
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.8.1.tgz",
+			"integrity": "sha512-/ah4oBIRGMZlxBBPiD6R5uamCPEXTzmsJ0iceDJxMHc5KvNcy59oHNCirD5yiRLORk8RrujUczIGfglpUjGh2Q==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -9367,10 +9370,11 @@
 			"license": "GPL-2.0-or-later"
 		},
 		"node_modules/@wordpress/blob": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.8.0.tgz",
-			"integrity": "sha512-RWl866IDC9IyQBmnedIjMA8lNwiYKbF4JzM9MkOdmXNveTwnFzrbpPJe/P4kGrlu7OdEK3IWWG2Mk+d/aqTfJw==",
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.8.1.tgz",
+			"integrity": "sha512-fMLWmum+B8aZi5w8Tie7mw+LEP/FF6RXVMG8AH4GwtXYYD2b3WgjbF7I4p6HYOaz3kAEnlJNo55qqLT2tFogww==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -9380,45 +9384,46 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-14.3.0.tgz",
-			"integrity": "sha512-V7mIfFQqjAig+lfEYSRp+6R6hQXsYm/NhO3p2INU2FhL85rSedM9G1HqPhZnrka3C9XMtoZmec2PVop6dgmbOQ==",
+			"version": "14.3.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-14.3.4.tgz",
+			"integrity": "sha512-7y7xrG8c7yH5HcJ3S5z0KJ9x1xAFTrgRSqD77YuNlhox3hfsxahcUjne1SqDafZcNIiHzJ5dhIcJZQs/qd3wFA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"@emotion/react": "^11.7.1",
 				"@emotion/styled": "^11.6.0",
 				"@react-spring/web": "^9.4.5",
-				"@wordpress/a11y": "^4.8.0",
-				"@wordpress/api-fetch": "^7.8.0",
-				"@wordpress/blob": "^4.8.0",
-				"@wordpress/block-serialization-default-parser": "^5.8.0",
-				"@wordpress/blocks": "^13.8.0",
-				"@wordpress/commands": "^1.8.0",
-				"@wordpress/components": "^28.8.0",
-				"@wordpress/compose": "^7.8.0",
-				"@wordpress/data": "^10.8.0",
-				"@wordpress/date": "^5.8.0",
-				"@wordpress/deprecated": "^4.8.0",
-				"@wordpress/dom": "^4.8.0",
-				"@wordpress/element": "^6.8.0",
-				"@wordpress/escape-html": "^3.8.0",
-				"@wordpress/hooks": "^4.8.0",
-				"@wordpress/html-entities": "^4.8.0",
-				"@wordpress/i18n": "^5.8.0",
-				"@wordpress/icons": "^10.8.0",
-				"@wordpress/is-shallow-equal": "^5.8.0",
-				"@wordpress/keyboard-shortcuts": "^5.8.0",
-				"@wordpress/keycodes": "^4.8.0",
-				"@wordpress/notices": "^5.8.0",
-				"@wordpress/preferences": "^4.8.0",
-				"@wordpress/private-apis": "^1.8.0",
-				"@wordpress/rich-text": "^7.8.0",
-				"@wordpress/style-engine": "^2.8.0",
-				"@wordpress/token-list": "^3.8.0",
-				"@wordpress/url": "^4.8.0",
-				"@wordpress/warning": "^3.8.0",
-				"@wordpress/wordcount": "^4.8.0",
+				"@wordpress/a11y": "^4.8.2",
+				"@wordpress/api-fetch": "^7.8.2",
+				"@wordpress/blob": "^4.8.1",
+				"@wordpress/block-serialization-default-parser": "^5.8.1",
+				"@wordpress/blocks": "^13.8.4",
+				"@wordpress/commands": "^1.8.4",
+				"@wordpress/components": "^28.8.4",
+				"@wordpress/compose": "^7.8.3",
+				"@wordpress/data": "^10.8.3",
+				"@wordpress/date": "^5.8.2",
+				"@wordpress/deprecated": "^4.8.2",
+				"@wordpress/dom": "^4.8.2",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/escape-html": "^3.8.1",
+				"@wordpress/hooks": "^4.8.2",
+				"@wordpress/html-entities": "^4.8.1",
+				"@wordpress/i18n": "^5.8.2",
+				"@wordpress/icons": "^10.8.2",
+				"@wordpress/is-shallow-equal": "^5.8.1",
+				"@wordpress/keyboard-shortcuts": "^5.8.3",
+				"@wordpress/keycodes": "^4.8.2",
+				"@wordpress/notices": "^5.8.3",
+				"@wordpress/preferences": "^4.8.4",
+				"@wordpress/private-apis": "^1.8.1",
+				"@wordpress/rich-text": "^7.8.3",
+				"@wordpress/style-engine": "^2.8.1",
+				"@wordpress/token-list": "^3.8.1",
+				"@wordpress/url": "^4.8.1",
+				"@wordpress/warning": "^3.8.1",
+				"@wordpress/wordcount": "^4.8.1",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -9444,13 +9449,14 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/keycodes": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.8.0.tgz",
-			"integrity": "sha512-HIg8ALiALwMfuI2MAeKaQPraERRf+skCixCIjHs9HM0C48Vov95F3aoHfINCrKXkyQXhTjrJrLDDNEXw6ZF+gw==",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.8.2.tgz",
+			"integrity": "sha512-BxZD5tk4sDHywV7HOF/hSY924ToW7YJe6hDh4yv+7vo5LpiYQq+/uW21hyXrWEjGXZtdmT1tx69wR16BG35bYw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.8.0"
+				"@wordpress/i18n": "^5.8.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9458,10 +9464,11 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/warning": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.8.0.tgz",
-			"integrity": "sha512-d8osKgKA7LgVGTo29+7qjoxLM84bIBeayCjwRsr2bhK9Naum0O341+JRmtlwc6u/zbbuxZEkoyhxG9ZvKjaezA==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.8.1.tgz",
+			"integrity": "sha512-xlo0Xw1jiyiE6nh43NAtQMAL05VDk837kY2xfjsus6wD597TeWFpj6gmcRMH25FZULTUHDB2EPfLviWXqOgUfg==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -9528,14 +9535,14 @@
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/keycodes": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.7.0.tgz",
-			"integrity": "sha512-x8I0xjRM8U0RnpFHWN9mA+x3MqjhJNBldiCpb59GTi3BIzPeDPgxbosAsAAgF0pYdDtGyiRkrOZA23NTia63TA==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.8.0.tgz",
+			"integrity": "sha512-HIg8ALiALwMfuI2MAeKaQPraERRf+skCixCIjHs9HM0C48Vov95F3aoHfINCrKXkyQXhTjrJrLDDNEXw6ZF+gw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.7.0"
+				"@wordpress/i18n": "^5.8.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9543,10 +9550,11 @@
 			}
 		},
 		"node_modules/@wordpress/block-serialization-default-parser": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.8.0.tgz",
-			"integrity": "sha512-ydYEVgOsug0Vlh83QeyvhVl/NCnSxFfCmgmiYfhuBK/yhSG6M0UnOAGOEGSbmlyn8qCeid3uMBX4yVcSN4INdQ==",
+			"version": "5.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.8.1.tgz",
+			"integrity": "sha512-SmbMiM/KTh9veMcujL+t375yMR1JZlIzbVEIk6NdiGV+7pvtenUe4Av0tr+0QaINmgo3MJmc4Y3csZrKFlRr+w==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -9556,27 +9564,28 @@
 			}
 		},
 		"node_modules/@wordpress/blocks": {
-			"version": "13.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-13.8.0.tgz",
-			"integrity": "sha512-eDWKRfkjmPpOsw7IJR/e1G/7fpKYhtRfz9Oo2NqxX7GPR5nUAsnnLDP3rey5Xg8jfFtAfNF43Wwac/6IqzFlKw==",
+			"version": "13.8.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-13.8.4.tgz",
+			"integrity": "sha512-nUwEu+eZRiPBTwwIUUbkAOin4HSQVNKYEFgaP/Fnz4i6GyBTRxoaQP1XCEG5PRsGTr+fMOfT02/z0Y157OOiQQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/autop": "^4.8.0",
-				"@wordpress/blob": "^4.8.0",
-				"@wordpress/block-serialization-default-parser": "^5.8.0",
-				"@wordpress/data": "^10.8.0",
-				"@wordpress/deprecated": "^4.8.0",
-				"@wordpress/dom": "^4.8.0",
-				"@wordpress/element": "^6.8.0",
-				"@wordpress/hooks": "^4.8.0",
-				"@wordpress/html-entities": "^4.8.0",
-				"@wordpress/i18n": "^5.8.0",
-				"@wordpress/is-shallow-equal": "^5.8.0",
-				"@wordpress/private-apis": "^1.8.0",
-				"@wordpress/rich-text": "^7.8.0",
-				"@wordpress/shortcode": "^4.8.0",
-				"@wordpress/warning": "^3.8.0",
+				"@wordpress/autop": "^4.8.1",
+				"@wordpress/blob": "^4.8.1",
+				"@wordpress/block-serialization-default-parser": "^5.8.1",
+				"@wordpress/data": "^10.8.3",
+				"@wordpress/deprecated": "^4.8.2",
+				"@wordpress/dom": "^4.8.2",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/hooks": "^4.8.2",
+				"@wordpress/html-entities": "^4.8.1",
+				"@wordpress/i18n": "^5.8.2",
+				"@wordpress/is-shallow-equal": "^5.8.1",
+				"@wordpress/private-apis": "^1.8.1",
+				"@wordpress/rich-text": "^7.8.3",
+				"@wordpress/shortcode": "^4.8.1",
+				"@wordpress/warning": "^3.8.1",
 				"change-case": "^4.1.2",
 				"colord": "^2.7.0",
 				"fast-deep-equal": "^3.1.3",
@@ -9598,10 +9607,11 @@
 			}
 		},
 		"node_modules/@wordpress/blocks/node_modules/@wordpress/warning": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.8.0.tgz",
-			"integrity": "sha512-d8osKgKA7LgVGTo29+7qjoxLM84bIBeayCjwRsr2bhK9Naum0O341+JRmtlwc6u/zbbuxZEkoyhxG9ZvKjaezA==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.8.1.tgz",
+			"integrity": "sha512-xlo0Xw1jiyiE6nh43NAtQMAL05VDk837kY2xfjsus6wD597TeWFpj6gmcRMH25FZULTUHDB2EPfLviWXqOgUfg==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -9618,19 +9628,20 @@
 			}
 		},
 		"node_modules/@wordpress/commands": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.8.0.tgz",
-			"integrity": "sha512-VSbg8FY6JO2Fb4FtD+YFnrt4GNY8Wboxl5PbQaBQIgh7OWlUHTR9y7mA0yN0vFndDtZwBRKZaUcoPbe52EVNJw==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.8.4.tgz",
+			"integrity": "sha512-7bUGWUspqkzuL2ZSbC+AAsOyrRgUdgBIqekK6+9IWMAx5FMgpOky/ca+kJ/QwIgim2kideGt6ASbEbyF1gwfFA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/components": "^28.8.0",
-				"@wordpress/data": "^10.8.0",
-				"@wordpress/element": "^6.8.0",
-				"@wordpress/i18n": "^5.8.0",
-				"@wordpress/icons": "^10.8.0",
-				"@wordpress/keyboard-shortcuts": "^5.8.0",
-				"@wordpress/private-apis": "^1.8.0",
+				"@wordpress/components": "^28.8.4",
+				"@wordpress/data": "^10.8.3",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/i18n": "^5.8.2",
+				"@wordpress/icons": "^10.8.2",
+				"@wordpress/keyboard-shortcuts": "^5.8.3",
+				"@wordpress/private-apis": "^1.8.1",
 				"clsx": "^2.1.1",
 				"cmdk": "^1.0.0"
 			},
@@ -9644,10 +9655,11 @@
 			}
 		},
 		"node_modules/@wordpress/components": {
-			"version": "28.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.8.0.tgz",
-			"integrity": "sha512-pj4OlTDwBvq68Rk5AgzEQjhoX5nMO5dxYFAnenvjdizQOyQ/XKisLhMNg4fGpB8W/y5fRVHB+gecGIkO2oct9A==",
+			"version": "28.8.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.8.4.tgz",
+			"integrity": "sha512-w/C2OfLeDoJlPaFFlb9QblLFpPSpGPwztyzjN8cmOHqLh4HVi0Yx+sYotTHYlyv2XWGIBExt8Z2Ea8QoeE2Fcw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.10",
 				"@babel/runtime": "^7.16.0",
@@ -9661,23 +9673,23 @@
 				"@types/gradient-parser": "0.1.3",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.8.0",
-				"@wordpress/compose": "^7.8.0",
-				"@wordpress/date": "^5.8.0",
-				"@wordpress/deprecated": "^4.8.0",
-				"@wordpress/dom": "^4.8.0",
-				"@wordpress/element": "^6.8.0",
-				"@wordpress/escape-html": "^3.8.0",
-				"@wordpress/hooks": "^4.8.0",
-				"@wordpress/html-entities": "^4.8.0",
-				"@wordpress/i18n": "^5.8.0",
-				"@wordpress/icons": "^10.8.0",
-				"@wordpress/is-shallow-equal": "^5.8.0",
-				"@wordpress/keycodes": "^4.8.0",
-				"@wordpress/primitives": "^4.8.0",
-				"@wordpress/private-apis": "^1.8.0",
-				"@wordpress/rich-text": "^7.8.0",
-				"@wordpress/warning": "^3.8.0",
+				"@wordpress/a11y": "^4.8.2",
+				"@wordpress/compose": "^7.8.3",
+				"@wordpress/date": "^5.8.2",
+				"@wordpress/deprecated": "^4.8.2",
+				"@wordpress/dom": "^4.8.2",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/escape-html": "^3.8.1",
+				"@wordpress/hooks": "^4.8.2",
+				"@wordpress/html-entities": "^4.8.1",
+				"@wordpress/i18n": "^5.8.2",
+				"@wordpress/icons": "^10.8.2",
+				"@wordpress/is-shallow-equal": "^5.8.1",
+				"@wordpress/keycodes": "^4.8.2",
+				"@wordpress/primitives": "^4.8.1",
+				"@wordpress/private-apis": "^1.8.1",
+				"@wordpress/rich-text": "^7.8.3",
+				"@wordpress/warning": "^3.8.1",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -9705,13 +9717,14 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/keycodes": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.8.0.tgz",
-			"integrity": "sha512-HIg8ALiALwMfuI2MAeKaQPraERRf+skCixCIjHs9HM0C48Vov95F3aoHfINCrKXkyQXhTjrJrLDDNEXw6ZF+gw==",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.8.2.tgz",
+			"integrity": "sha512-BxZD5tk4sDHywV7HOF/hSY924ToW7YJe6hDh4yv+7vo5LpiYQq+/uW21hyXrWEjGXZtdmT1tx69wR16BG35bYw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.8.0"
+				"@wordpress/i18n": "^5.8.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9719,30 +9732,32 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/warning": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.8.0.tgz",
-			"integrity": "sha512-d8osKgKA7LgVGTo29+7qjoxLM84bIBeayCjwRsr2bhK9Naum0O341+JRmtlwc6u/zbbuxZEkoyhxG9ZvKjaezA==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.8.1.tgz",
+			"integrity": "sha512-xlo0Xw1jiyiE6nh43NAtQMAL05VDk837kY2xfjsus6wD597TeWFpj6gmcRMH25FZULTUHDB2EPfLviWXqOgUfg==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/compose": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.8.0.tgz",
-			"integrity": "sha512-bxyy3800+WxEDPj1ksPnCGsOTAUza7OQBhpuaJLzXsB5Q4oJQLKI+WOZUDUxeXOajy1G+WeofAcJjFOdi1RUdg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.8.3.tgz",
+			"integrity": "sha512-knHfFz1/rzFr69d2lDIFspXYTn56Fdd6+4Enc9QhHfkICpwi59jQCXqtNguCB2O8FdL2FNpK1YSgx1FrTo37dA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.8.0",
-				"@wordpress/dom": "^4.8.0",
-				"@wordpress/element": "^6.8.0",
-				"@wordpress/is-shallow-equal": "^5.8.0",
-				"@wordpress/keycodes": "^4.8.0",
-				"@wordpress/priority-queue": "^3.8.0",
-				"@wordpress/undo-manager": "^1.8.0",
+				"@wordpress/deprecated": "^4.8.2",
+				"@wordpress/dom": "^4.8.2",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/is-shallow-equal": "^5.8.1",
+				"@wordpress/keycodes": "^4.8.2",
+				"@wordpress/priority-queue": "^3.8.1",
+				"@wordpress/undo-manager": "^1.8.1",
 				"change-case": "^4.1.2",
 				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
@@ -9757,13 +9772,14 @@
 			}
 		},
 		"node_modules/@wordpress/compose/node_modules/@wordpress/keycodes": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.8.0.tgz",
-			"integrity": "sha512-HIg8ALiALwMfuI2MAeKaQPraERRf+skCixCIjHs9HM0C48Vov95F3aoHfINCrKXkyQXhTjrJrLDDNEXw6ZF+gw==",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.8.2.tgz",
+			"integrity": "sha512-BxZD5tk4sDHywV7HOF/hSY924ToW7YJe6hDh4yv+7vo5LpiYQq+/uW21hyXrWEjGXZtdmT1tx69wR16BG35bYw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.8.0"
+				"@wordpress/i18n": "^5.8.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9801,28 +9817,29 @@
 			}
 		},
 		"node_modules/@wordpress/core-data": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.8.0.tgz",
-			"integrity": "sha512-KVAtp4HdRM0EV+nvgx5NTFpo/7TIhwJ0z6k0oHmt82BypF4bjHGonHyzCMMRi6a6OFGkHxPfi8hapbpuWRlcqA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.8.4.tgz",
+			"integrity": "sha512-+3iIu8k4G2zYYFtzFp561D+2krJMAPFgKJZlhuEcvutyuhZGGcUqa/7HL1Cl8AGKURbnnVw2FmSHltpvXS6XIg==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "^7.8.0",
-				"@wordpress/block-editor": "^14.3.0",
-				"@wordpress/blocks": "^13.8.0",
-				"@wordpress/compose": "^7.8.0",
-				"@wordpress/data": "^10.8.0",
-				"@wordpress/deprecated": "^4.8.0",
-				"@wordpress/element": "^6.8.0",
-				"@wordpress/html-entities": "^4.8.0",
-				"@wordpress/i18n": "^5.8.0",
-				"@wordpress/is-shallow-equal": "^5.8.0",
-				"@wordpress/private-apis": "^1.8.0",
-				"@wordpress/rich-text": "^7.8.0",
-				"@wordpress/sync": "^1.8.0",
-				"@wordpress/undo-manager": "^1.8.0",
-				"@wordpress/url": "^4.8.0",
-				"@wordpress/warning": "^3.8.0",
+				"@wordpress/api-fetch": "^7.8.2",
+				"@wordpress/block-editor": "^14.3.4",
+				"@wordpress/blocks": "^13.8.4",
+				"@wordpress/compose": "^7.8.3",
+				"@wordpress/data": "^10.8.3",
+				"@wordpress/deprecated": "^4.8.2",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/html-entities": "^4.8.1",
+				"@wordpress/i18n": "^5.8.2",
+				"@wordpress/is-shallow-equal": "^5.8.1",
+				"@wordpress/private-apis": "^1.8.1",
+				"@wordpress/rich-text": "^7.8.3",
+				"@wordpress/sync": "^1.8.1",
+				"@wordpress/undo-manager": "^1.8.1",
+				"@wordpress/url": "^4.8.1",
+				"@wordpress/warning": "^3.8.1",
 				"change-case": "^4.1.2",
 				"equivalent-key-map": "^0.2.2",
 				"fast-deep-equal": "^3.1.3",
@@ -9839,29 +9856,31 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/warning": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.8.0.tgz",
-			"integrity": "sha512-d8osKgKA7LgVGTo29+7qjoxLM84bIBeayCjwRsr2bhK9Naum0O341+JRmtlwc6u/zbbuxZEkoyhxG9ZvKjaezA==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.8.1.tgz",
+			"integrity": "sha512-xlo0Xw1jiyiE6nh43NAtQMAL05VDk837kY2xfjsus6wD597TeWFpj6gmcRMH25FZULTUHDB2EPfLviWXqOgUfg==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/data": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.8.0.tgz",
-			"integrity": "sha512-oRbZkY/CGS36XtoAOfZPvLImnRo6CzLAR00ZDd/e43CvRlx4szjr3hMbD55XDF2PG3W4EHAPNYfZvYU3C7PymA==",
+			"version": "10.8.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.8.3.tgz",
+			"integrity": "sha512-JunqBEVVwJJz45N8JTZNh9WHFn857SUtbp7Efp55oesH/g3ejLMuNu6Ewf9/qEEGQut8VeVQ7yGhl+GQDu9u+w==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^7.8.0",
-				"@wordpress/deprecated": "^4.8.0",
-				"@wordpress/element": "^6.8.0",
-				"@wordpress/is-shallow-equal": "^5.8.0",
-				"@wordpress/priority-queue": "^3.8.0",
-				"@wordpress/private-apis": "^1.8.0",
-				"@wordpress/redux-routine": "^5.8.0",
+				"@wordpress/compose": "^7.8.3",
+				"@wordpress/deprecated": "^4.8.2",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/is-shallow-equal": "^5.8.1",
+				"@wordpress/priority-queue": "^3.8.1",
+				"@wordpress/private-apis": "^1.8.1",
+				"@wordpress/redux-routine": "^5.8.1",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -9879,23 +9898,23 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-4.3.0.tgz",
-			"integrity": "sha512-ZAKgac4sFINnAKABhf4/0qAEm1LTTRDJGd8+qfi6mbiQr42BoNVIKtFw8o5uOL4cOEF01wdoUDaCZv6oP9e+eA==",
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-4.4.4.tgz",
+			"integrity": "sha512-b+2DTP8uPznxpnD0khRHDUeuj3U5Cy32amr3vwiN9xqV9hl51fzSe+ELAUTHrFKlMaQNkH/0c8cH81fU0JIeuw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.10",
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/components": "^28.7.0",
-				"@wordpress/compose": "^7.7.0",
-				"@wordpress/data": "^10.7.0",
-				"@wordpress/element": "^6.7.0",
-				"@wordpress/i18n": "^5.7.0",
-				"@wordpress/icons": "^10.7.0",
-				"@wordpress/primitives": "^4.7.0",
-				"@wordpress/private-apis": "^1.7.0",
-				"@wordpress/warning": "^3.7.0",
+				"@wordpress/components": "^28.8.4",
+				"@wordpress/compose": "^7.8.3",
+				"@wordpress/data": "^10.8.3",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/i18n": "^5.8.2",
+				"@wordpress/icons": "^10.8.2",
+				"@wordpress/primitives": "^4.8.1",
+				"@wordpress/private-apis": "^1.8.1",
+				"@wordpress/warning": "^3.8.1",
 				"clsx": "^2.1.1",
 				"remove-accents": "^0.5.0"
 			},
@@ -9908,9 +9927,9 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/warning": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.7.0.tgz",
-			"integrity": "sha512-wGbQfPlf8YV6gGhcGPYWUhHORct4xaBQSaDTJrwzlgHYyrrJUVXXgZxaM4+Aa23zQoA13nvFQHvfssOkwdh65g==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.8.1.tgz",
+			"integrity": "sha512-xlo0Xw1jiyiE6nh43NAtQMAL05VDk837kY2xfjsus6wD597TeWFpj6gmcRMH25FZULTUHDB2EPfLviWXqOgUfg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -9919,13 +9938,14 @@
 			}
 		},
 		"node_modules/@wordpress/date": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.8.0.tgz",
-			"integrity": "sha512-i4AI/0eDg1WSRat5wgPWPgwu8G040rdhFKTrYlEUQn5lMW7s+X3ymw9xt+zstNAtaU3OMuU6NetXGaFGO46Gsg==",
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.8.2.tgz",
+			"integrity": "sha512-ECPE9JXQ0GN+A3ssP+bmEtt122JQnkuXzGOUXfED+kjdmFZ1MgPtyKfXBFDzyW6fPHAwzpSbyFSBXfwxevxWAQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/deprecated": "^4.8.0",
+				"@wordpress/deprecated": "^4.8.2",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -9951,13 +9971,14 @@
 			}
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.8.0.tgz",
-			"integrity": "sha512-ijyGPkQMGREGDOGS3oGrB6a+9vf+naYGXHJ7oRvAS7mK9NyZfs5EZveslEYlYvZTKBmeY7L0f2SVjPrjwGFl4A==",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.8.2.tgz",
+			"integrity": "sha512-AMO0FeqYfIcQRNzAVYDYHZ6ISdfkPHm8Rt8HQOl0Bg7tWX3ocVYnMULUGg/VzgM8AJzAUrfBpwcXZBMF1g4Xpw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^4.8.0"
+				"@wordpress/hooks": "^4.8.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9965,13 +9986,14 @@
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.8.0.tgz",
-			"integrity": "sha512-7tSLmWPaYOQSsoA+eKW3xLh+GNBuCtbIvPvzlUWb+JHu0t/XBesrs/2XXPm4NZXZxruAgT4+XBnc759RKDjiZA==",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.8.2.tgz",
+			"integrity": "sha512-5VZooybouKVkQ6W2+ef7AnAYQG54lkUN8+Kzc7ly84+WL13RbrwfE4Bj9/RFE5Ew59XTfHME0+GzE3fpLNiTYA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/deprecated": "^4.8.0"
+				"@wordpress/deprecated": "^4.8.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9979,9 +10001,10 @@
 			}
 		},
 		"node_modules/@wordpress/dom-ready": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.8.0.tgz",
-			"integrity": "sha512-HgjykkaC+yLHWnhBkQEua2dbeB8ckF7ht2S4WJELjVo52FXdbDIfw3ht3N4AlN92r6uUaYm/1X1MTVa+DkLasg==",
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.8.1.tgz",
+			"integrity": "sha512-xVMNpOaLzpZS4HFH5yYE3ToOhpsDpV29PoeDzuki18XA+ZPg6SvQ/TmwggMasnI1PoyAcQWxugXMV+YUFGM8Mg==",
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -10061,14 +10084,14 @@
 			}
 		},
 		"node_modules/@wordpress/edit-post/node_modules/@wordpress/keycodes": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.7.0.tgz",
-			"integrity": "sha512-x8I0xjRM8U0RnpFHWN9mA+x3MqjhJNBldiCpb59GTi3BIzPeDPgxbosAsAAgF0pYdDtGyiRkrOZA23NTia63TA==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.8.0.tgz",
+			"integrity": "sha512-HIg8ALiALwMfuI2MAeKaQPraERRf+skCixCIjHs9HM0C48Vov95F3aoHfINCrKXkyQXhTjrJrLDDNEXw6ZF+gw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.7.0"
+				"@wordpress/i18n": "^5.8.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10076,9 +10099,9 @@
 			}
 		},
 		"node_modules/@wordpress/edit-post/node_modules/@wordpress/warning": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.7.0.tgz",
-			"integrity": "sha512-wGbQfPlf8YV6gGhcGPYWUhHORct4xaBQSaDTJrwzlgHYyrrJUVXXgZxaM4+Aa23zQoA13nvFQHvfssOkwdh65g==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.8.0.tgz",
+			"integrity": "sha512-d8osKgKA7LgVGTo29+7qjoxLM84bIBeayCjwRsr2bhK9Naum0O341+JRmtlwc6u/zbbuxZEkoyhxG9ZvKjaezA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10087,47 +10110,48 @@
 			}
 		},
 		"node_modules/@wordpress/editor": {
-			"version": "14.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.7.0.tgz",
-			"integrity": "sha512-kpDgRAh5FfxmDfyhaVchXRmM5ueQfcYGqyKdXExe1Mt/Anw8IxHcz7/YqtE+L8BakDsS/A7OudlBiLANjrhUVw==",
+			"version": "14.8.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.8.3.tgz",
+			"integrity": "sha512-C8q6UfnKQVRZNXEK4kJ6d4Mk2TDWi2nG2NHtYASXJmC1lp2tUOkwN/Nb+EKcJ0N+/+HjQhQsQyIZLApc189z8Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.7.0",
-				"@wordpress/api-fetch": "^7.7.0",
-				"@wordpress/blob": "^4.7.0",
-				"@wordpress/block-editor": "^14.2.0",
-				"@wordpress/blocks": "^13.7.0",
-				"@wordpress/commands": "^1.7.0",
-				"@wordpress/components": "^28.7.0",
-				"@wordpress/compose": "^7.7.0",
-				"@wordpress/core-data": "^7.7.0",
-				"@wordpress/data": "^10.7.0",
-				"@wordpress/dataviews": "^4.3.0",
-				"@wordpress/date": "^5.7.0",
-				"@wordpress/deprecated": "^4.7.0",
-				"@wordpress/dom": "^4.7.0",
-				"@wordpress/element": "^6.7.0",
-				"@wordpress/hooks": "^4.7.0",
-				"@wordpress/html-entities": "^4.7.0",
-				"@wordpress/i18n": "^5.7.0",
-				"@wordpress/icons": "^10.7.0",
-				"@wordpress/interface": "^6.7.0",
-				"@wordpress/keyboard-shortcuts": "^5.7.0",
-				"@wordpress/keycodes": "^4.7.0",
-				"@wordpress/media-utils": "^5.7.0",
-				"@wordpress/notices": "^5.7.0",
-				"@wordpress/patterns": "^2.7.0",
-				"@wordpress/plugins": "^7.7.0",
-				"@wordpress/preferences": "^4.7.0",
-				"@wordpress/private-apis": "^1.7.0",
-				"@wordpress/reusable-blocks": "^5.7.0",
-				"@wordpress/rich-text": "^7.7.0",
-				"@wordpress/server-side-render": "^5.7.0",
-				"@wordpress/url": "^4.7.0",
-				"@wordpress/warning": "^3.7.0",
-				"@wordpress/wordcount": "^4.7.0",
+				"@wordpress/a11y": "^4.8.1",
+				"@wordpress/api-fetch": "^7.8.1",
+				"@wordpress/blob": "^4.8.1",
+				"@wordpress/block-editor": "^14.3.1",
+				"@wordpress/blocks": "^13.8.1",
+				"@wordpress/commands": "^1.8.1",
+				"@wordpress/components": "^28.8.1",
+				"@wordpress/compose": "^7.8.1",
+				"@wordpress/core-data": "^7.8.1",
+				"@wordpress/data": "^10.8.1",
+				"@wordpress/dataviews": "^4.4.1",
+				"@wordpress/date": "^5.8.1",
+				"@wordpress/deprecated": "^4.8.1",
+				"@wordpress/dom": "^4.8.1",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/fields": "^0.0.2",
+				"@wordpress/hooks": "^4.8.1",
+				"@wordpress/html-entities": "^4.8.1",
+				"@wordpress/i18n": "^5.8.1",
+				"@wordpress/icons": "^10.8.1",
+				"@wordpress/interface": "^6.8.1",
+				"@wordpress/keyboard-shortcuts": "^5.8.1",
+				"@wordpress/keycodes": "^4.8.1",
+				"@wordpress/media-utils": "^5.8.1",
+				"@wordpress/notices": "^5.8.1",
+				"@wordpress/patterns": "^2.8.1",
+				"@wordpress/plugins": "^7.8.1",
+				"@wordpress/preferences": "^4.8.1",
+				"@wordpress/private-apis": "^1.8.1",
+				"@wordpress/reusable-blocks": "^5.8.1",
+				"@wordpress/rich-text": "^7.8.1",
+				"@wordpress/server-side-render": "^5.8.1",
+				"@wordpress/url": "^4.8.1",
+				"@wordpress/warning": "^3.8.1",
+				"@wordpress/wordcount": "^4.8.1",
 				"change-case": "^4.1.2",
 				"client-zip": "^2.4.5",
 				"clsx": "^2.1.1",
@@ -10150,14 +10174,14 @@
 			}
 		},
 		"node_modules/@wordpress/editor/node_modules/@wordpress/keycodes": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.7.0.tgz",
-			"integrity": "sha512-x8I0xjRM8U0RnpFHWN9mA+x3MqjhJNBldiCpb59GTi3BIzPeDPgxbosAsAAgF0pYdDtGyiRkrOZA23NTia63TA==",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.8.2.tgz",
+			"integrity": "sha512-BxZD5tk4sDHywV7HOF/hSY924ToW7YJe6hDh4yv+7vo5LpiYQq+/uW21hyXrWEjGXZtdmT1tx69wR16BG35bYw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.7.0"
+				"@wordpress/i18n": "^5.8.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10165,9 +10189,9 @@
 			}
 		},
 		"node_modules/@wordpress/editor/node_modules/@wordpress/warning": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.7.0.tgz",
-			"integrity": "sha512-wGbQfPlf8YV6gGhcGPYWUhHORct4xaBQSaDTJrwzlgHYyrrJUVXXgZxaM4+Aa23zQoA13nvFQHvfssOkwdh65g==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.8.1.tgz",
+			"integrity": "sha512-xlo0Xw1jiyiE6nh43NAtQMAL05VDk837kY2xfjsus6wD597TeWFpj6gmcRMH25FZULTUHDB2EPfLviWXqOgUfg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10176,15 +10200,16 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.8.0.tgz",
-			"integrity": "sha512-RufMjsZl0vyYRWGbc/iDlUbu10qRcpOYLCBnayKcAeRh0ojQ/upMcObW+PPnpo/FOcbDRqj29FCvkZDqI/2cOg==",
+			"version": "6.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.8.1.tgz",
+			"integrity": "sha512-JUd0XUHjNtQexAUJq5TodweU9kooCdrh/3NlKj8jEMKgveDx+ipXN2zVsaJWzAcu50FBhegaL+hFH6XRtqEDdQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"@types/react": "^18.2.79",
 				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.8.0",
+				"@wordpress/escape-html": "^3.8.1",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -10299,10 +10324,11 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.8.0.tgz",
-			"integrity": "sha512-PTooGfO0I6wQ4WT96iAjiljT7nU1Jvc45XC1jxahC0Tml9pGxGx7Rkxlldq2F41aBpg3ZgBZ+ceEb+DOOSy+kQ==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.8.1.tgz",
+			"integrity": "sha512-JFOjsD6rSFVoFqK+f5YCeYmRycn7Hj29cX3+sBXL0p5Uox7SQLhY/rmATm6o/PiGCVtDeQlZ9I8dBeQSZBoXqQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -10570,11 +10596,60 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@wordpress/hooks": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.8.0.tgz",
-			"integrity": "sha512-6CPXtkZOHg8Q9gFulbuB+V74yCaPK2E2nRMw2BXE1yNfIAItqMbUiC8zrNOamtLcg3ifsk1PPeJ2DX5mR7Wyug==",
+		"node_modules/@wordpress/fields": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.0.2.tgz",
+			"integrity": "sha512-e20z6lFI1Q1QpahKHTfOiA2/6v1fVl5feu0LfJCQzOiFfqPOIe6PC+dAbBrC0EOCbu4B22X8paDWEb/NpY0jdA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/blob": "^4.8.1",
+				"@wordpress/blocks": "^13.8.1",
+				"@wordpress/components": "^28.8.1",
+				"@wordpress/compose": "^7.8.1",
+				"@wordpress/core-data": "^7.8.1",
+				"@wordpress/data": "^10.8.1",
+				"@wordpress/dataviews": "^4.4.1",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/hooks": "^4.8.1",
+				"@wordpress/html-entities": "^4.8.1",
+				"@wordpress/i18n": "^5.8.1",
+				"@wordpress/icons": "^10.8.1",
+				"@wordpress/notices": "^5.8.1",
+				"@wordpress/patterns": "^2.8.1",
+				"@wordpress/primitives": "^4.8.1",
+				"@wordpress/private-apis": "^1.8.1",
+				"@wordpress/url": "^4.8.1",
+				"@wordpress/warning": "^3.8.1",
+				"change-case": "4.1.2",
+				"client-zip": "^2.4.5"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/warning": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.8.1.tgz",
+			"integrity": "sha512-xlo0Xw1jiyiE6nh43NAtQMAL05VDk837kY2xfjsus6wD597TeWFpj6gmcRMH25FZULTUHDB2EPfLviWXqOgUfg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/hooks": {
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.8.2.tgz",
+			"integrity": "sha512-BhhYJB/RFIng6Taydah6zCMd9iDYdSlISvByP9tBDsuHZL6iuVBmEGBXmm0Mt6ABCFHELuhFkxwdWPRjWTiqSw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -10584,10 +10659,11 @@
 			}
 		},
 		"node_modules/@wordpress/html-entities": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.8.0.tgz",
-			"integrity": "sha512-kJZg83oKZLvXz4jmZUoqPxXTDeoGxy1yV2nyqVWuEXoGRVFzBSPZRxVf7Rn6R06WU/0bGpjMH2ZDrj9MlMoWqA==",
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.8.1.tgz",
+			"integrity": "sha512-JOiXUdts9PvanVj3cuPlzJop6UBMDApzLRWRLeZNjZPq0IsTGcI7zPhBVT++aW1C8zTzngzpdFfFaWle3p5w7Q==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -10597,13 +10673,14 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.8.0.tgz",
-			"integrity": "sha512-pPx8RPT69Kds8wygHGfkt+D2jxdyu2HIYw3yM+dj47rNW2rHtZFVoOr+QzwOJ4yoHRuN1zMhOfzHsC4WV+ARcg==",
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.8.2.tgz",
+			"integrity": "sha512-evcwjw1cfGoyJoPMZlaYNwmYJAlIJh5pkgM1QWanpBPTMLsMOMcpZQGzOwvKf1uLozGOKkBAe106qQ7rgjZkoQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^4.8.0",
+				"@wordpress/hooks": "^4.8.2",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"sprintf-js": "^1.1.1",
@@ -10618,14 +10695,15 @@
 			}
 		},
 		"node_modules/@wordpress/icons": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.8.0.tgz",
-			"integrity": "sha512-JiBI44uNkJEHV3IU0rKLn0wO36crWY62NqiQ6Fi+nn8KG0J4e1/JrJoV5EiFkaLneWBAFPeUkLjIOYlNPcZnmA==",
+			"version": "10.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.8.2.tgz",
+			"integrity": "sha512-ebJ3mRJo3bMgPm9vSTxc7I98HT30mgU59WGUAQyx31cElKbzMhd3jM7bD2JhYXZ1OPnJGY3W4lHovMFfU7wsOQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/element": "^6.8.0",
-				"@wordpress/primitives": "^4.8.0"
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/primitives": "^4.8.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10662,25 +10740,25 @@
 			}
 		},
 		"node_modules/@wordpress/interface": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-6.7.0.tgz",
-			"integrity": "sha512-Me6EaNHNPcI9hiX97hYC2f7Y5PnuQ/HN3yo1DB4/+AAW/71Gl9oGKebGujivchl7RJ3a7Ztg/PJYIDFA+B/XEA==",
+			"version": "6.8.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-6.8.4.tgz",
+			"integrity": "sha512-Z2TZY0FsmVfEmiwFtFtXrxWy61Dn+nntXqcYpWxzwLFbNOz4YWQKRk4zAZ44Jb+tv9ipIRZaZUNrPf7ryPQ+4A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.7.0",
-				"@wordpress/components": "^28.7.0",
-				"@wordpress/compose": "^7.7.0",
-				"@wordpress/data": "^10.7.0",
-				"@wordpress/deprecated": "^4.7.0",
-				"@wordpress/element": "^6.7.0",
-				"@wordpress/i18n": "^5.7.0",
-				"@wordpress/icons": "^10.7.0",
-				"@wordpress/plugins": "^7.7.0",
-				"@wordpress/preferences": "^4.7.0",
-				"@wordpress/private-apis": "^1.7.0",
-				"@wordpress/viewport": "^6.7.0",
+				"@wordpress/a11y": "^4.8.2",
+				"@wordpress/components": "^28.8.4",
+				"@wordpress/compose": "^7.8.3",
+				"@wordpress/data": "^10.8.3",
+				"@wordpress/deprecated": "^4.8.2",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/i18n": "^5.8.2",
+				"@wordpress/icons": "^10.8.2",
+				"@wordpress/plugins": "^7.8.4",
+				"@wordpress/preferences": "^4.8.4",
+				"@wordpress/private-apis": "^1.8.1",
+				"@wordpress/viewport": "^6.8.3",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -10693,10 +10771,11 @@
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.8.0.tgz",
-			"integrity": "sha512-DLADJVspAFOeY6wO+uYQrcEy+IF3OtRLh4xbI0Qrc6nIs3gdEd+Dwud9tDu6BirV+9ZpON9yDffmq1/5Nhhtww==",
+			"version": "5.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.8.1.tgz",
+			"integrity": "sha512-2UpGvp+y7pCxQQoNyb5PIYPptZZjfcR80evR/V/0Abyxde+N0dEJHroiOd+Nm1BJJijzhmMH1B7AlyGqnKaFXA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -10741,15 +10820,16 @@
 			}
 		},
 		"node_modules/@wordpress/keyboard-shortcuts": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.8.0.tgz",
-			"integrity": "sha512-w0Oc/SzcEtD5i1aTtpbVvr2oQ1IMF8h6j1OyDk/YqAX/WN7T/KZZCo3DqQi6sLmnbhUYDas1KgDII9vjBVLRRw==",
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.8.3.tgz",
+			"integrity": "sha512-V8HUZ63/6hronEBO0dQmYxlk7aSM7+fawTDLrqHfMhqi75GWrwhztWSb2Xju0J7rOvSVO7Oc5gk+JX+ZvniWqA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/data": "^10.8.0",
-				"@wordpress/element": "^6.8.0",
-				"@wordpress/keycodes": "^4.8.0"
+				"@wordpress/data": "^10.8.3",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/keycodes": "^4.8.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10760,13 +10840,14 @@
 			}
 		},
 		"node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/keycodes": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.8.0.tgz",
-			"integrity": "sha512-HIg8ALiALwMfuI2MAeKaQPraERRf+skCixCIjHs9HM0C48Vov95F3aoHfINCrKXkyQXhTjrJrLDDNEXw6ZF+gw==",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.8.2.tgz",
+			"integrity": "sha512-BxZD5tk4sDHywV7HOF/hSY924ToW7YJe6hDh4yv+7vo5LpiYQq+/uW21hyXrWEjGXZtdmT1tx69wR16BG35bYw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.8.0"
+				"@wordpress/i18n": "^5.8.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10822,17 +10903,17 @@
 			}
 		},
 		"node_modules/@wordpress/media-utils": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.7.0.tgz",
-			"integrity": "sha512-uWaU/El9f58fdj9gYWqlTvH2m+5MmV2SKl0jsQhJXL+NEBY8KWsXwAWJyNJ6LyAQztoU1evHIB7a07GJp7gksg==",
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.8.2.tgz",
+			"integrity": "sha512-r8C9WapBHkoLPOU9so3Ocdo17xHwJ43EfXckc47c9Wvu9Gn3CulkZWSvnIMeQLcm1Ay/PBBRu2Vxim5PNCaTpg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "^7.7.0",
-				"@wordpress/blob": "^4.7.0",
-				"@wordpress/element": "^6.7.0",
-				"@wordpress/i18n": "^5.7.0"
+				"@wordpress/api-fetch": "^7.8.2",
+				"@wordpress/blob": "^4.8.1",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/i18n": "^5.8.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10840,14 +10921,15 @@
 			}
 		},
 		"node_modules/@wordpress/notices": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.8.0.tgz",
-			"integrity": "sha512-bSIv4KUbuZpXC/hP03Id6cfFjbgjTrCyReCJetZzqIGNhvcbtyobonGw0KSso3oHx47bVneBcQ6t421bhHAFRA==",
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.8.3.tgz",
+			"integrity": "sha512-k2I6vS4y3OvaDIGGO5B94up7uQqpO0Vtykz7rvez0+nXJazYylKNv88zsegyjf74bWhhJ3HpfiDl+JVehwHnxw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.8.0",
-				"@wordpress/data": "^10.8.0"
+				"@wordpress/a11y": "^4.8.2",
+				"@wordpress/data": "^10.8.3"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10871,27 +10953,27 @@
 			}
 		},
 		"node_modules/@wordpress/patterns": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.7.0.tgz",
-			"integrity": "sha512-6aE/+bSsAqffzqWLKReN9o5Szk4zMyNzkCsclSPjNp/hBCY7HYKfqlD6TNqLWKLlHgw+mYmtw5gZho6U3hRO9Q==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.8.4.tgz",
+			"integrity": "sha512-gTXB6EHOLNFEwqYxv+nrFilvg7yjRKCURDQ5asXGoFw/Yr3eJ6od6plyXP9T+YnS877LV0ot2x9OA2whz09SFg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.7.0",
-				"@wordpress/block-editor": "^14.2.0",
-				"@wordpress/blocks": "^13.7.0",
-				"@wordpress/components": "^28.7.0",
-				"@wordpress/compose": "^7.7.0",
-				"@wordpress/core-data": "^7.7.0",
-				"@wordpress/data": "^10.7.0",
-				"@wordpress/element": "^6.7.0",
-				"@wordpress/html-entities": "^4.7.0",
-				"@wordpress/i18n": "^5.7.0",
-				"@wordpress/icons": "^10.7.0",
-				"@wordpress/notices": "^5.7.0",
-				"@wordpress/private-apis": "^1.7.0",
-				"@wordpress/url": "^4.7.0"
+				"@wordpress/a11y": "^4.8.2",
+				"@wordpress/block-editor": "^14.3.4",
+				"@wordpress/blocks": "^13.8.4",
+				"@wordpress/components": "^28.8.4",
+				"@wordpress/compose": "^7.8.3",
+				"@wordpress/core-data": "^7.8.4",
+				"@wordpress/data": "^10.8.3",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/html-entities": "^4.8.1",
+				"@wordpress/i18n": "^5.8.2",
+				"@wordpress/icons": "^10.8.2",
+				"@wordpress/notices": "^5.8.3",
+				"@wordpress/private-apis": "^1.8.1",
+				"@wordpress/url": "^4.8.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10903,18 +10985,19 @@
 			}
 		},
 		"node_modules/@wordpress/plugins": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.8.0.tgz",
-			"integrity": "sha512-q76pct46psk2G1Cne6UnqsbgMHpcly4pR1bAWN9tbMRjjfnfpK5aliN+Y0RjhWSJ6PanqaFZqI0rpqV3kPxF0A==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.8.4.tgz",
+			"integrity": "sha512-qghBNRSPbxZ1RQdiWm0OD5ROqhCVi2Gs3buFGZnVBRCmH/oz6ocFrx9jtqDUD5acOODSLoy4OL6wmM8R54IJ6w==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/components": "^28.8.0",
-				"@wordpress/compose": "^7.8.0",
-				"@wordpress/element": "^6.8.0",
-				"@wordpress/hooks": "^4.8.0",
-				"@wordpress/icons": "^10.8.0",
-				"@wordpress/is-shallow-equal": "^5.8.0",
+				"@wordpress/components": "^28.8.4",
+				"@wordpress/compose": "^7.8.3",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/hooks": "^4.8.2",
+				"@wordpress/icons": "^10.8.2",
+				"@wordpress/is-shallow-equal": "^5.8.1",
 				"memize": "^2.0.1"
 			},
 			"engines": {
@@ -10944,21 +11027,22 @@
 			}
 		},
 		"node_modules/@wordpress/preferences": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.8.0.tgz",
-			"integrity": "sha512-gqOzLUBBue1Kfunknw8B/8aJVRAffm0v1eGOKSHdQZGSG9Td+uowEuGsEY6Ei8E+dVryhlQNpSSRQ0eLIGLNXA==",
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.8.4.tgz",
+			"integrity": "sha512-K5/YJu2vIQ7d05ZQ2e7wfPeazIw3RGYbYYMiLEfysIZHRbK2x0BLiG97OygFlx2SeBrAOjioaWtHlRzix3flEQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.8.0",
-				"@wordpress/components": "^28.8.0",
-				"@wordpress/compose": "^7.8.0",
-				"@wordpress/data": "^10.8.0",
-				"@wordpress/deprecated": "^4.8.0",
-				"@wordpress/element": "^6.8.0",
-				"@wordpress/i18n": "^5.8.0",
-				"@wordpress/icons": "^10.8.0",
-				"@wordpress/private-apis": "^1.8.0",
+				"@wordpress/a11y": "^4.8.2",
+				"@wordpress/components": "^28.8.4",
+				"@wordpress/compose": "^7.8.3",
+				"@wordpress/data": "^10.8.3",
+				"@wordpress/deprecated": "^4.8.2",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/i18n": "^5.8.2",
+				"@wordpress/icons": "^10.8.2",
+				"@wordpress/private-apis": "^1.8.1",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -10984,13 +11068,14 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.8.0.tgz",
-			"integrity": "sha512-ZGY+vrc6+Rklsbc+cm506fHc8JGCSXKv041VHtxwxtc92zVdVjugx+4XWzEsiEe0/vV6aFqFdGibKwureMmQ5A==",
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.8.1.tgz",
+			"integrity": "sha512-enfNxpEWycMNnvF7lpP8QYGKotu6B0UfUVcA89oDkam4OhP8tkpP1OVZyPHPgseRWweS/hL6aW/4bvwNSklf+g==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/element": "^6.8.0",
+				"@wordpress/element": "^6.8.1",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -11002,10 +11087,11 @@
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.8.0.tgz",
-			"integrity": "sha512-AVzPk/Y+Cs3cjgg1cOLSXYbM7s8lRVWh1f4b6yXNaaskv932EiE25CEqihE8PVZgXVQzlF292aP0jR1YYisZDg==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.8.1.tgz",
+			"integrity": "sha512-USgFi75o7GlWiPu1hSGSWFXcj5nOjTVjrj0jM6sV+vqa39oRXxE4zpxGkvV4EINn8OrqvHBs/17uygAFXqppZQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"requestidlecallback": "^0.3.0"
@@ -11016,10 +11102,11 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.8.0.tgz",
-			"integrity": "sha512-FHpv4YajpMePibZzmGxToXa0HPXIkhju0xCk7fxdETU22YJKQA9uUMNuWcZDSY3XpakCuUCu3cAemKgme+yaTg==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.8.1.tgz",
+			"integrity": "sha512-/5PV8+QfkaLJs9TsFTIVMc3Ns+KdysFzS5ZGSmRGgsjzzgqHZb670mxf/6YaFldNjELbg5QsvcHNm3mkfkYiQg==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -11029,10 +11116,11 @@
 			}
 		},
 		"node_modules/@wordpress/redux-routine": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.8.0.tgz",
-			"integrity": "sha512-drTkSRELSw0b0AxcvQmcxRIBhTDuyYAFYToe4N0PsQoZM9pbhZHdBespX2Jrz4s/npHkmGr/KSL7vungzg47jQ==",
+			"version": "5.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.8.1.tgz",
+			"integrity": "sha512-mScAi3R/o9dAeS5yQm7F/txNSHhXthYE/NbHtm808+iMgXvgTztAJSg4K29YpAhXgqPTFYMTX0cFiiQ1uNEGqw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"is-plain-object": "^5.0.0",
@@ -11048,24 +11136,24 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.7.0.tgz",
-			"integrity": "sha512-F4CPUtLMKPSDK+OdrJRRBFlA6yBHpfV2tfcrqpo95l06GskIrgr1IQpyLiFnVKZPhO82K5Y/R3NS0xwD2NxuRQ==",
+			"version": "5.8.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.8.4.tgz",
+			"integrity": "sha512-KFe9+mn5XkTGttNvXaZ/fGjW+QjLtxZpH05M5Q9P5cLW4WVNNePyIMJvlomzVtcycDSp5nSxbnwJp2Xu2JYDnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/block-editor": "^14.2.0",
-				"@wordpress/blocks": "^13.7.0",
-				"@wordpress/components": "^28.7.0",
-				"@wordpress/core-data": "^7.7.0",
-				"@wordpress/data": "^10.7.0",
-				"@wordpress/element": "^6.7.0",
-				"@wordpress/i18n": "^5.7.0",
-				"@wordpress/icons": "^10.7.0",
-				"@wordpress/notices": "^5.7.0",
-				"@wordpress/private-apis": "^1.7.0",
-				"@wordpress/url": "^4.7.0"
+				"@wordpress/block-editor": "^14.3.4",
+				"@wordpress/blocks": "^13.8.4",
+				"@wordpress/components": "^28.8.4",
+				"@wordpress/core-data": "^7.8.4",
+				"@wordpress/data": "^10.8.3",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/i18n": "^5.8.2",
+				"@wordpress/icons": "^10.8.2",
+				"@wordpress/notices": "^5.8.3",
+				"@wordpress/private-apis": "^1.8.1",
+				"@wordpress/url": "^4.8.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -11077,20 +11165,21 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.8.0.tgz",
-			"integrity": "sha512-j/cQGiRFVXMiQjYff0yZfnm+aQw2zOiZ86Hulvj1zW/EVdWfOd1bWqB3CVV92H33y75/uEj2ZpHRf7SCDdpFSg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.8.3.tgz",
+			"integrity": "sha512-rB2hebZbTAI5LdLLtatwijpRKzYO+UdQes1Bni2WBAd59KH0YIj4kkVnj39lYYrV3OS+CqSqH2W4UJB7HPNRWQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.8.0",
-				"@wordpress/compose": "^7.8.0",
-				"@wordpress/data": "^10.8.0",
-				"@wordpress/deprecated": "^4.8.0",
-				"@wordpress/element": "^6.8.0",
-				"@wordpress/escape-html": "^3.8.0",
-				"@wordpress/i18n": "^5.8.0",
-				"@wordpress/keycodes": "^4.8.0",
+				"@wordpress/a11y": "^4.8.2",
+				"@wordpress/compose": "^7.8.3",
+				"@wordpress/data": "^10.8.3",
+				"@wordpress/deprecated": "^4.8.2",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/escape-html": "^3.8.1",
+				"@wordpress/i18n": "^5.8.2",
+				"@wordpress/keycodes": "^4.8.2",
 				"memize": "^2.1.0"
 			},
 			"engines": {
@@ -11102,13 +11191,14 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/keycodes": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.8.0.tgz",
-			"integrity": "sha512-HIg8ALiALwMfuI2MAeKaQPraERRf+skCixCIjHs9HM0C48Vov95F3aoHfINCrKXkyQXhTjrJrLDDNEXw6ZF+gw==",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.8.2.tgz",
+			"integrity": "sha512-BxZD5tk4sDHywV7HOF/hSY924ToW7YJe6hDh4yv+7vo5LpiYQq+/uW21hyXrWEjGXZtdmT1tx69wR16BG35bYw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.8.0"
+				"@wordpress/i18n": "^5.8.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -11633,22 +11723,22 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@wordpress/server-side-render": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-5.7.0.tgz",
-			"integrity": "sha512-VXBluHj/WICCx4OcjZrcrBg+YxXbah1YL4n2yLWhDMENAL0p4Ne67EqrQjCGbIfpGUpNDCQhIXXzSJ3gNiuCMg==",
+			"version": "5.8.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-5.8.4.tgz",
+			"integrity": "sha512-2IdotmrwxMbTJqFe6s2Ji8b4isyt42tJNIgy+ONl4NhuFaWI7fLUhLGItrZWdNDfxwLDjH4dzvEcH8fTVyLxEA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "^7.7.0",
-				"@wordpress/blocks": "^13.7.0",
-				"@wordpress/components": "^28.7.0",
-				"@wordpress/compose": "^7.7.0",
-				"@wordpress/data": "^10.7.0",
-				"@wordpress/deprecated": "^4.7.0",
-				"@wordpress/element": "^6.7.0",
-				"@wordpress/i18n": "^5.7.0",
-				"@wordpress/url": "^4.7.0",
+				"@wordpress/api-fetch": "^7.8.2",
+				"@wordpress/blocks": "^13.8.4",
+				"@wordpress/components": "^28.8.4",
+				"@wordpress/compose": "^7.8.3",
+				"@wordpress/data": "^10.8.3",
+				"@wordpress/deprecated": "^4.8.2",
+				"@wordpress/element": "^6.8.1",
+				"@wordpress/i18n": "^5.8.2",
+				"@wordpress/url": "^4.8.1",
 				"fast-deep-equal": "^3.1.3"
 			},
 			"engines": {
@@ -11661,10 +11751,11 @@
 			}
 		},
 		"node_modules/@wordpress/shortcode": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.8.0.tgz",
-			"integrity": "sha512-+94owQNcMkB/U6XaDiOsJmnf9+efQWPR4Acl51qlkFP1Fka79j8JLXkZWcNc4OWHrknBbNjmiaULz1CK/8JS3A==",
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.8.1.tgz",
+			"integrity": "sha512-c8wYr2zmXOonAgABnFmuKRQ7wYyAIvshb3nCVrjFbpHnFmK+CHMg/y/KmcnfnPscdAO+uKDBKYNp0fnYfQBhiQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"memize": "^2.0.1"
@@ -11675,10 +11766,11 @@
 			}
 		},
 		"node_modules/@wordpress/style-engine": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.8.0.tgz",
-			"integrity": "sha512-ukD/bn3HwhZDgkdELlLuwIHKmkqO7HHyjzjlSVvdCKDA9dXYlGJlaosbjYgY//sImAr9Er4uaWiIIl3Ls8KLRg==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.8.1.tgz",
+			"integrity": "sha512-wsYdvrc+CEqidp9TmpG+/9s6zm1GEUU2Qp5qIELcQWU6VNzuycc5nqzFnRiKv0Pz+6TRgksjLsb86IQrCcg2nA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"change-case": "^4.1.2"
@@ -11706,14 +11798,15 @@
 			}
 		},
 		"node_modules/@wordpress/sync": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.8.0.tgz",
-			"integrity": "sha512-s7HtjPHlVs856EJBdVMPk/qzDrVlBMz+onX/o6h8hP86Fj71UOcDq6zFHAzn5MqO2bHQ3d+z6dkBVIgUzexCXw==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.8.1.tgz",
+			"integrity": "sha512-i2vYN15nh5Cf8EgryZIIKAvx0IZi34gBqXNwvSymhh1/eD4yzcFyaFfko7NS93fPeGuVy/Hxj+2M1CdZ7fd43w==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"@types/simple-peer": "^9.11.5",
-				"@wordpress/url": "^4.8.0",
+				"@wordpress/url": "^4.8.1",
 				"import-locals": "^2.0.0",
 				"lib0": "^0.2.42",
 				"simple-peer": "^9.11.0",
@@ -11728,10 +11821,11 @@
 			}
 		},
 		"node_modules/@wordpress/token-list": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.8.0.tgz",
-			"integrity": "sha512-6YLnAzBhyDHMq7vdzPh4vYjGvD+BKQPcR8WEmysmMh+xZySAd2GjuKvYGigXCqi1QjDqUy6zVmimZOg9vhwfqg==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.8.1.tgz",
+			"integrity": "sha512-uQEimvYlEsjQh5PHscYnctSnuK11ZOpUGLlYbJ10VtoisDJP2bqYwu36FBGrEuY5g0y6y/rP/Hw1BirZ+wrZyw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -11741,13 +11835,14 @@
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.8.0.tgz",
-			"integrity": "sha512-Cl8Eb+VxVYX9AptMXdMczLkUmcaKXx0PJpgTQ+isZASagXBLZ3ebWGqbChtShqR0IyPn9jMYkPw6Zk4+V6T+eg==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.8.1.tgz",
+			"integrity": "sha512-l5U3NswNDWHVQ3sAsiCvI65JDrAFlBnAIsoKsc38zg2OkNO1m8IIf/K+D3YAqBBM+zDahSGbNaLCEftBbZVSUg==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/is-shallow-equal": "^5.8.0"
+				"@wordpress/is-shallow-equal": "^5.8.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -11755,10 +11850,11 @@
 			}
 		},
 		"node_modules/@wordpress/url": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.8.0.tgz",
-			"integrity": "sha512-8Za/lrTTH3+Y5/shsqmDgQ493Sr1Do99tIyCu62Z2hm6KmP5KH6nHX+kInKtBamdW+fHTBFN56cZj5/AgByM8w==",
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.8.1.tgz",
+			"integrity": "sha512-YZcNOlJAUhkxMWlmkkc6mvSdXukkleq8j5Z8p8kBWQX9Wxng84ygyBSMiqFeFvAIs8nNDXBrqG9zGGRxMW6q/g==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"remove-accents": "^0.5.0"
@@ -11769,16 +11865,16 @@
 			}
 		},
 		"node_modules/@wordpress/viewport": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.7.0.tgz",
-			"integrity": "sha512-T05rktsX+xOgTekKKRIAwuK+FdtmOMQVfbkxtGW2RtfwBWc161ZdgXT0C3x+LWwzhocYg2ymwkM9Mm8/MBhgFw==",
+			"version": "6.8.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.8.3.tgz",
+			"integrity": "sha512-izS9YQmogTilQx0xrd9RspAeF/PT1V9N7S7QjNAH9UZ7E4k32m2Vg6ebcYQGShRgmjUReiunIDDr0VDSK5h3PQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^7.7.0",
-				"@wordpress/data": "^10.7.0",
-				"@wordpress/element": "^6.7.0"
+				"@wordpress/compose": "^7.8.3",
+				"@wordpress/data": "^10.8.3",
+				"@wordpress/element": "^6.8.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -11829,10 +11925,11 @@
 			}
 		},
 		"node_modules/@wordpress/wordcount": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.8.0.tgz",
-			"integrity": "sha512-jFDOllifLzQ+9msNL2dABMjezaXSxRt6XwKApZfJQBezjL7liOlelLAsRddhL9oWo48frKHHrRJq8nZYQ9L5SQ==",
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.8.1.tgz",
+			"integrity": "sha512-72e8N6I6he5pA9KDwqrq3mRMb+9WtzqR67C0uBmrlQg4FT23XptG8fDVacD2Das2nWSAgaLR/4GhKv34pPj1vg==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"@wordpress/data": "^10.8.0",
 		"@wordpress/e2e-test-utils-playwright": "^1.8.0",
 		"@wordpress/edit-post": "^8.7.0",
-		"@wordpress/editor": "^14.7.0",
+		"@wordpress/editor": "^14.8.3",
 		"@wordpress/element": "^6.8.0",
 		"@wordpress/env": "^10.8.0",
 		"@wordpress/eslint-plugin": "^21.1.2",


### PR DESCRIPTION
## Description
Updates `@wordpress/editor` from 14.7.0 to 14.8.3. Replaces #2788 as the update of `@types/wordpress__editor` was causing issues.

## Motivation and context
Update dependencies while keeping our sanity.

## How has this been tested?
The builds that fail in #2788 succeed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the WordPress editor package to the latest version, potentially introducing new features and improvements.
  
- **Bug Fixes**
	- Included bug fixes and performance enhancements from the updated editor package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->