### PR TITLE
GitHub Workflows: Update Ubuntu to v24.04 LTS

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     name: Build and Commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   validate_version:
     name: Validate the new version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       current_version: ${{ steps.get_current_version.outputs.current_version }}
 
@@ -68,7 +68,7 @@ jobs:
   run_release_php_script:
     name: Bump the version and create the PR
     needs: validate_version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       CURRENT_VERSION: ${{ needs.validate_version.outputs.current_version }}
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   checkcs:
     name: 'Basic CS and QA checks'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     env:
       XMLLINT_INDENT: '	'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Check out the source code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ on: workflow_dispatch
 jobs:
   tag:
     name: New tag
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Build # Remove or modify this step as needed

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,6 +73,11 @@ jobs:
         with:
           composer-options: --ignore-platform-reqs
 
+      - name: Install Subversion
+        run: |
+          sudo apt-get update
+          sudo apt-get install subversion
+
       - name: Start MySQL Service
         run: sudo systemctl start mysql.service
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   test:
     name: PHP ${{ matrix.php }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     env:
       WP_VERSION: ${{ matrix.wp }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   validate_version:
     name: Validate Version and Branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Output Inputs
         run: |
@@ -121,7 +121,7 @@ jobs:
     name: Tag and Release
     needs: [ validate_version, integration_tests, e2e_tests ]
     if: ${{ !failure() && !cancelled() }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       tag_name: ${{ steps.tag.outputs.tag_name }}
     steps:
@@ -211,7 +211,7 @@ jobs:
     name: Deploy to WordPress.org
     needs: tag_and_release
     if: ${{ !failure() && !cancelled() }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Deploy Details
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test:
     name: PHP ${{ matrix.php }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     env:
       WP_VERSION: latest


### PR DESCRIPTION
## Description
I mistakenly thought GitHub Ubuntu v20.04 LTS runner images were being phased on in the end of April, but it turns out this is done today.

This PR updates all our runner images to Ubuntu 24.04. I also opted to substitute `ubuntu-latest` with `ubuntu-24.04` to have a specific version lock-in.

## Motivation and context
Some of our tests started failing, and I discovered that we need to update our runner images now.

## How has this been tested?
As a first step, all our testing workflows should pass. I expect this might impact our release workflows, which can be fixed in another PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated all GitHub Actions workflows to use the Ubuntu 24.04 runner environment.
	- Added a step to install Subversion (svn) in the integration tests workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->