### PR TITLE
Shell scripts: Use tabs for indentation

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -20,11 +20,11 @@ WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 
 download() {
-    if [ `which curl` ]; then
-        curl -s "$1" > "$2";
-    elif [ `which wget` ]; then
-        wget -nv -O "$2" "$1"
-    fi
+	if [ `which curl` ]; then
+		curl -s "$1" > "$2";
+	elif [ `which wget` ]; then
+		wget -nv -O "$2" "$1"
+	fi
 }
 
 if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
@@ -75,7 +75,7 @@ install_wp() {
 			rm -rf $TMPDIR/wordpress-nightly;
 		fi
 		mkdir -p $TMPDIR/wordpress-nightly
-		download https://wordpress.org/nightly-builds/wordpress-latest.zip  $TMPDIR/wordpress-nightly/wordpress-nightly.zip
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip $TMPDIR/wordpress-nightly/wordpress-nightly.zip
 		unzip -q $TMPDIR/wordpress-nightly/wordpress-nightly.zip -d $TMPDIR/wordpress-nightly/
 		mv $TMPDIR/wordpress-nightly/wordpress/* $WP_CORE_DIR
 	else
@@ -100,7 +100,7 @@ install_wp() {
 		else
 			local ARCHIVE_NAME="wordpress-$WP_VERSION"
 		fi
-		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz $TMPDIR/wordpress.tar.gz
 		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
 

--- a/bin/update-version.sh
+++ b/bin/update-version.sh
@@ -11,8 +11,8 @@ set -e
 export LC_ALL=C
 
 if [ -z "$1" ]; then
-    echo "Error: You must specify a version number."
-    exit 1
+	echo "Error: You must specify a version number."
+	exit 1
 fi
 
 VERSION=$1
@@ -21,16 +21,16 @@ git checkout -b update/wp-parsely-version-to-$VERSION
 
 # Function to perform in-place sed substitution.
 sed_inplace() {
-    local expression="$1"
-    local file="$2"
+	local expression="$1"
+	local file="$2"
 
-    if [[ "$(uname)" == "Darwin" ]]; then
-        # MacOS/BSD sed.
-        sed -i '' -e "$expression" "$file"
-    else
-        # GNU sed (Linux).
-        sed -i -e "$expression" "$file"
-    fi
+	if [[ "$(uname)" == "Darwin" ]]; then
+		# MacOS/BSD sed.
+		sed -i '' -e "$expression" "$file"
+	else
+		# GNU sed (Linux).
+		sed -i -e "$expression" "$file"
+	fi
 }
 
 # Update version in files.


### PR DESCRIPTION
## Description
We had a mix of tabs and spaces in our shell scripts. This PR converts everything to tabs.

## Motivation and context
Consistent way of indenting our shell scripts.

## How has this been tested?
- No functionality changes.
- Manually checked that `install-wp-tests.sh` still downloads WordPress after removing the extra space in lines 78 and 103.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved indentation and formatting in installation and version update scripts for better readability. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->