### PR TITLE
Make some caching checks more flexible

### DIFF
--- a/src/Models/class-inbound-smart-link.php
+++ b/src/Models/class-inbound-smart-link.php
@@ -1069,7 +1069,7 @@ class Inbound_Smart_Link extends Smart_Link {
 		$cache_key = self::get_suggestions_count_cache_key( $post_id );
 		$count     = wp_cache_get( $cache_key, PARSELY_CACHE_GROUP );
 
-		if ( is_numeric( $count ) ) {
+		if ( false !== $count && is_numeric( $count ) ) {
 			return (int) $count;
 		}
 

--- a/src/Models/class-inbound-smart-link.php
+++ b/src/Models/class-inbound-smart-link.php
@@ -1069,9 +1069,8 @@ class Inbound_Smart_Link extends Smart_Link {
 		$cache_key = self::get_suggestions_count_cache_key( $post_id );
 		$count     = wp_cache_get( $cache_key, PARSELY_CACHE_GROUP );
 
-		if ( false !== $count ) {
-			/** @var int $count */
-			return $count;
+		if ( is_numeric( $count ) ) {
+			return (int) $count;
 		}
 
 		$args = array(

--- a/src/Models/class-smart-link.php
+++ b/src/Models/class-smart-link.php
@@ -196,8 +196,9 @@ class Smart_Link extends Base_Model {
 	private function get_smart_link_object_by_uid( string $uid ): int {
 		$cache_key = self::get_uid_to_smart_link_cache_key( $uid );
 		$cached    = wp_cache_get( $cache_key, PARSELY_CACHE_GROUP );
-		if ( is_int( $cached ) && 0 !== $cached ) {
-			return $cached;
+
+		if ( is_numeric( $cached ) && 0 !== (int) $cached ) {
+			return (int) $cached;
 		}
 
 		$smart_links = new \WP_Query(
@@ -1097,8 +1098,7 @@ class Smart_Link extends Base_Model {
 		$cache_group = self::get_smart_links_post_cache_group( $post_id );
 		$link_counts = wp_cache_get( $cache_key, $cache_group );
 
-		if ( false !== $link_counts ) {
-			/** @var array<string,int> */
+		if ( is_array( $link_counts ) ) {
 			return $link_counts;
 		}
 

--- a/src/Models/class-smart-link.php
+++ b/src/Models/class-smart-link.php
@@ -197,7 +197,7 @@ class Smart_Link extends Base_Model {
 		$cache_key = self::get_uid_to_smart_link_cache_key( $uid );
 		$cached    = wp_cache_get( $cache_key, PARSELY_CACHE_GROUP );
 
-		if ( is_numeric( $cached ) && 0 !== (int) $cached ) {
+		if ( false !== $cached && is_numeric( $cached ) ) {
 			return (int) $cached;
 		}
 
@@ -1098,7 +1098,7 @@ class Smart_Link extends Base_Model {
 		$cache_group = self::get_smart_links_post_cache_group( $post_id );
 		$link_counts = wp_cache_get( $cache_key, $cache_group );
 
-		if ( is_array( $link_counts ) ) {
+		if ( false !== $link_counts && is_array( $link_counts ) ) {
 			return $link_counts;
 		}
 

--- a/src/Utils/class-utils.php
+++ b/src/Utils/class-utils.php
@@ -430,7 +430,7 @@ class Utils {
 		$cache_key = sprintf( 'url-to-postid-%s', hash( 'sha256', $url ) );
 		$cache     = wp_cache_get( $cache_key, PARSELY_CACHE_GROUP );
 
-		if ( is_numeric( $cache ) ) {
+		if ( false !== $cache && is_numeric( $cache ) ) {
 			return (int) $cache;
 		}
 

--- a/src/Utils/class-utils.php
+++ b/src/Utils/class-utils.php
@@ -430,8 +430,8 @@ class Utils {
 		$cache_key = sprintf( 'url-to-postid-%s', hash( 'sha256', $url ) );
 		$cache     = wp_cache_get( $cache_key, PARSELY_CACHE_GROUP );
 
-		if ( is_integer( $cache ) ) {
-			return $cache;
+		if ( is_numeric( $cache ) ) {
+			return (int) $cache;
 		}
 
 		if ( function_exists( 'wpcom_vip_url_to_postid' ) ) {


### PR DESCRIPTION
## Description
In issue #3350 we got a report of a type error, which seems to be due to the way we perform our checks after using `wp_cache_get()`.

This PR makes our checks more flexible, accommodating for the possibility of numeric strings when a number is expected. We're also casting the returned value to int when the function is expected to return an integer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache validation to ensure only appropriate numeric or array values are used, reducing the risk of invalid cached data affecting app behavior.
  - Enhanced type checking and value casting for cached data, resulting in more reliable and consistent handling of cached information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->