### PR TITLE
add_parsely_preview_wrapper(): Allow mixed type values

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,7 +13,7 @@ parameters:
     - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
     - vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php
   type_coverage:
-      return_type: 87.7
+      return_type: 87.6
       param_type: 79.1
       property_type: 0 # We can't use property types until PHP 7.4 becomes the plugin's minimum version.
       print_suggestions: false

--- a/src/UI/class-dashboard-page.php
+++ b/src/UI/class-dashboard-page.php
@@ -119,12 +119,13 @@ final class Dashboard_Page {
 	 * @since 3.19.0
 	 *
 	 * @param mixed $content The post content.
-	 * @return mixed The modified content with wrapper div if needed.
+	 * @return mixed The modified content with wrapper div if needed, or the
+	 *               unmodified content value in case of a non-string.
 	 */
-	public function add_parsely_preview_wrapper( mixed $content ): mixed {
+	public function add_parsely_preview_wrapper( $content ) {
 		if ( ! is_string( $content ) ) {
-			// Workaround for possible `the_content` filter issues that can cause fatal type errors
-			// if a prior filter returns a non-string value like `null`. In this case, ignore the filter.
+			// $content should always be a string, but is filterable by `the_content`.
+			// If we get a non-string value, return it as is to avoid fatal errors.
 			return $content;
 		}
 

--- a/src/UI/class-dashboard-page.php
+++ b/src/UI/class-dashboard-page.php
@@ -118,10 +118,16 @@ final class Dashboard_Page {
 	 *
 	 * @since 3.19.0
 	 *
-	 * @param string $content The post content.
-	 * @return string The modified content with wrapper div if needed.
+	 * @param mixed $content The post content.
+	 * @return mixed The modified content with wrapper div if needed.
 	 */
-	public function add_parsely_preview_wrapper( string $content ): string {
+	public function add_parsely_preview_wrapper( mixed $content ): mixed {
+		if ( ! is_string( $content ) ) {
+			// Workaround for possible `the_content` filter issues that can cause fatal type errors
+			// if a prior filter returns a non-string value like `null`. In this case, ignore the filter.
+			return $content;
+		}
+
 		if ( ! isset( $_GET['parsely_preview'] ) || 'true' !== $_GET['parsely_preview'] ) {
 			return $content;
 		}


### PR DESCRIPTION
## Description

If a prior `the_content` filter returns a non-`string` value like `null`, our `add_parsely_preview_wrapper()` function will fatal with a PHP type error due to the requirement of `$content` to be a `string`.

This code modifies our filter code to accept a `mixed` value and verify that a string is present instead of using the PHP type system, which can only fail if expectations are unmet.

## Motivation and context

This solves a customer issue we've seen when a `the_content` filter returns a non-string value.

## How has this been tested?

An easy way to test this is by adding a `the_content` filter prior to ours that returns `null`. Add these lines before [line 55 in `src/UI/class-dashboard-page.php`](https://github.com/Parsely/wp-parsely/blob/42a47ca5eb3d8145c4aa96ffb80d305f66f4cd3a/src/UI/class-dashboard-page.php#L55):

```diff
public function run(): void {
    add_action( 'admin_menu', array( $this, 'add_dashboard_page_to_menu' ) );
    add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_dashboard_page_scripts' ) );
    add_filter( 'parent_file', array( $this, 'fix_submenu_highlighting' ) );
    add_action( 'wp_ajax_parsely_post_preview', array( $this, 'handle_preview_template' ) );

+   add_filter( 'the_content', function() { return null; } );
    add_filter( 'the_content', array( $this, 'add_parsely_preview_wrapper' ) );
}
```

On `develop`, this will show a fatal error on the Traffic Boost page:

![Screenshot 2025-05-28 at 4 24 06 PM](https://github.com/user-attachments/assets/c3a81656-c16c-4e8f-8c6d-ce5172fec61b)

On this branch (`fix/the-content-filter-typing`), it should ignore the invalid `the_content` value and load properly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved content handling to prevent errors when non-string values are processed, ensuring greater stability and compatibility with other plugins or filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->