### PR TITLE
Make additional adjustments to GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_template.md
+++ b/.github/ISSUE_TEMPLATE/blank_template.md
@@ -1,0 +1,5 @@
+---
+name: Blank issue
+about: For anything that isn't a feature request or bug report
+labels: wp-parsely
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: "wp-parsely, bug"
+labels: "wp-parsely, Type: Bug"
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,9 +1,0 @@
----
-name: Blank issue
-about: For anything that isn't a feature request or bug report
-labels: wp-parsely
----
-
-<!--
-Hello! If this is a feature request or a bug report, please use the respective issue templates. Thank you!
--->


### PR DESCRIPTION
## Description
Continuing the work introduced on https://github.com/Parsely/wp-parsely/pull/3218, that should hopefully fix some final quirks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Blank issue" template for non-feature, non-bug submissions.
- **Chores**
  - Updated bug report labels for clearer categorization.
  - Added a setting to disable blank issue submissions.
  - Removed an outdated blank issue template to streamline the issue submission process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->