### PR TITLE
README.md: Update "Tested up to" to 6.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Stable tag: 3.16.4  
 Requires at least: 5.2  
-Tested up to: 6.5  
+Tested up to: 6.7  
 Requires PHP: 7.2  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  


### PR DESCRIPTION
## Description
This PR updates the "Tested up to" field of `README.md` to `6.7`.

## Motivation and Context
Keep our `README.md` updated with the latest information.

## How Has This Been Tested?
- Current tests pass.
- No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the "Tested up to" version in the README.md for the Parse.ly plugin to reflect compatibility with WordPress version 6.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->