### PR TITLE
Traffic Boost: Fix "Invalid page template" error

### DIFF
--- a/src/Models/class-inbound-smart-link.php
+++ b/src/Models/class-inbound-smart-link.php
@@ -15,6 +15,7 @@ use Parsely\Parsely;
 use Parsely\Utils\Utils;
 use ReflectionClass;
 use WP_Post;
+use WP_Error;
 
 /**
  * Model for Inbound Smart Link.
@@ -812,7 +813,7 @@ class Inbound_Smart_Link extends Smart_Link {
 			true
 		);
 
-		if ( is_wp_error( $updated_post ) ) {
+		if ( is_wp_error( $updated_post ) && ! $this->is_ignorable_update_error( $updated_post ) ) {
 			return $updated_post;
 		}
 
@@ -942,7 +943,7 @@ class Inbound_Smart_Link extends Smart_Link {
 			true
 		);
 
-		if ( is_wp_error( $updated_post ) ) {
+		if ( is_wp_error( $updated_post ) && ! $this->is_ignorable_update_error( $updated_post ) ) {
 			return $updated_post;
 		}
 
@@ -1279,5 +1280,28 @@ class Inbound_Smart_Link extends Smart_Link {
 		$text2 = html_entity_decode( $text2 );
 
 		return $text1 === $text2;
+	}
+
+	/**
+	 * Checks if a WP_Error from wp_update_post() is ignorable.
+	 *
+	 * @since 3.19.0
+	 *
+	 * @param WP_Error $error The error to check.
+	 * @return bool True if the error is ignorable, false otherwise.
+	 */
+	private function is_ignorable_update_error( WP_Error $error ): bool {
+		// The 'invalid_page_template' error can be returned from wp_update_post()
+		// if the saved page template is a custom type that no longer exists.
+		// This error is returned *after* the post has been updated with a new smart
+		// link, so we can safely ignore it.
+		//
+		// The post will use the 'default' page template if a custom type
+		// doesn't exist anyway.
+		if ( 'invalid_page_template' === $error->get_error_code() ) {
+			return true;
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
## Description

In testing, we encountered some "Invalid page template." errors followed by "Failed to accept suggestion. The current link is already linked to this smart link." when attempting to insert links in Traffic Boost:

![Screenshot 2025-04-25 at 10 35 21 AM](https://github.com/user-attachments/assets/0716a717-f475-41b6-82e7-65f123f94936)

This was caused by our posts and pages using an out-of-date page template. The error works like this:

1. Link insertion works all the way up until we want to [update the post with content](https://github.com/Parsely/wp-parsely/blob/d4d84d01cfa39936c3307984eee81003a975e8b1/src/Models/class-inbound-smart-link.php#L807-L813).
2. Deep down in WordPress code, [`wp_insert_page()`](https://github.com/WordPress/wordpress-develop/blob/d2f5e3bc7a5e5a68982eb02bd6400ca13e743a4e/src/wp-includes/post.php#L4986-L4992) checks the page_template value saved with the post.
3. In our test data, the `page_template` for the page we're inserting to is `wp-custom-template-single-post-page`.
4. Because that template is no longer registered with the theme, and we've passed [`$wp_error = true`](https://github.com/Parsely/wp-parsely/blob/d4d84d01cfa39936c3307984eee81003a975e8b1/src/Models/class-inbound-smart-link.php#L812), the page template mismatch is returned as an error.
4. However, the database update has already happened in `wp_insert_page()` to change the content with the proper link. 

In short, I think the root cause is data that uses posts with templates that no longer exist. When we attempt to update these pages, we get an error, and due to the way `wp_insert_page()` works, we also successfully insert the link at the same time.

To fix this, the PR specifically ignores the `invalid_page_template` error. The content is already updated, and there's nothing we can do about it at the point we receive the error anyhow.

## How has this been tested?

I've tested locally with the original data and confirmed that updates to a post with an invalid page template now work correctly.

If you'd like to try testing manually with other data:

1. In the `add/traffic-boost` branch (without this fix), generate Traffic Boost links for a post. Do not insert yet.
2. Find the post ID for one of the suggested posts to insert. Update the post's `_wp_page_template` post meta value to something invalid, e.g. `not-a-valid-page-template`.
3. Go back to the Traffic Boost UI and attempt to insert a link into the post.
4. See the "Invalid page template" error. Check the post's content, and see that it was correctly updated.
5. Switch to this branch `fix/invalid-page-template-error`.
6. Find a new post ID to insert, and update the `_wp_page_template` to an invalid value.
7. Try the insertion again. See it work.
