### PR TITLE
Remove deprecated @types/wordpress__editor package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
 				"@types/wordpress__block-editor": "^11.5.15",
 				"@types/wordpress__blocks": "^12.5.15",
 				"@types/wordpress__edit-post": "^8.4.1",
-				"@types/wordpress__editor": "^14.3.1",
 				"@types/wordpress__wordcount": "^2.4.5",
 				"@typescript-eslint/eslint-plugin": "^6.21.0",
 				"@wordpress/api-fetch": "^7.13.0",
@@ -81,20 +80,20 @@
 			}
 		},
 		"node_modules/@ariakit/core": {
-			"version": "0.4.12",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.12.tgz",
-			"integrity": "sha512-+NNpy88tdP/w9mOBPuDrMTbtapPbo/8yVIzpQB7TAmN0sPh/Cq3nU1f2KCTCIujPmwRvAcMSW9UHOlFmbKEPOA==",
+			"version": "0.4.13",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.13.tgz",
+			"integrity": "sha512-XwHm1OAKZhHkT5z3pSzeRyjUxW2VtPesMP0wa7fiVRXmibRJnJIxffGLZmUy4CHbOtQ46nlT3AlP5hXNQrS0Ow==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@ariakit/react": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.13.tgz",
-			"integrity": "sha512-pTGYgoqCojfyt2xNJ5VQhejxXwwtcP7VDDqcnnVChv7TA2TWWyYerJ5m4oxViI1pgeNqnHZwKlQ79ZipF7W2kQ==",
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.14.tgz",
+			"integrity": "sha512-UfUf54idAiUvkrnqmr55birSMiJ2+xHWviaKHXX9kdFHV27xL2O2ulNEXvk79wnjrgOlBXOvWe16FrY1VR5Vcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/react-core": "0.4.13"
+				"@ariakit/react-core": "0.4.14"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -106,13 +105,13 @@
 			}
 		},
 		"node_modules/@ariakit/react-core": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.13.tgz",
-			"integrity": "sha512-iIjQeupP9d0pOubOzX4a0UPXbhXbp0ZCduDpkv7+u/pYP/utk/YRECD0M/QpZr6YSeltmDiNxKjdyK8r9Yhv4Q==",
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.14.tgz",
+			"integrity": "sha512-vRdl3k7Q7Z3oHNbv8Afz3lbvmpqhKlHW22REFIdA/UE7/YsbD3dhMVncGsmsCHSA06PXF3esk7wP0QkZymO1CQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/core": "0.4.12",
+				"@ariakit/core": "0.4.13",
 				"@floating-ui/dom": "^1.0.0",
 				"use-sync-external-store": "^1.2.0"
 			},
@@ -6414,22 +6413,6 @@
 				"@wordpress/element": "^6.4.0"
 			}
 		},
-		"node_modules/@types/wordpress__editor": {
-			"version": "14.3.1",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__editor/-/wordpress__editor-14.3.1.tgz",
-			"integrity": "sha512-vFHz6mJ0NYfh4fPxOsYG6V5VluMFqK0vk/uEn0VuZ7Kh+OkQYiUSAN7I5X7Pj73gkPtVXYWXrB97b3h/XOvaqg==",
-			"dev": true,
-			"dependencies": {
-				"@types/react": "*",
-				"@types/wordpress__block-editor": "*",
-				"@types/wordpress__blocks": "*",
-				"@wordpress/components": "^28.3.0",
-				"@wordpress/core-data": "^7.3.0",
-				"@wordpress/data": "^10.3.0",
-				"@wordpress/element": "^6.3.0",
-				"@wordpress/media-utils": "^5.8.0"
-			}
-		},
 		"node_modules/@types/wordpress__shortcode": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/@types/wordpress__shortcode/-/wordpress__shortcode-2.3.6.tgz",
@@ -6955,9 +6938,9 @@
 			}
 		},
 		"node_modules/@wordpress/a11y": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.11.0.tgz",
