### PR TITLE
Fix corrupt Traffic Boost option when upgrading

### DIFF
--- a/src/class-parsely.php
+++ b/src/class-parsely.php
@@ -555,16 +555,37 @@ class Parsely {
 		 */
 		$options = get_option( self::OPTIONS_KEY, null );
 
-		// @phpstan-ignore isset.offset, booleanAnd.alwaysFalse
+		// Existing plugin installation without full metadata option.
+		/* @phpstan-ignore isset.offset, booleanAnd.alwaysFalse */
 		if ( is_array( $options ) && ! isset( $options['full_metadata_in_non_posts'] ) ) {
-			// Existing plugin installation without full metadata option.
 			$this->set_default_full_metadata_in_non_posts();
 		}
 
-		// @phpstan-ignore isset.offset, booleanAnd.alwaysFalse
+		// Existing plugin installation without Content Helper options.
+		/* @phpstan-ignore isset.offset, booleanAnd.alwaysFalse */
 		if ( is_array( $options ) && ! isset( $options['content_helper'] ) ) {
-			// Existing plugin installation without Content Helper options.
 			$this->set_default_content_helper_settings_values();
+		}
+
+		// Existing plugin installation that's missing a Content Helper feature option.
+		/* @phpstan-ignore isset.offset */
+		if ( is_array( $options ) && isset( $options['content_helper'] ) ) {
+			/** @var array<string,Parsely_Options_Content_Helper_Feature> $pch_options */
+			$pch_options = $options['content_helper'];
+
+			/** @var array<string,Parsely_Options_Content_Helper_Feature> $pch_options_defaults */
+			$pch_options_defaults = $this->option_defaults['content_helper'];
+
+			if ( count( $pch_options ) !== count( $pch_options_defaults ) ) {
+				$new_keys = array_diff(
+					array_keys( $pch_options_defaults ),
+					array_keys( $pch_options )
+				);
+
+				foreach ( $new_keys as $key ) {
+					$options['content_helper'][ $key ] = $pch_options_defaults[ $key ];
+				}
+			}
 		}
 
 		// New plugin installation that hasn't saved its options yet.

--- a/tests/Integration/OptionsTest.php
+++ b/tests/Integration/OptionsTest.php
@@ -56,6 +56,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_default_options_are_returned_when_options_are_corrupted_or_not_set(): void {
 		add_option( Parsely::OPTIONS_KEY, 'someinvalidvalue' );
@@ -80,6 +82,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_get_options_returns_correct_track_as_defaults(): void {
 		$options = self::$parsely->get_options();
@@ -101,6 +105,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_set_default_track_as_values_should_not_be_called_when_saved_options_exist(): void {
 		$options                     = self::$parsely->get_options();
@@ -128,6 +134,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_managed_credentials
 	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_get_options_track_as_defaults_when_cpts_are_registered(): void {
 		$custom_post_types = array(
@@ -206,6 +214,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_get_options_returns_correct_full_metadata_in_non_posts_default_value(): void {
 		$options = self::$parsely->get_options();
@@ -226,6 +236,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_set_default_full_metadata_in_non_posts_values_should_not_be_called_when_saved_options_exist(): void {
 		$option_key             = 'full_metadata_in_non_posts';
@@ -258,6 +270,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::sanitize_managed_option
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_set_default_full_metadata_in_non_posts_returns_expected_values(): void {
 		$option_key      = 'full_metadata_in_non_posts';
@@ -295,6 +309,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_managed_credentials
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_set_default_full_metadata_in_non_posts_returns_false_when_metadata_filters_are_used(): void {
 		$option_key = 'full_metadata_in_non_posts';
@@ -356,6 +372,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_managed_credentials
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_full_metadata_in_non_posts_gets_set_to_true_when_it_does_not_exist_in_options_array(): void {
 		$option_key = 'full_metadata_in_non_posts';
@@ -379,6 +397,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_managed_credentials
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_full_metadata_in_non_posts_gets_set_to_false_when_it_does_not_exist_in_options_array_and_a_metadata_filter_is_used(): void {
 		$option_key = 'full_metadata_in_non_posts';
@@ -404,6 +424,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::sanitize_managed_option
 	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 * @uses \Parsely\UI\Settings_Page::get_section_taxonomies
 	 */
 	public function test_set_managed_options_override_all_other_option_types(): void {
@@ -447,6 +469,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::sanitize_managed_option
 	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_null_managed_options_get_their_value_from_the_database_or_defaults(): void {
 		$default_options = self::$parsely->get_default_options();
@@ -490,6 +514,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::sanitize_managed_option
 	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_certain_options_cannot_be_set_as_managed(): void {
 		add_filter(
@@ -531,6 +557,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::get_managed_credentials
 	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 * @uses \Parsely\UI\Settings_Page::get_section_taxonomies
 	 *
 	 * @expectedIncorrectUsage sanitize_managed_option
@@ -575,6 +603,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
 	 * @uses \Parsely\Permissions::build_pch_permissions_settings_array
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_content_helper_options_in_a_new_plugin_install(): void {
 		delete_option( Parsely::OPTIONS_KEY );
@@ -612,6 +642,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_content_helper_options_in_existing_plugin_install_first_run(): void {
 		$options = ( new Parsely() )->get_options();
@@ -647,6 +679,8 @@ final class OptionsTest extends TestCase {
 	 * @uses \Parsely\Parsely::set_default_track_as_values
 	 * @uses \Parsely\Parsely::set_managed_options
 	 * @uses \Parsely\Permissions::build_pch_permissions_settings_array
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
 	 */
 	public function test_content_helper_options_in_existing_plugin_install_subsequent_runs(): void {
 		$options  = ( new Parsely() )->get_options();
@@ -656,6 +690,45 @@ final class OptionsTest extends TestCase {
 		);
 
 		$options['content_helper'] = $expected;
+		add_option( Parsely::OPTIONS_KEY, $options );
+
+		self::assertSame(
+			$expected,
+			( new Parsely() )->get_options()['content_helper']
+		);
+	}
+
+	/**
+	 * Verifies that Content Helper options are as expected when we have an
+	 * existing plugin installation with a missing Content Helper feature
+	 * option.
+	 *
+	 * In this case, the feature option should be added from default options to
+	 * the current options array.
+	 *
+	 * @since 3.19.0
+	 *
+	 * @covers \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::__construct
+	 * @uses \Parsely\Parsely::allow_parsely_remote_requests
+	 * @uses \Parsely\Parsely::are_credentials_managed
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
+	 * @uses \Parsely\Parsely::set_default_track_as_values
+	 * @uses \Parsely\Parsely::set_managed_options
+	 * @uses \Parsely\Permissions::build_pch_permissions_settings_array
+	 * @uses \Parsely\Services\Content_API\Content_API_Service::get_base_url
+	 * @uses \Parsely\Services\Suggestions_API\Suggestions_API_Service::get_base_url
+	 */
+	public function test_content_helper_options_in_existing_plugin_install_missing_feature_option(): void {
+		$options  = ( new Parsely() )->get_options();
+		$expected = Permissions::build_pch_permissions_settings_array(
+			true,
+			array( 'administrator' )
+		);
+
+		$options['content_helper'] = $expected;
+		unset( $options['content_helper']['traffic_boost'] );
 		add_option( Parsely::OPTIONS_KEY, $options );
 
 		self::assertSame(


### PR DESCRIPTION
## Description
Upgrading from v3.18 (or earlier) to our Traffic Boost branch was resulting in a corrupt TB option within the plugin's settings. The effect was that the feature's `Enabled` checkbox would be checked, but all user roles checkboxes would be unchecked. The expected behavior in this case was to have the `Administrator` checkbox checked.

This PR fixes the issue. When a PCH feature doesn't exist in the current options, it now gets added from the default options array.

Also, while working on`tests/Integration/OptionsTest.php`, I added 2 new `@uses` which allow the file to pass the `composer coveragewp` command.

## Motivation and context
Prevent a faulty behavior that could result in many undesirable side-effects.

## How has this been tested?
- Tested the upgrade flow manually.
- An integration test was written for this, and the test was ran with and without the fix. Commenting line 586 in `src/class-parsely.php` will make the test fail, as the feature option will be corrupt.

## Screenshots
| After upgrade before the fix | After upgrade after the fix |
|--------|--------|
| <img width="644" alt="image" src="https://github.com/user-attachments/assets/d46fc6f6-2ee0-442c-9995-a3ffec29686a" /> | <img width="644" alt="image" src="https://github.com/user-attachments/assets/6814825e-81ab-435b-8f76-084065a5cdea" /> | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of plugin options to ensure all expected Content Helper feature options are present for existing installations.

- **Tests**
  - Added a new test to verify that missing Content Helper feature options are automatically restored to default values for existing plugin installations.
  - Expanded test coverage annotations for related services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->