### PR TITLE
Add "wp-parsely" label to all GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+labels: wp-parsely, bug
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+labels: wp-parsely
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,3 @@
+---
+labels: wp-parsely
+---

--- a/.github/ISSUE_TEMPLATE/release-template-new.md
+++ b/.github/ISSUE_TEMPLATE/release-template-new.md
@@ -2,7 +2,7 @@
 name: Release template [NEW]
 about: Internally used for new releases
 title: Release wp-parsely x.y.z
-labels: 'Type: Maintenance'
+labels: wp-parsely, 'Type: Maintenance'
 ---
 
 This is an issue for tracking the next `wp-parsely` release. This ticket is to be opened the week before the actual release, so we have enough time to complete all the related tasks.

--- a/.github/ISSUE_TEMPLATE/release-template.md
+++ b/.github/ISSUE_TEMPLATE/release-template.md
@@ -2,8 +2,7 @@
 name: Release template
 about: Internally used for new releases
 title: Release wp-parsely x.y.z
-labels: 'Type: Maintenance'
-
+labels: wp-parsely, 'Type: Maintenance'
 ---
 
 This is an issue for tracking the next `wp-parsely` release. This ticket is to be opened the week before the actual release, so we have enough time to complete all the related tasks.


### PR DESCRIPTION
## Description
This PR adds the "wp-parsely" label to all our issue templates, to make the label get auto-included on newly opened issues.

## Motivation and context
We need that label for internal management purposes, so auto-including it should reduce toil and prevent us from forgetting it.

## How has this been tested?
After merging this PR, we will verify that new issues auto-include the label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the reporting experience by adding improved categorization fields to bug reports, feature requests, and release notes, streamlining how issues and updates are organized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->