-			"integrity": "sha512-gUrsmDvxuD8HXYmoND+niJw4Tk0qMDqMsOryzuQEymyO63o89DfoT1NBpJUk8P9P+xSCRHp5EoxaMUQ0Kiz81w==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.13.0.tgz",
+			"integrity": "sha512-ZCNhj8GDi6cOVm7L0vfwG5y7XPZONfRbb1KEsJjfgiLY9BnjmfpI5TAqYXcoXbm+Xkea84dQWw1J03EfkuSyIg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -7224,9 +7207,9 @@
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/keycodes": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.11.0.tgz",
-			"integrity": "sha512-aI8ftrEU62Y25p4881+d5zglPNOmWJJTokfC0eF4iW6DRnBy/btOMC6zIf+oATjG2pGTyMfHveALJf0YSpdyEw==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.13.0.tgz",
+			"integrity": "sha512-8py+qvvpd/RVDuIAMyPl4qLgES4Y8F9og8jpOlvL8s0Lj+41/WcvJEVMZKDS69tqhN3bi2M566kpIIFq/JbLBw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -7239,10 +7222,11 @@
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/warning": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.11.0.tgz",
-			"integrity": "sha512-tXCsxlMAYXbRCgZmVHsBkoBGnrytZPGGezGXANRTsyJ00QoQJgxvnH6u22Rs/NOIVHQ5o65/9jKC3g0e6qn7PA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.13.0.tgz",
+			"integrity": "sha512-e35ab+D1aE2zFOLd/f1zmjlHtVjVL31ayOszwRgK+XXv7jnhjW5KUjquAykKQbYnFlVLHC20h6p8IiNuSyzfUQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -7566,9 +7550,9 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/warning": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.11.0.tgz",
-			"integrity": "sha512-tXCsxlMAYXbRCgZmVHsBkoBGnrytZPGGezGXANRTsyJ00QoQJgxvnH6u22Rs/NOIVHQ5o65/9jKC3g0e6qn7PA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.13.0.tgz",
+			"integrity": "sha512-e35ab+D1aE2zFOLd/f1zmjlHtVjVL31ayOszwRgK+XXv7jnhjW5KUjquAykKQbYnFlVLHC20h6p8IiNuSyzfUQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7577,9 +7561,9 @@
 			}
 		},
 		"node_modules/@wordpress/date": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.11.0.tgz",
-			"integrity": "sha512-pDoTw1c3BTtgeG9xfIARTU6iCQ40Sksfaekhwz8EHPa9dgE1BU1ko4nb2VPTck6iQFggwfDlQcbg2Wf/ui8Kcw==",
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.13.0.tgz",
+			"integrity": "sha512-g72ZCtPA5g2cFlODUVXHhpRuk6qb+e5WnYFQqdQjgAthjAlw6xpOIjYlSCTCAg4yFSN9WGX/Jh8eoqYD45nZGA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -7610,9 +7594,9 @@
 			}
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.11.0.tgz",
-			"integrity": "sha512-CPXMS2IbGonba6Ny3IhzOudZ8QSCQzjg8AaS8dAq6p47AIUNxfj8bef+7C36lJKt9KPDkez7eY5x7UF5CaDkug==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.13.0.tgz",
+			"integrity": "sha512-wSDfGwRHzxcfpcUUlIHGQOIKYdGvTHbmVWIRf7dlPCRr5anpZTXsC/4ElDJFoi+w/gQklm//LrxjWP1Gqj8hmA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -7625,9 +7609,9 @@
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.11.0.tgz",
-			"integrity": "sha512-8u9USBEpGiQvVZeWSY82Ze3Yrwj5JkmmPUF+HfKvqywFlYIZfYLLc5lNrvUCqw7klIje+LO3MnKR3kfRx/uozA==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.13.0.tgz",
+			"integrity": "sha512-ucaz3Kh9L3EGpLiXXWqflC0T/1zMOe4DR31ynl+B68YSEWpM0VqTnRUFJRUFEc5wiOa70T8yFa3RLSwWpqJTIw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -7913,9 +7897,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.11.0.tgz",
-			"integrity": "sha512-TGiUoUpnPxNKCvpZzskIjtgPH8UhZAYTflbHTaA9IALBc1alq0SDdmMAfQ7qhnKer4CPU9+dSXv79q7olobeLQ==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.13.0.tgz",
+			"integrity": "sha512-wKPFlXD2d3K6ies4+btGcPB+p8lvgiMOVS3L0b1O+1s+cKUkgtq1aD0Q1pxQ2sLHXFIQjYWjVfTUvZrKE+6xPA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -8223,9 +8207,9 @@
 			}
 		},
 		"node_modules/@wordpress/fields/node_modules/@wordpress/warning": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.11.0.tgz",
