### PR TITLE
Move plugin Settings page under Parse.ly menu

### DIFF
--- a/src/UI/class-dashboard-page.php
+++ b/src/UI/class-dashboard-page.php
@@ -180,7 +180,7 @@ final class Dashboard_Page {
 			'Parse.ly Settings',
 			'Settings',
 			Parsely::CAPABILITY, // phpcs:ignore WordPress.WP.Capabilities.Undetermined
-			'parsely-dashboard-page#/settings',
+			Parsely::MENU_SLUG,
 			'__return_null'
 		);
 	}
@@ -261,7 +261,7 @@ final class Dashboard_Page {
 
 		if ( $this->parsely->site_id_is_set() ) {
 			wp_add_inline_script(
-				'parsely-dashboard-page', 
+				'parsely-dashboard-page',
 				'window.wpParselySiteId = ' . wp_json_encode( $this->parsely->get_site_id() ) . ';',
 				'before'
 			);

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -150,6 +150,8 @@ final class Settings_Page {
 	 */
 	public function run(): void {
 		add_action( 'admin_menu', array( $this, 'add_settings_sub_menu' ) );
+		// Show the plugin's settings page only under the Parse.ly menu.
+		add_action( 'admin_head', array( $this, 'remove_settings_sub_menu' ) );
 		add_action( 'admin_init', array( $this, 'initialize_settings' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_settings_assets' ) );
 	}
@@ -204,6 +206,16 @@ final class Settings_Page {
 			// Adds help text when admin page loads.
 			add_action( 'load-' . $this->hook_suffix, array( $this, 'add_help_text' ) );
 		}
+	}
+
+	/**
+	 * Removes the plugin's Settings page from the WordPress Settings menu,
+	 * while still keeping the page available through its slug/URL.
+	 *
+	 * @since 3.18.0
+	 */
+	public function remove_settings_sub_menu(): void {
+		remove_submenu_page( 'options-general.php', Parsely::MENU_SLUG );
 	}
 
 	/**

--- a/src/UI/class-site-health.php
+++ b/src/UI/class-site-health.php
@@ -84,7 +84,7 @@ final class Site_Health {
 			if ( $this->parsely->site_id_is_missing() ) {
 				$result['status']  = 'critical';
 				$result['label']   = __( 'You need to provide the Site ID', 'wp-parsely' );
-				$result['actions'] = __( 'The site ID can be set in the <a href="/wp-admin/options-general.php?page=parsely">Parse.ly Settings Page</a>.', 'wp-parsely' );
+				$result['actions'] = __( 'The site ID can be set in the <a href="/wp-admin/admin.php?page=parsely">Parse.ly Settings Page</a>.', 'wp-parsely' );
 			}
 
 			return $result;

--- a/src/content-helper/common/class-content-helper-feature.php
+++ b/src/content-helper/common/class-content-helper-feature.php
@@ -207,7 +207,7 @@ abstract class Content_Helper_Feature {
 					'Existing Parse.ly customers can enable this feature by setting their Site ID and API Secret in ',
 					'wp-parsely'
 				) . '
-				<a href="/wp-admin/options-general.php?page=parsely" target="_blank" rel="noopener">' .
+				<a href="/wp-admin/admin.php?page=parsely" target="_blank" rel="noopener">' .
 					__( 'wp-parsely options.', 'wp-parsely' ) . '
 				</a>
 			</p>


### PR DESCRIPTION
## Description
With this PR, we're moving the plugin's Settings page under the Parse.ly menu, removing the Parse.ly page from the Settings menu.

The settings page is still accessible using its URL and slug. In other words, trying to access `/wp-admin/options-general.php?page=parsely` will still work. Although we could try to block this, I don't think we need to. @vaurdan, let me know if you have a different opinion.

The remaining issue to tackle is that success/error messages don't show in the page under its new home.

## Motivation and context
Keep all things Parse.ly in a single place.

## How has this been tested?
Manual testing, existing tests pass.

## Screenshots
| Parse.ly Menu | General Menu |
|--------|--------|
| <img width="402" alt="image" src="https://github.com/user-attachments/assets/ccf48367-8ce4-4af8-b16a-6fe56ea1a54c" /> | <img width="402" alt="image" src="https://github.com/user-attachments/assets/f1e671c2-6560-4cc2-b592-2045667ea7ae" /> |