### PR TITLE
Simplify check in admin_bar_parsely_stats_button()

### DIFF
--- a/src/UI/class-admin-bar.php
+++ b/src/UI/class-admin-bar.php
@@ -60,20 +60,23 @@ final class Admin_Bar {
 	}
 
 	/**
-	 * Adds the `Parse.ly Stats` button on the admin bar when the current object
+	 * Adds the "Parse.ly Stats" button on the admin bar when the current object
 	 * is a post or a page.
 	 *
 	 * @param WP_Admin_Bar $admin_bar WP_Admin_Bar instance, passed by reference.
 	 */
 	public function admin_bar_parsely_stats_button( WP_Admin_Bar $admin_bar ): void {
 		/**
-		 * Variable.
+		 * The result of calling get_queried_object().
 		 *
-		 * @var \WP_Term|\WP_Post_Type|WP_Post|\WP_User|null
+		 * Although it shouldn't return false per the documentation, it can
+		 * happen in practice.
+		 *
+		 * @var \WP_Term|\WP_Post_Type|WP_Post|\WP_User|null|false
 		 */
 		$queried_object = $GLOBALS['wp_the_query']->get_queried_object();
 
-		if ( ! $queried_object || ! ( $queried_object instanceof WP_Post ) ) {
+		if ( ! $queried_object instanceof WP_Post ) {
 			return;
 		}
 


### PR DESCRIPTION
## Description
With the code introduced in https://github.com/Parsely/wp-parsely/pull/3178, PHPStan started complaining with an `Only booleans are allowed in a negated boolean, WP_Post|WP_Post_Type|WP_Term|WP_User|null given` error.

Looking into it, it seems that we can further simplify the check as `instanceof` works with `null` values. Per the [docs](https://www.php.net/manual/en/language.operators.type.php), "instanceof does not throw any error if the variable being tested is not an object, it simply returns false".

@srtfisher: I'm confident this should work for you, but feel free to give it a test and get back to us if you want.

## Motivation and context
- Keep PHPStan happy while also simplifying our code.
- Related to #3178.

## How has this been tested?
Manually checked that the check was capturing `false` and `null` values, and that no fatals were being produced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This update includes behind‐the‐scenes enhancements that improve internal clarity and consistency, contributing to overall system robustness without altering visible features.

- **Documentation**
  - Refined internal commentary for improved clarity and precision.
  
- **Refactor**
  - Streamlined internal logic checks for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->