### PR TITLE
Allow Traffic Boost features that rely on Smart Linking taxonomies to work when Smart Linking is disabled

### DIFF
--- a/src/content-helper/editor-sidebar/smart-linking/class-smart-linking.php
+++ b/src/content-helper/editor-sidebar/smart-linking/class-smart-linking.php
@@ -65,10 +65,6 @@ class Smart_Linking extends Editor_Sidebar_Feature {
 	 * @since 3.16.0
 	 */
 	public function run(): void {
-		if ( ! $this->can_enable_feature() ) {
-			return;
-		}
-
 		// Register private custom post type for the Smart Links.
 		$this->register_post_type();
 


### PR DESCRIPTION
## Description

Currently, if the "Smart Linking" feature is disabled in settings, Traffic Boost link planting fails. To replicate:

1. Go to WordPress Admin -> Parse.ly -> "Traffic Boost (beta)" and turn off Smart Linking. Click "Save Changes".

    ![Screenshot 2025-05-19 at 10 34 08 AM](https://github.com/user-attachments/assets/2899e570-6083-40fa-8867-4c8a3451b9a0)

2. Go to the "Traffic Boost (beta)" page, then click the "Boost Traffic" button on a post. When a suggestion is available, click the "Accept" button on the right side of the page.

3. See a error that says `Failed to accept suggestion. Source post not found`:

    ![Screenshot 2025-05-19 at 10 33 28 AM](https://github.com/user-attachments/assets/f2e2ad86-7983-4aba-bb95-dd6ae7f87ae5)

## The problem

The issue here is that when the Smart Linking feature is disabled, the code that registers the custom post type and taxonomies associated with Smart Links doesn't run. The error shown in the UI `Source post not found` comes from this part of code, run when initializing Traffic Boost links:

https://github.com/Parsely/wp-parsely/blob/ac3445e23b5f8e5432ed30f8f3ad94b5f67a63fa/src/Models/class-smart-link.php#L277-L282

The `smart_link_source` taxonomy is not registered, due to Smart Linking being disabled, so the `wp_get_post_terms()` call returns a `WP_Error` with a "Invalid taxonomy" code.

We also can see a cache issue when loading an existing post in Traffic Boost when Smart Linking is off. Because we rely on the [`parsely_smart_link` post type when querying](https://github.com/Parsely/wp-parsely/blob/fe2e45ad5496953e0694db2d3de59807a2618321/src/Models/class-smart-link.php#L951), and this post type doesn't exist with Smart Linking disabled, the links in cache are not properly returned and the cache is missed.

## The fix

The fix is to still register the Smart Linking-related taxonomies and post type even when the feature is disabled, because we rely on the internals of Smart Links for other features and queries like Traffic Boost. Even though we're still registering some data types, we're still properly only showing the PCH sidebar when Smart Linking is off:

*Smart Linking enabled:*

![Screenshot 2025-05-19 at 10 27 51 AM](https://github.com/user-attachments/assets/83a4ec22-e83f-4a0b-abaa-48b49ea970aa)

---

*Smart Linking disabled:*

![Screenshot 2025-05-19 at 10 28 14 AM](https://github.com/user-attachments/assets/f8e2c471-a284-46c0-8f9a-be7294e1f7a8)

## How has this been tested?

I verified this locally with these steps:

1. Disable "Smart Linking" in Parse.ly settings.
2. Go to Traffic Boost and accept a link suggestion. Ensure it does not return an error.
3. Go to the source post for the suggestion and ensure a link was properly inserted.
4. Go to a post and verify that the "Smart Linking" dropdown is not available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the initialization behavior for Smart Links so that related features are always registered, regardless of previous conditional checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->