### PR TITLE
Fix AMP validation issues

### DIFF
--- a/src/Integrations/class-amp.php
+++ b/src/Integrations/class-amp.php
@@ -85,7 +85,8 @@ class Amp extends Integration {
 	}
 
 	/**
-	 * Adds AMP actions.
+	 * Adds AMP actions and deregisters any scripts that create AMP validation
+	 * issues.
 	 *
 	 * @since 2.6.0
 	 */
@@ -93,6 +94,16 @@ class Amp extends Integration {
 		if ( $this->can_handle_amp_request() ) {
 			add_filter( 'amp_post_template_analytics', array( $this, 'register_parsely_for_amp_analytics' ) );
 			add_filter( 'amp_analytics_entries', array( $this, 'register_parsely_for_amp_native_analytics' ) );
+
+			// The tracker script isn't needed here, since tracking is done via
+			// the amp-analytics tag. Including the tracker creates an AMP
+			// validation issue.
+			wp_deregister_script( 'wp-parsely-tracker' );
+
+			// Our loader script creates an AMP validation issue, and it might
+			// not be useful under the AMP context. If we get feedback that it's
+			// needed, we can consider adding it under AMP.
+			wp_deregister_script( 'wp-parsely-loader' );
 		}
 	}
 


### PR DESCRIPTION
## Description
When using the [AMP plugin](https://wordpress.org/plugins/amp/), wp-parsely would be the source of certain AMP validation issues.

The culprits were found to be the Parse.ly tracker script, as well as our loader script. Both scripts were removed from AMP requests, since:
- Tracking is already being taken care of by `<amp-analytics>` (see [docs](https://docs.parse.ly/google-amp/)).
- The loader script probably doesn't have any practical use under the AMP context, and would probably require some work to be available under it. We can consider adding the loader script in the future if we see that there are practical use cases for it.

Since these scripts were being auto-removed by the AMP plugin anyway, these changes are more to appease warnings, rather than to fix something that wasn't working. This is to say that AMP integration was working, regardless of the warnings.

## Motivation and context
- Offer a user experience without quirky warnings, that might make users believe that their integration isn't working because they're getting warnings.
- Fixes #2846.

## How has this been tested?
Manually tested that we are getting AMP site scanning errors before the fix, and no errors after the fix has been applied. Also checked that the correct markup is still being added to non-AMP pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the AMP integration by adding functionality to deregister scripts that could cause validation issues.
	- Updated comments to clarify the necessity of deregistering specific scripts for improved AMP compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->