### PR TITLE
Fix traffic boost suggestion cache refresh

### DIFF
--- a/src/Models/class-inbound-smart-link.php
+++ b/src/Models/class-inbound-smart-link.php
@@ -1098,7 +1098,7 @@ class Inbound_Smart_Link extends Smart_Link {
 
 		$query = new \WP_Query( $args );
 
-		wp_cache_set( $cache_key, $query->found_posts, PARSELY_CACHE_GROUP, MONTH_IN_SECONDS );
+		wp_cache_set( $cache_key, $query->found_posts, PARSELY_CACHE_GROUP, DAY_IN_SECONDS );
 
 		return $query->found_posts;
 	}

--- a/src/Models/class-smart-link.php
+++ b/src/Models/class-smart-link.php
@@ -222,7 +222,7 @@ class Smart_Link extends Base_Model {
 				$cache_key,
 				$smart_links->posts[0],
 				PARSELY_CACHE_GROUP,
-				MONTH_IN_SECONDS
+				WEEK_IN_SECONDS
 			);
 			return $smart_links->posts[0];
 		}
@@ -361,7 +361,7 @@ class Smart_Link extends Base_Model {
 				self::get_uid_to_smart_link_cache_key( $this->uid ),
 				$post_id,
 				PARSELY_CACHE_GROUP,
-				MONTH_IN_SECONDS
+				WEEK_IN_SECONDS
 			);
 		}
 
@@ -961,7 +961,7 @@ class Smart_Link extends Base_Model {
 
 			// Cache the queried IDs.
 			$smart_link_ids = $smart_links_query->posts;
-			wp_cache_set( $cache_key, $smart_link_ids, $cache_group, MONTH_IN_SECONDS );
+			wp_cache_set( $cache_key, $smart_link_ids, $cache_group, DAY_IN_SECONDS );
 		}
 
 		// Create and process the smart links.
@@ -1163,7 +1163,7 @@ class Smart_Link extends Base_Model {
 			'outbound' => $outbound_links->found_posts,
 		);
 
-		wp_cache_set( $cache_key, $link_counts, $cache_group, MONTH_IN_SECONDS );
+		wp_cache_set( $cache_key, $link_counts, $cache_group, WEEK_IN_SECONDS );
 
 		return $link_counts;
 	}

