### PR TITLE
Hide Traffic Boost submenu when API Secret is not set

### DIFF
--- a/src/UI/class-dashboard-page.php
+++ b/src/UI/class-dashboard-page.php
@@ -142,7 +142,8 @@ final class Dashboard_Page {
 	 * @since 3.19.0
 	 */
 	public function add_dashboard_page_to_menu(): void {
-		$show_traffic_boost_submenu = Permissions::current_user_can_use_pch_feature(
+		$show_traffic_boost_submenu = $this->parsely->api_secret_is_set() &&
+		Permissions::current_user_can_use_pch_feature(
 			'traffic_boost',
 			$this->parsely->get_options()['content_helper']
 		);
@@ -194,7 +195,8 @@ final class Dashboard_Page {
 		);
 
 		/**
-		 * Settings submenu is registered in add_settings_sub_menu() at src/UI/class-settings-page.php.
+		 * Settings submenu is registered in add_settings_sub_menu() at
+		 * src/UI/class-settings-page.php.
 		 *
 		 * @see Settings_Page::add_settings_sub_menu()
 		 */


### PR DESCRIPTION
## Description
We're updating the Traffic Boost submenu behavior to not be shown when the API Secret isn't set in the plugin's options.

## Motivation and context
This follows the hide/show convention we use in other PCH tools, such as the Dashboard Widget and Posts screen stats.

## How has this been tested?
Manually tested by removing and re-adding the API Secret and refreshing the page with and without this code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- The "Traffic Boost" submenu in the dashboard will now only be displayed if the Parsely API secret is configured and the user has the appropriate permissions.
- **Style**
	- Improved readability of comments in the dashboard menu code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->