-			"integrity": "sha512-tXCsxlMAYXbRCgZmVHsBkoBGnrytZPGGezGXANRTsyJ00QoQJgxvnH6u22Rs/NOIVHQ5o65/9jKC3g0e6qn7PA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.13.0.tgz",
+			"integrity": "sha512-e35ab+D1aE2zFOLd/f1zmjlHtVjVL31ayOszwRgK+XXv7jnhjW5KUjquAykKQbYnFlVLHC20h6p8IiNuSyzfUQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -8248,9 +8232,9 @@
 			}
 		},
 		"node_modules/@wordpress/html-entities": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.11.0.tgz",
-			"integrity": "sha512-OMpq/oP7CvfMojedgeI9unIAx0wuB8n10JwM72xi0CI/NYuymAcaOoD3OGkmS+4i6IW/geC3AooyWwRduzY85Q==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.13.0.tgz",
+			"integrity": "sha512-8213NNZdsyPHaYawu8v9xOKfIpX8vfThZ7uBHqeZKHg/DqPrK2jlX89EnI8s+V8cwBj1qHc6Xf78mKGW2iqkuQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -8358,9 +8342,9 @@
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.11.0.tgz",
-			"integrity": "sha512-LWMFSHcsD/FecJytZP3uboNUkVyowUN4HtFz3rJkAjpcvgZV9S++4ALejzN9jegOWfD6KNKAyWc7FyV25WXPYw==",
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.13.0.tgz",
+			"integrity": "sha512-Z32eGYExzGq/dN4iSNCddCMQU8p1u6mYzyNXDCovw4JSEN3Fr3HvmGYQGRIlkuTrlE6okSqArAvXVKR+I8S5Qg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -8426,9 +8410,9 @@
 			}
 		},
 		"node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/keycodes": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.11.0.tgz",
-			"integrity": "sha512-aI8ftrEU62Y25p4881+d5zglPNOmWJJTokfC0eF4iW6DRnBy/btOMC6zIf+oATjG2pGTyMfHveALJf0YSpdyEw==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.13.0.tgz",
+			"integrity": "sha512-8py+qvvpd/RVDuIAMyPl4qLgES4Y8F9og8jpOlvL8s0Lj+41/WcvJEVMZKDS69tqhN3bi2M566kpIIFq/JbLBw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -8610,10 +8594,11 @@
 			}
 		},
 		"node_modules/@wordpress/patterns/node_modules/@wordpress/warning": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.11.0.tgz",
-			"integrity": "sha512-tXCsxlMAYXbRCgZmVHsBkoBGnrytZPGGezGXANRTsyJ00QoQJgxvnH6u22Rs/NOIVHQ5o65/9jKC3g0e6qn7PA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.13.0.tgz",
+			"integrity": "sha512-e35ab+D1aE2zFOLd/f1zmjlHtVjVL31ayOszwRgK+XXv7jnhjW5KUjquAykKQbYnFlVLHC20h6p8IiNuSyzfUQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -8703,9 +8688,9 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.11.0.tgz",
-			"integrity": "sha512-CoBXbh0mOSxcZtuzL7gK3RVumFx71DXQBfd3IkbRHuuVxa+2hI4KDuFyomSsbjQDshHsfuVrKUvuT3UGt6pdpQ==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.13.0.tgz",
+			"integrity": "sha512-iAMBTPUDq28pm+ObSk5C4fbA90V+35xnjJoThlHIKJYSSllwJV8mlqQGzNTDNynj+S1EPsr6wK8Zyb9W77h1iQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -8736,9 +8721,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.11.0.tgz",
-			"integrity": "sha512-ohTXVFf+a5t585qivy1XWfu0JDoloB/t19mJpFAcLGw1zw6wWs4upYyOsiJ8skSL+mbHCWpSWWZjGre/LcD0Ew==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.13.0.tgz",
+			"integrity": "sha512-HGGWMFWIobfkhJdS+WYmmkSJ0m5beQ9x/2DUoQxxd/zISLMD7qQyRn016s/spapoT2fBLjtoQBWyfX2v0q+odA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -8839,19 +8824,20 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/warning": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.11.0.tgz",
-			"integrity": "sha512-tXCsxlMAYXbRCgZmVHsBkoBGnrytZPGGezGXANRTsyJ00QoQJgxvnH6u22Rs/NOIVHQ5o65/9jKC3g0e6qn7PA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.13.0.tgz",
+			"integrity": "sha512-e35ab+D1aE2zFOLd/f1zmjlHtVjVL31ayOszwRgK+XXv7jnhjW5KUjquAykKQbYnFlVLHC20h6p8IiNuSyzfUQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.11.0.tgz",
-			"integrity": "sha512-xrTvJ6H9UOnH+aA4QzeSQKV+rQS9RD87y1XoLZxrynDxLjsNO95PVhopfs0qIGNLr8wFhMtb0LQ+KXkxqA7fDw==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.13.0.tgz",
+			"integrity": "sha512-MZmW48WB9U5mcFGgARuaeDv2Hl53RGpSBL+r0ekB75B/QrbfmT7Kx2jQ0BGYUP+FptELNACMvAQfnW9DPqTfLA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -9447,10 +9433,11 @@
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/warning": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.11.0.tgz",
-			"integrity": "sha512-tXCsxlMAYXbRCgZmVHsBkoBGnrytZPGGezGXANRTsyJ00QoQJgxvnH6u22Rs/NOIVHQ5o65/9jKC3g0e6qn7PA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.13.0.tgz",
+			"integrity": "sha512-e35ab+D1aE2zFOLd/f1zmjlHtVjVL31ayOszwRgK+XXv7jnhjW5KUjquAykKQbYnFlVLHC20h6p8IiNuSyzfUQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -9679,10 +9666,11 @@
 			}
 		},
 		"node_modules/@wordpress/widgets/node_modules/@wordpress/warning": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.11.0.tgz",
