### PR TITLE
bootstrap.php: Add PARSELY_DATA_SCHEMA_VERSION constant

### DIFF
--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -51,7 +51,8 @@ namespace Parsely\Tests\Integration {
 // constants here.
 // phpcs:ignore Universal.Namespaces.DisallowCurlyBraceSyntax.Forbidden, Universal.Namespaces.OneDeclarationPerFile.MultipleFound
 namespace Parsely {
-	const PARSELY_VERSION     = '123456.78.9';
-	const PARSELY_FILE        = __DIR__ . '/../../wp-parsely.php';
-	const PARSELY_CACHE_GROUP = 'wp-parsely';
+	const PARSELY_VERSION             = '123456.78.9';
+	const PARSELY_FILE                = __DIR__ . '/../../wp-parsely.php';
+	const PARSELY_DATA_SCHEMA_VERSION = '1';
+	const PARSELY_CACHE_GROUP         = 'wp-parsely';
 }


### PR DESCRIPTION
## Description
With this PR, we're adding the `PARSELY_DATA_SCHEMA_VERSION` constant (found [here](https://github.com/Parsely/wp-parsely/blob/757889323b99f9ffac36291c8e2c3d3e4c6f5408/wp-parsely.php#L54)) to our integration tests `bootstrap.php` file. While this wasn't currently creating any side effects, it could in the future.

## How has this been tested?
Automated testing still passes after the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a new constant to the integration test setup for improved version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->