### PR TITLE
Add content API url filter

### DIFF
--- a/src/rest-api/stats/class-endpoint-posts.php
+++ b/src/rest-api/stats/class-endpoint-posts.php
@@ -326,14 +326,16 @@ class Endpoint_Posts extends Base_Endpoint {
 			$params['urls'] = $new_urls;
 		}
 
-		/**
-		 * Allow adjustments to post URLs before request. Useful for testing non-local URLs, or mirroring site content.
-		 *
-		 * @since 3.19.1
-		 *
-		 * @param array<string>|null $urls The URLs to be used in the request.
-		 */
-		$params['urls'] = apply_filters( 'wp_parsely_stats_posts_urls', $params['urls'] ?? null );
+		if ( isset( $params['urls'] ) && is_array( $params['urls'] ) ) {
+			/**
+			 * Allow adjustments to post URLs before request. Useful for testing non-local URLs, or mirroring site content.
+			 *
+			 * @since 3.19.1
+			 *
+			 * @param array<string> $urls The URLs to be used in the request.
+			 */
+			$params['urls'] = apply_filters( 'wp_parsely_stats_posts_urls', $params['urls'] );
+		}
 
 		// Build the request params.
 		$request_params = array(

--- a/src/rest-api/stats/class-endpoint-posts.php
+++ b/src/rest-api/stats/class-endpoint-posts.php
@@ -326,6 +326,15 @@ class Endpoint_Posts extends Base_Endpoint {
 			$params['urls'] = $new_urls;
 		}
 
+		/**
+		 * Allow adjustments to post URLs before request. Useful for testing non-local URLs, or mirroring site content.
+		 *
+		 * @since 3.19.1
+		 *
+		 * @param array<string>|null $urls The URLs to be used in the request.
+		 */
+		$params['urls'] = apply_filters( 'wp_parsely_stats_posts_urls', $params['urls'] );
+
 		// Build the request params.
 		$request_params = array(
 			'period_start'   => $params['period_start'] ?? null,

--- a/src/rest-api/stats/class-endpoint-posts.php
+++ b/src/rest-api/stats/class-endpoint-posts.php
@@ -333,7 +333,7 @@ class Endpoint_Posts extends Base_Endpoint {
 		 *
 		 * @param array<string>|null $urls The URLs to be used in the request.
 		 */
-		$params['urls'] = apply_filters( 'wp_parsely_stats_posts_urls', $params['urls'] );
+		$params['urls'] = apply_filters( 'wp_parsely_stats_posts_urls', $params['urls'] ?? null );
 
 		// Build the request params.
 		$request_params = array(


### PR DESCRIPTION
## Description

This is a minor filter addition that gives us some useful capabilities when testing. We currently have some test sites that mirror live Parse.ly data from our other sites. In these circumstances, it can be useful to convert some not real local URLs to remote URLs that match our Parse.ly setup, like this:

```php
add_filter( 'wp_parsely_stats_posts_urls', function ( $urls ) {
    return array_map( function ( $url ) {
        return str_replace( 'https://my-local-site.go-vip.net/', 'https://the-real-site.com/', $url );
    }, $urls );
});
```

This filter adds a foothold so we can easily make those testing changes without editing plugin code.

## Motivation and context

This fixes a testing and deployment task we currently need to do when pushing changes to our test sites.

## How has this been tested?

Integration tests will cover that this does not cause any issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for external plugins and themes to customize the list of post URLs used in stats-related API requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->