### PR TITLE
Build Workflow: Remove the `/vendor` directory from .gitignore in built branches

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -60,6 +60,10 @@ jobs:
           npm run build
           composer install --no-dev --optimize-autoloader --classmap-authoritative
 
+      - name: Remove `/vendor` from .gitignore
+        run: |
+          sed -i '/vendor/d' .gitignore
+
       - name: Get list of changed files
         run: git status -s
 


### PR DESCRIPTION
## Description
Removes the `vendor/ `directory of `.gitignore` from the `-built` branches. This allows committing this directory without needing to force add it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build workflow to remove the `/vendor` entry from the `.gitignore` file, potentially affecting file tracking in future git operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->