### PR TITLE
Attempt to fix GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: wp-parsely, bug
+labels: "wp-parsely, bug"
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,5 +1,5 @@
 ---
-Name: Blank issue
+name: Blank issue
 about: For anything that isn't a feature request or bug report
 labels: wp-parsely
 ---

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,3 +1,9 @@
 ---
+Name: Blank issue
+about: For anything that isn't a feature request or bug report
 labels: wp-parsely
 ---
+
+<!--
+Hello! If this is a feature request or a bug report, please use the respective issue templates. Thank you!
+-->

--- a/.github/ISSUE_TEMPLATE/release-template-new.md
+++ b/.github/ISSUE_TEMPLATE/release-template-new.md
@@ -2,7 +2,7 @@
 name: Release template [NEW]
 about: Internally used for new releases
 title: Release wp-parsely x.y.z
-labels: wp-parsely, 'Type: Maintenance'
+labels: "wp-parsely, Type: Maintenance"
 ---
 
 This is an issue for tracking the next `wp-parsely` release. This ticket is to be opened the week before the actual release, so we have enough time to complete all the related tasks.

--- a/.github/ISSUE_TEMPLATE/release-template.md
+++ b/.github/ISSUE_TEMPLATE/release-template.md
@@ -2,7 +2,7 @@
 name: Release template
 about: Internally used for new releases
 title: Release wp-parsely x.y.z
-labels: wp-parsely, 'Type: Maintenance'
+labels: "wp-parsely, Type: Maintenance"
 ---
 
 This is an issue for tracking the next `wp-parsely` release. This ticket is to be opened the week before the actual release, so we have enough time to complete all the related tasks.


### PR DESCRIPTION
## Description
After merging https://github.com/Parsely/wp-parsely/pull/3217, some of our issue templates face issues. This PR is an attempt to fix this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Standardized label formatting across issue and release templates for consistency.
  - Added a new "Blank issue" template to help guide users when submitting issues that do not fall under bug reports or feature requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->