### PR TITLE
Fix update-version.sh

### DIFF
--- a/bin/update-version.sh
+++ b/bin/update-version.sh
@@ -11,8 +11,8 @@ set -e
 export LC_ALL=C
 
 if [ -z "$1" ]; then
-  echo "Error: You must specify a version number."
-  exit 1
+ echo "Error: You must specify a version number."
+ exit 1
 fi
 
 VERSION=$1
@@ -38,7 +38,7 @@ sed_inplace "s/Stable tag: .*  $/Stable tag: $VERSION  /" README.md
 sed_inplace "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" package.json
 sed_inplace "s/export const PLUGIN_VERSION = '.*'/export const PLUGIN_VERSION = '$VERSION'/" tests/e2e/utils.ts
 sed_inplace "s/ \* Version:           .*$/ \* Version:           $VERSION/" wp-parsely.php
-sed_inplace "s/const PARSELY_VERSION = '.*'/const PARSELY_VERSION = '$VERSION'/" wp-parsely.php
+sed_inplace "s/const PARSELY_VERSION             = '.*'/const PARSELY_VERSION             = '$VERSION'/" wp-parsely.php
 
 npm install --ignore-scripts # Update package-lock.json with the new version.
 

--- a/bin/update-version.sh
+++ b/bin/update-version.sh
@@ -11,8 +11,8 @@ set -e
 export LC_ALL=C
 
 if [ -z "$1" ]; then
- echo "Error: You must specify a version number."
- exit 1
+    echo "Error: You must specify a version number."
+    exit 1
 fi
 
 VERSION=$1


### PR DESCRIPTION
## Description
The addition of the `PARSELY_DATA_SCHEMA_VERSION` constant in `wp-parsely.php` line 54, introduced additional spaces on line 52.

This caused our release workflow to stop updating the version number on line 52, requiring [manual intervention](https://github.com/Parsely/wp-parsely/pull/3346/commits/44499445507013bf626ad5766d76480957d95b52) during the release process.

This PR fixes the issue.

## Motivation and context
Prevent our workflow from breaking.

## How has this been tested?
Locally tested that line 52 correctly updates after the fix by directly running the `update-version.sh` script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the accuracy of version update handling to better match the formatting of the target line. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->