### PR TITLE
GitHub Actions: Add Build Plugin action

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -1,0 +1,92 @@
+name: Build wp-parsely
+on:
+  push:
+    branches:
+      - trunk
+      - develop
+      - temp-testing-branch
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to build'
+        required: false
+        default: 'develop'
+env:
+  SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref_name }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref_name }}
+  cancel-in-progress: true
+jobs:
+  build:
+    name: Build and Commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup BUILT_BRANCH env
+        run: echo "BUILT_BRANCH=${SOURCE_REF}-built" >> $GITHUB_ENV
+
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Checkout the specific branch/ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_REF }}
+          fetch-depth: 0
+
+      - name: Fetch and checkout built branch
+        run: |
+          if git ls-remote --exit-code origin "${BUILT_BRANCH}"; then
+            git fetch origin "${BUILT_BRANCH}"
+            git checkout "${BUILT_BRANCH}"
+            git pull origin "${BUILT_BRANCH}"
+          else
+            git checkout --orphan "${BUILT_BRANCH}" "${SOURCE_REF}"
+            git commit --allow-empty -m "Create ${BUILT_BRANCH} branch"
+          fi
+
+      - name: Merge current branch into built
+        run: |
+          git merge "${SOURCE_REF}" --strategy-option theirs --no-edit --squash --allow-unrelated-histories
+
+      - name: Read .nvmrc
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Build
+        run: |
+          npm ci
+          npm run build
+          composer install --no-dev --optimize-autoloader --classmap-authoritative
+
+      - name: Get list of changed files
+        run: git status -s
+
+      - name: Create Commit Message
+        run: |
+          # Get the short SHA of the commit
+          COMMIT_SHA=${GITHUB_SHA::7}
+          # Retrieve the original commit message and replace newlines with spaces
+          ORIGINAL_COMMIT_MESSAGE=$(git log -1 --pretty=%B "${GITHUB_SHA}" | tr '\n' ' ' | awk '{$1=$1; sub(/^ +| +$/,"")}1')
+          # Construct the commit message safely using printf
+          printf "Build \"%s\" (%s)\n" "$ORIGINAL_COMMIT_MESSAGE" "$COMMIT_SHA"  > final_commit_message.txt
+
+      - name: Commit built files
+        run: |
+          # Add the built files
+          git add -Af vendor/ build/
+          git status -s
+          # Commit the changes using the commit message file
+          git commit -F final_commit_message.txt --no-verify
+          git push origin "${BUILT_BRANCH}"
+
+
+      - name: Clean up commit message files
+        run: |
+          rm final_commit_message.txt

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -1,0 +1,33 @@
+name: Release wp-parsely
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to release'
+        required: false
+        default: 'trunk'
+      skip_tests:
+        description: 'Skip tests'
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: 'Dry run deployment'
+        required: false
+        type: boolean
+        default: true
+      version:
+        description: 'Version to release'
+        required: true
+
+jobs:
+  output_inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Output Inputs
+        run: |
+          echo "Branch: ${{ github.event.inputs.branch }}"
+          echo "Skip Tests: ${{ github.event.inputs.skip_tests }}"
+          echo "Dry Run: ${{ github.event.inputs.dry_run }}"
+          echo "Version: ${{ github.event.inputs.version }}"


### PR DESCRIPTION
## Description
Adds a GitHub action that automatically builds the Parse.ly plugin when there's a push to `trunk` or `develop`. This action can also be manually triggered. 

This PR also adds a stub action for the release plugin action. 

I'm merging this PR directly to `develop` without further review as I need to test the `workflow_dispatch` triggers. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new automated build workflow for streamlined integration and deployment.
	- Added a release workflow allowing customizable release processes with user-defined parameters.

These enhancements improve the efficiency of the build and release processes for the project, providing users with greater control and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->