### PR TITLE
Fix reference to Pendo class

### DIFF
--- a/src/Telemetry/telemetry-init.php
+++ b/src/Telemetry/telemetry-init.php
@@ -67,10 +67,10 @@ add_action(
 
 // Attempt to enable the Pendo JavaScript library. It's up to the Pendo class to
 // decide whether the library will be enabled.
-if ( class_exists( 'Automattic\VIP\Telemetry\Pendo' ) ) {
+if ( class_exists( '\Automattic\VIP\Telemetry\Pendo' ) ) {
 	add_action(
 		'admin_init',
 		// @phpstan-ignore argument.type
-		array( Automattic\VIP\Telemetry\Pendo::class, 'enable_javascript_library' )
+		array( \Automattic\VIP\Telemetry\Pendo::class, 'enable_javascript_library' )
 	);
 }


### PR DESCRIPTION
## Description
With this PR, we're porting a fix (originally posted [here](https://github.com/Automattic/remote-data-blocks/pull/553/files)) for the reference to our Pendo class.

## Motivation and context
Both more context and the original fix are [here](https://github.com/Automattic/remote-data-blocks/pull/553).

## How has this been tested?
We expect @LauraKalnicky and @smithjw1 to test the integration to see if this is all we need.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of telemetry functionality by correcting class references for better namespace handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->