### PR TITLE
Build Plugin Workflow: Add .gitignore to staging if it has been changed

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Remove `/vendor` from .gitignore
         run: |
           sed -i '/vendor/d' .gitignore
+          # If the file was modified, add it to the git staging area
+          git status -s | grep .gitignore && git add .gitignore
 
       - name: Get list of changed files
         run: git status -s


### PR DESCRIPTION
## Description
When building the repository, if the .gitignore file was changed, i.e. removed the `vendor/` entry, add it explicitly to the git staging so it can be committed later. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved handling of the `.gitignore` file in the commit process.
	- Added a step to create a formatted commit message based on the latest commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->