### PR TITLE
Do not return Traffic Boost sample settings

### DIFF
--- a/src/UI/class-dashboard-page.php
+++ b/src/UI/class-dashboard-page.php
@@ -3,7 +3,7 @@
  * UI: Dashboard page class
  *
  * @package Parsely
- * @since   3.18.0
+ * @since   3.19.0
  */
 
 declare(strict_types=1);

--- a/src/rest-api/content-helper/class-endpoint-traffic-boost.php
+++ b/src/rest-api/content-helper/class-endpoint-traffic-boost.php
@@ -4,7 +4,7 @@
  * Parse.ly Content Helper `/traffic-boost` API endpoint class
  *
  * @package Parsely
- * @since   3.18.0
+ * @since   3.19.0
  */
 
 declare(strict_types=1);

--- a/src/rest-api/settings/class-endpoint-traffic-boost-settings.php
+++ b/src/rest-api/settings/class-endpoint-traffic-boost-settings.php
@@ -3,7 +3,7 @@
  * API Endpoint: Traffic Boost Settings
  *
  * @package Parsely
- * @since   3.18.0
+ * @since   3.19.0
  */
 
 declare(strict_types=1);
@@ -48,11 +48,6 @@ class Endpoint_Traffic_Boost_Settings extends Base_Settings_Endpoint {
 	 * @return array<string, Subvalue_Spec>
 	 */
 	protected function get_subvalues_specs(): array {
-		return array(
-			'Setting1' => array(
-				'values'  => array(),
-				'default' => 'Hello World!',
-			),
-		);
+		return array();
 	}
 }

--- a/src/services/suggestions-api/endpoints/class-endpoint-suggest-inbound-link-positions.php
+++ b/src/services/suggestions-api/endpoints/class-endpoint-suggest-inbound-link-positions.php
@@ -3,7 +3,7 @@
  * Parse.ly Suggestions API Endpoint: Suggest Inbound Link Positions
  *
  * @package Parsely
- * @since   3.18.0
+ * @since   3.19.0
  */
 
 declare(strict_types=1);

--- a/src/services/suggestions-api/endpoints/class-endpoint-suggest-inbound-links.php
+++ b/src/services/suggestions-api/endpoints/class-endpoint-suggest-inbound-links.php
@@ -3,7 +3,7 @@
  * Parse.ly Suggestions API Endpoint: Suggest Inbound Links
  *
  * @package Parsely
- * @since   3.18.0
+ * @since   3.19.0
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
## Description
When we first introduced the Parse.ly Dashboard page, we also created the basic machinery for passing settings from the plugin to that page, similarly to what we do for other parts of the PCH, such as the Dashboard Widget or the Post Editor Sidebar.

When we implemented that, we passed some dummy settings as a proof of concept. However, as we approach release we shouldn't do that, so we're just removing the settings in question, while keeping the system so it can be used when needed.

While working on that, I also noticed some incorrect `@since`s, so I fixed those as well (although admittedly I should have done this in another PR).

## Motivation and context
Don't send junk settings to the Parse.ly Dashboard page.

## How has this been tested?
Manually tested the Parse.ly Dashboard page for any errors after the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated version annotations in documentation from 3.18.0 to 3.19.0 across multiple components.
- **Bug Fixes**
  - Adjusted settings to return an empty array by default in one configuration area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->