### PR TITLE
Build Plugin Workflow: Add explicit write permission to the build job

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - trunk
       - develop
-      - temp-testing-branch
   workflow_dispatch:
 env:
   SOURCE_REF: ${{ github.ref_name }}
@@ -15,6 +14,10 @@ jobs:
   build:
     name: Build and Commit
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Setup BUILT_BRANCH env
         run: echo "BUILT_BRANCH=${SOURCE_REF}-built" >> $GITHUB_ENV
@@ -79,7 +82,7 @@ jobs:
       - name: Commit built files
         run: |
           # Add the built files
-          git add -Af vendor/ build/
+          git add -A vendor/ build/
           git status -s
           # Commit the changes using the commit message file
           git commit -F final_commit_message.txt --no-verify


### PR DESCRIPTION
## Description

Adds explicit write permissions to the build job of the Build Plugin workflow. This tries to fix an issue with building PRs from dependabot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the workflow by removing an unnecessary branch trigger.
	- Enhanced permissions for the build job.
	- Refined the file staging process for commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->