--- a/src/Models/class-smart-link.php
+++ b/src/Models/class-smart-link.php
@@ -1258,7 +1258,7 @@ class Smart_Link extends Base_Model {
 	protected static function flush_cache_by_post_id( int $post_id ): void {
 		$cache_group = self::get_smart_links_post_cache_group( $post_id );
 
-		if ( function_exists( 'wp_cache_flush_group' ) ) {
+		if ( function_exists( 'wp_cache_flush_group' ) && wp_cache_supports( 'flush_group' ) ) {
 			wp_cache_flush_group( $cache_group );
 		} else {
 			$statuses = Smart_Link_Status::get_all_statuses();


### PR DESCRIPTION
## Description

This fixes a regression introduced by the caching changes in https://github.com/Parsely/wp-parsely/pull/3293#issuecomment-2867660240 that caused generated suggestions to improperly save due to a cache emptying error.

In short, we were using the `wp_cache_flush_group()` function without the proper checks, which resulted in a stale cache value for suggestions. A more in-depth explanation is below.

### Generating suggestions flow (new post)

Here's how a request runs to generate suggestions:

1. User clicks "Boost Traffic" button on a new post.
2. The browser calls into the `traffic-boost/<post-id>/get-suggestions` endpoint to determine if suggestions already exist:

    1. This calls into the [`get_existing_suggestions()`](https://github.com/Parsely/wp-parsely/blob/94667bd8a66fa6cc221ff8d7ec9c724102386afd/src/rest-api/content-helper/class-endpoint-traffic-boost.php#L554) REST handler.

    1. This goes into `Inbound_Smart_Link::get_existing_suggestions()`, which eventually calls down into [`Smart_Link::get_smart_links()`](https://github.com/Parsely/wp-parsely/blob/94667bd8a66fa6cc221ff8d7ec9c724102386afd/src/Models/class-smart-link.php#L891).
    1. No cache currently exists for the new post, so the code [queries for pending smart links](https://github.com/Parsely/wp-parsely/blob/94667bd8a66fa6cc221ff8d7ec9c724102386afd/src/Models/class-smart-link.php#L962) and [saves the result to cache](https://github.com/Parsely/wp-parsely/blob/94667bd8a66fa6cc221ff8d7ec9c724102386afd/src/Models/class-smart-link.php#L966). As this is a new post, there are no pending links, so an empty array `[]` is saved to cache.

3. Because there are no existing suggestions, the browser makes a call to `traffic-boost/<post-id>/generate`:

    1. This calls into the [`generate_link_suggestions()`](https://wpvip-com.wpvip.vipdev.lndo.site/wp-json/wp-parsely/v2/content-helper/traffic-boost/91587/generate?_locale=user) REST handler.

    2. After [generating new suggestions](https://github.com/Parsely/wp-parsely/blob/94667bd8a66fa6cc221ff8d7ec9c724102386afd/src/rest-api/content-helper/class-endpoint-traffic-boost.php#L364-L371), the code [calls into `Inbound_Smart_Link::delete_pending_suggestions()`](https://github.com/Parsely/wp-parsely/blob/94667bd8a66fa6cc221ff8d7ec9c724102386afd/src/rest-api/content-helper/class-endpoint-traffic-boost.php#L380-L382), because `$discard_previous` is [`true` by default](https://github.com/Parsely/wp-parsely/blob/94667bd8a66fa6cc221ff8d7ec9c724102386afd/src/rest-api/content-helper/class-endpoint-traffic-boost.php#L108).
    3. `delete_pending_suggestions()` then deletes any existing pending links (of which there are none) and [calls `self::flush_cache_by_post_id()`](https://github.com/Parsely/wp-parsely/blob/94667bd8a66fa6cc221ff8d7ec9c724102386afd/src/Models/class-inbound-smart-link.php#L1167).
    4. Finally, `flush_cache_by_post_id()` [calls `wp_cache_flush_group()`](https://github.com/Parsely/wp-parsely/blob/94667bd8a66fa6cc221ff8d7ec9c724102386afd/src/Models/class-smart-link.php#L1263-L1264) on the group cache for the post, which should clear out any existing cached data.

### The bug

The final step is where the bug happens. Looking at the documentation for `wp_cache_flush_group()`, there's also [this important caveat](https://developer.wordpress.org/reference/functions/wp_cache_flush_group/):

> Before calling this function, always check for group flushing support using the `wp_cache_supports( 'flush_group' )` function.

Our code was not doing this step properly, and even though the `wp_cache_flush_group()` function exists, `wp_cache_supports( 'flush_group' )` returns `false` on WPVIP. Note that the prior code [was correctly using this check](https://github.com/Parsely/wp-parsely/commit/6389c74cd3a0801f65b358ca33dec31f378f92f6#diff-8d88aea3ac2808a072a7fc86be31d2c8811ad4b1fc2feec908aefcd72dfcf83cL1223), and this bug was introduced during the caching refactor.

In step 2.3, the code saves an empty array to the post's suggestion cache, and step 3.4 doesn't actually clear that cache. In subsequent requests, `get-suggestions` has a cached value of `[]` which is returned. When the cache is properly cleared on step 3.4, the next `get-suggestions` request will make a new query and correctly return all of the existing suggestions.

By properly clearing out cached post values one at a time, we bypass the caching issue and fix the bug.

### Other changes

I reduced the `wp_cache_set()` times from a maximum of `MONTH_IN_SECONDS` to `WEEK_IN_SECONDS` or `DAY_IN_SECONDS`. This isn't strictly necessary, but I think a month of cache time is probably too long in retrospect for most of these queries. Shorter cache times also means that cache-related bugs will clear up quicker.

## How has this been tested?

This has been tested locally, and by pushing to a sandbox environment and ensuring caching works. To test locally, use this branch and clear your existing cache:

```
vip dev-env exec -- wp cache flush
```

Alternatively, to test on a production or child environment on VIP, use this command:

```
vip @<side-id>.<environment> -- wp cache flush
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Reduced cache expiration times for smart link data, resulting in more frequent updates.
	- Improved cache flushing reliability by adding an additional capability check before clearing cache groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->