### PR TITLE
Update minimum WordPress version to 6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Parse.ly
 
 Stable tag: 3.18.1  
-Requires at least: 5.2  
+Requires at least: 6.0  
 Tested up to: 6.8  
 Requires PHP: 7.2  
 License: GPLv2 or later  

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -19,7 +19,7 @@
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * GitHub Plugin URI: https://github.com/Parsely/wp-parsely
  * Requires PHP:      7.2
- * Requires WP:       5.0.0
+ * Requires WP:       6.0.0
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
## Description
With this PR, we're bumping the minimum required WordPress version to 6.0.0. This version was selected as:
- It should not have any adverse side-effects on our customer environments.
- For the sake of precaution, it allows us to have some additional leeway.

Our goal is to bump this value to 6.3.0 as soon as we can, based on our findings in #2133.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the minimum required WordPress version to 6.0 in plugin information and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->