-			"integrity": "sha512-tXCsxlMAYXbRCgZmVHsBkoBGnrytZPGGezGXANRTsyJ00QoQJgxvnH6u22Rs/NOIVHQ5o65/9jKC3g0e6qn7PA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.13.0.tgz",
+			"integrity": "sha512-e35ab+D1aE2zFOLd/f1zmjlHtVjVL31ayOszwRgK+XXv7jnhjW5KUjquAykKQbYnFlVLHC20h6p8IiNuSyzfUQ==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -13150,9 +13138,9 @@
 			}
 		},
 		"node_modules/docker-compose/node_modules/yaml": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-			"integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+			"integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -14321,9 +14309,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint/node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14648,9 +14636,9 @@
 			}
 		},
 		"node_modules/execa/node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -26809,9 +26797,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-			"integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
 			"license": "0BSD"
 		},
@@ -27702,9 +27690,9 @@
 			}
 		},
 		"node_modules/webpack-cli/node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
 		"@types/wordpress__block-editor": "^11.5.15",
 		"@types/wordpress__blocks": "^12.5.15",
 		"@types/wordpress__edit-post": "^8.4.1",
-		"@types/wordpress__editor": "^14.3.1",
 		"@types/wordpress__wordcount": "^2.4.5",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",
 		"@wordpress/api-fetch": "^7.13.0",

--- a/src/content-helper/editor-sidebar/excerpt-suggestions/component-panel.tsx
+++ b/src/content-helper/editor-sidebar/excerpt-suggestions/component-panel.tsx
@@ -20,7 +20,6 @@ import { ToneProp } from '../../common/components/tone-selector';
 /**
  * Internal dependencies
  */
-import { GutenbergFunction } from '../../../@types/gutenberg/types';
 import { Telemetry } from '../../../js/telemetry/telemetry';
 import {
 	ContentHelperError,
@@ -97,7 +96,7 @@ export const PostExcerptSuggestions = ( {
 
 	// Get the current excerpt, post content, and post title.
 	const { excerpt, postContent, postTitle } = useSelect( ( select ) => {
-		const { getEditedPostAttribute, getEditedPostContent } = select( editorStore ) as GutenbergFunction;
+		const { getEditedPostAttribute, getEditedPostContent } = select( editorStore );
 
 		let content = getEditedPostContent();
 		if ( ! content ) {


### PR DESCRIPTION
## Description
The `@types/wordpress__editor` package is now [deprecated](https://www.npmjs.com/package/@types/wordpress__editor) and we're removing it in this PR. With this done, we also don't need `as GutenbergFunction` when using `select( editorStore )`.

This PR also cleans-up after the latest component updates, by running `npm dedupe` a couple of times.

## Motivation and context
Remove unneeded code.

## How has this been tested?
Builds succeed and automated testing keeps passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved user interaction in the excerpt suggestions feature with enhanced event handling.
	- Added a loading animation component for better user feedback during processing.

- **Bug Fixes**
	- Refined error handling in the excerpt generation process for clearer management of different error types.

- **Refactor**
	- Simplified return value types and method signatures in the excerpt suggestions component for better code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->