### PR TITLE
Release wp-parsely 3.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.19.3](https://github.com/Parsely/wp-parsely/compare/3.19.2...3.19.3) - 2025-06-03
+
+### Dependency Updates
+
+- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.19.3+label%3ADeps).
+
 ## [3.19.2](https://github.com/Parsely/wp-parsely/compare/3.19.1...3.19.2) - 2025-05-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.19.2  
+Stable tag: 3.19.3  
 Requires at least: 6.0  
 Tested up to: 6.8  
 Requires PHP: 7.2  

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
 				"@wordpress/url": "^4.24.0",
 				"@wordpress/wordcount": "^4.24.0",
 				"concurrently": "^9.1.2",
-				"eslint-plugin-jest": "^28.11.1",
+				"eslint-plugin-jest": "^28.12.0",
 				"husky": "^9.1.7",
 				"lodash.debounce": "^4.0.8",
 				"prettier": "^3.5.3",
@@ -14074,9 +14074,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "28.11.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.11.1.tgz",
-			"integrity": "sha512-17+112oYbm56kt6ecFDoyi+keLpYblvVG+yze7/DbwsZGorfqaFg9UtgQpaAzJRvA2P64vifMo6WGn7gbj9LXg==",
+			"version": "28.12.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.12.0.tgz",
+			"integrity": "sha512-J6zmDp8WiQ9tyvYXE+3RFy7/+l4hraWLzmsabYXyehkmmDd36qV4VQFc7XzcsD8C1PTNt646MSx25bO1mdd9Yw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.19.2",
+	"version": "3.19.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.19.2",
+			"version": "3.19.3",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24921,9 +24921,9 @@
 			}
 		},
 		"node_modules/tar-fs": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-			"integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+			"integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"@wordpress/url": "^4.24.0",
 		"@wordpress/wordcount": "^4.24.0",
 		"concurrently": "^9.1.2",
-		"eslint-plugin-jest": "^28.11.1",
+		"eslint-plugin-jest": "^28.12.0",
 		"husky": "^9.1.7",
 		"lodash.debounce": "^4.0.8",
 		"prettier": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.19.2",
+	"version": "3.19.3",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/src/content-helper/dashboard-page/components/posts-table/component.tsx
+++ b/src/content-helper/dashboard-page/components/posts-table/component.tsx
@@ -31,7 +31,7 @@ import { SinglePostRow } from './components/single-post-row';
  *
  * @since 3.19.0
  *
- * @param {Object}   props                The component props.
+ * @param {Object}   props                The component's props.
  * @param {boolean}  props.isLoading      Whether the posts are loading.
  * @param {number}   props.currentPage    The current page.
  * @param {Function} props.setCurrentPage The function to set the current page.
@@ -113,7 +113,7 @@ type PostsTableType = {
  *
  * @since 3.19.0
  *
- * @param {PostsTableType} props The component props.
+ * @param {PostsTableType} props The component's props.
  */
 export const PostsTable = ( {
 	query = {},

--- a/src/content-helper/dashboard-page/components/posts-table/components/post-details.tsx
+++ b/src/content-helper/dashboard-page/components/posts-table/components/post-details.tsx
@@ -26,7 +26,7 @@ type PostDetailsProps = {
  *
  * @since 3.19.0
  *
- * @param {PostDetailsProps} props The component props.
+ * @param {PostDetailsProps} props The component's props.
  */
 export const PostDetails = ( { post }: PostDetailsProps ): React.JSX.Element => {
 	const prettyDate = post.date ? getSmartShortDate( new Date( post.date ) ) : '';

--- a/src/content-helper/dashboard-page/components/typography-components.tsx
+++ b/src/content-helper/dashboard-page/components/typography-components.tsx
@@ -22,7 +22,7 @@ export type DashboardHeadingProps = {
  *
  * @since 3.19.0
  *
- * @param {DashboardHeadingProps} props The component props.
+ * @param {DashboardHeadingProps} props The component's props.
  */
 export const DashboardHeading = ( { children, ...props }: DashboardHeadingProps ) => {
 	return (

--- a/src/content-helper/editor-sidebar/smart-linking/component-link-monitor.tsx
+++ b/src/content-helper/editor-sidebar/smart-linking/component-link-monitor.tsx
@@ -3,9 +3,9 @@
  */
 // eslint-disable-next-line import/named
 import { BlockInstance } from '@wordpress/blocks';
-import { useEffect, useRef } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 import { debounce } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -123,7 +123,7 @@ type LinkMonitorProps = {
  *
  * @since 3.16.0
  *
- * @param {LinkMonitorProps} props The component props.
+ * @param {LinkMonitorProps} props The component's props.
  */
 export const LinkMonitor = ( {
 	isDetectingEnabled,

--- a/src/content-helper/editor-sidebar/smart-linking/review-modal/component-block-preview.tsx
+++ b/src/content-helper/editor-sidebar/smart-linking/review-modal/component-block-preview.tsx
@@ -42,7 +42,7 @@ type StylesProps = {
  *
  * @since 3.16.0
  *
- * @param {StylesProps} props The component props.
+ * @param {StylesProps} props The component's props.
  */
 const Styles = ( { styles }: StylesProps ): React.JSX.Element => {
 	/**
@@ -146,7 +146,7 @@ type BlockPreviewProps = {
  *
  * @since 3.16.0
  *
- * @param {BlockPreviewProps} props The component props.
+ * @param {BlockPreviewProps} props The component's props.
  */
 export const BlockPreview = ( { block, link, useOriginalBlock }: BlockPreviewProps ) => {
 	/**

--- a/src/content-helper/editor-sidebar/smart-linking/review-modal/component-inbound-link.tsx
+++ b/src/content-helper/editor-sidebar/smart-linking/review-modal/component-inbound-link.tsx
@@ -3,7 +3,7 @@
  */
 // eslint-disable-next-line import/named
 import { BlockInstance, parse } from '@wordpress/blocks';
-import { __experimentalDivider as Divider, Button, KeyboardShortcuts, Tooltip } from '@wordpress/components';
+import { Button, __experimentalDivider as Divider, KeyboardShortcuts, Tooltip } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { arrowLeft, arrowRight, Icon, page } from '@wordpress/icons';
@@ -29,7 +29,7 @@ type ThreeDotsProps = {
  *
  * @since 3.16.0
  *
- * @param {ThreeDotsProps} props The component props.
+ * @param {ThreeDotsProps} props The component's props.
  */
 const ThreeDots: React.FC<ThreeDotsProps> = ( {
 	topOrBottom,
@@ -55,7 +55,7 @@ type LinkingPostDetailsProps = {
  *
  * @since 3.16.0
  *
- * @param {LinkingPostDetailsProps} props The component props.
+ * @param {LinkingPostDetailsProps} props The component's props.
  */
 const LinkingPostDetails = ( { link }: LinkingPostDetailsProps ): React.JSX.Element => {
 	return (
@@ -108,7 +108,7 @@ type InboundLinkDetailsProps = {
  *
  * @since 3.16.0
  *
- * @param {InboundLinkDetailsProps} props The component props.
+ * @param {InboundLinkDetailsProps} props The component's props.
  */
 export const InboundLinkDetails = ( {
 	link,

--- a/src/content-helper/editor-sidebar/smart-linking/review-modal/component-modal.tsx
+++ b/src/content-helper/editor-sidebar/smart-linking/review-modal/component-modal.tsx
@@ -36,7 +36,7 @@ export type SmartLinkingReviewModalProps = {
  *
  * @since 3.16.0
  *
- * @param {SmartLinkingReviewModalProps} props The component props.
+ * @param {SmartLinkingReviewModalProps} props The component's props.
  */
 const SmartLinkingReviewModalComponent = ( {
 	onClose,

--- a/src/content-helper/editor-sidebar/smart-linking/review-modal/component-sidebar.tsx
+++ b/src/content-helper/editor-sidebar/smart-linking/review-modal/component-sidebar.tsx
@@ -24,7 +24,7 @@ type ReviewModalSidebarProps = {
  *
  * @since 3.16.0
  *
- * @param {ReviewModalSidebarProps} props The component props.
+ * @param {ReviewModalSidebarProps} props The component's props.
  */
 export const ReviewModalSidebar = ( {
 	activeLink,

--- a/src/content-helper/editor-sidebar/smart-linking/review-modal/component-suggestion.tsx
+++ b/src/content-helper/editor-sidebar/smart-linking/review-modal/component-suggestion.tsx
@@ -54,7 +54,7 @@ type SuggestionBreadcrumbProps = {
  *
  * @since 3.16.0
  *
- * @param {SuggestionBreadcrumbProps} props The component props.
+ * @param {SuggestionBreadcrumbProps} props The component's props.
  */
 const SuggestionBreadcrumb = ( { link }: SuggestionBreadcrumbProps ): React.JSX.Element => {
 	const blockId = link.match?.blockId;
@@ -108,7 +108,7 @@ const SuggestionBreadcrumb = ( { link }: SuggestionBreadcrumbProps ): React.JSX.
  * @since 3.16.0
  * @since 3.18.0 Added the post type to the link details.
  *
- * @param {{link: SmartLink}} props The component props.
+ * @param {{link: SmartLink}} props The component's props.
  */
 const LinkDetails = ( { link }: { link: SmartLink } ): React.JSX.Element => {
 	const author = link.wp_post_meta?.author ?? __( 'N/A', 'wp-parsely' );
@@ -203,7 +203,7 @@ type ReviewSuggestionProps = {
  *
  * @since 3.16.0
  *
- * @param {ReviewSuggestionProps} props The component props.
+ * @param {ReviewSuggestionProps} props The component's props.
  */
 export const ReviewSuggestion = ( {
 	link,

--- a/src/content-helper/editor-sidebar/title-suggestions/component-settings.tsx
+++ b/src/content-helper/editor-sidebar/title-suggestions/component-settings.tsx
@@ -30,7 +30,7 @@ type TitleSuggestionsSettingsProps = {
  * @since 3.13.0
  * @since 3.14.0 Removed isOpen prop as the component is no longer collapsible.
  *
- * @param {TitleSuggestionsSettingsProps} props The component props.
+ * @param {TitleSuggestionsSettingsProps} props The component's props.
  */
 export const TitleSuggestionsSettings = ( {
 	isLoading,

--- a/src/rest-api/class-base-api-controller.php
+++ b/src/rest-api/class-base-api-controller.php
@@ -185,7 +185,7 @@ abstract class Base_API_Controller {
 	 *
 	 * @since 3.17.0
 	 *
-	 * @param string $endpoint The endpoint name/path.
+	 * @param string $endpoint The endpoint's name/path.
 	 * @return Base_Endpoint|null The endpoint object, or null if not found.
 	 */
 	protected function get_endpoint( string $endpoint ): ?Base_Endpoint {

--- a/src/rest-api/class-base-endpoint.php
+++ b/src/rest-api/class-base-endpoint.php
@@ -89,7 +89,7 @@ abstract class Base_Endpoint {
 	}
 
 	/**
-	 * Returns the endpoint name.
+	 * Returns the endpoint's name.
 	 *
 	 * This method should be overridden by child classes and used to return the
 	 * endpoint name.
@@ -186,7 +186,7 @@ abstract class Base_Endpoint {
 	/**
 	 * Returns the endpoint slug.
 	 *
-	 * The slug is the endpoint name prefixed with the route prefix, from
+	 * The slug is the endpoint's name prefixed with the route prefix, from
 	 * the API controller.
 	 *
 	 * Used as an identifier for the endpoint, when registering routes.

--- a/src/rest-api/content-helper/class-endpoint-check-auth.php
+++ b/src/rest-api/content-helper/class-endpoint-check-auth.php
@@ -52,7 +52,7 @@ class Endpoint_Check_Auth extends Base_Endpoint {
 	 *
 	 * @since 3.19.0
 	 *
-	 * @return string The endpoint name.
+	 * @return string The endpoint's name.
 	 */
 	public static function get_endpoint_name(): string {
 		return 'check-auth';

--- a/src/rest-api/content-helper/class-endpoint-excerpt-generator.php
+++ b/src/rest-api/content-helper/class-endpoint-excerpt-generator.php
@@ -53,7 +53,7 @@ class Endpoint_Excerpt_Generator extends Base_Endpoint {
 	 *
 	 * @since 3.17.0
 	 *
-	 * @return string The endpoint name.
+	 * @return string The endpoint's name.
 	 */
 	public static function get_endpoint_name(): string {
 		return 'excerpt-generator';
@@ -64,7 +64,7 @@ class Endpoint_Excerpt_Generator extends Base_Endpoint {
 	 *
 	 * @since 3.17.0
 	 *
-	 * @return string The feature name.
+	 * @return string The feature's name.
 	 */
 	public function get_pch_feature_name(): string {
 		return 'excerpt_suggestions';

--- a/src/rest-api/content-helper/class-endpoint-smart-linking.php
+++ b/src/rest-api/content-helper/class-endpoint-smart-linking.php
@@ -59,7 +59,7 @@ class Endpoint_Smart_Linking extends Base_Endpoint {
 	 *
 	 * @since 3.17.0
 	 *
-	 * @return string The endpoint name.
+	 * @return string The endpoint's name.
 	 */
 	public static function get_endpoint_name(): string {
 		return 'smart-linking';
@@ -70,7 +70,7 @@ class Endpoint_Smart_Linking extends Base_Endpoint {
 	 *
 	 * @since 3.17.0
 	 *
-	 * @return string The feature name.
+	 * @return string The feature's name.
 	 */
 	public function get_pch_feature_name(): string {
 		return 'smart_linking';

--- a/src/rest-api/content-helper/class-endpoint-title-suggestions.php
+++ b/src/rest-api/content-helper/class-endpoint-title-suggestions.php
@@ -53,7 +53,7 @@ class Endpoint_Title_Suggestions extends Base_Endpoint {
 	 *
 	 * @since 3.17.0
 	 *
-	 * @return string The endpoint name.
+	 * @return string The endpoint's name.
 	 */
 	public static function get_endpoint_name(): string {
 		return 'title-suggestions';

--- a/src/rest-api/content-helper/class-endpoint-traffic-boost.php
+++ b/src/rest-api/content-helper/class-endpoint-traffic-boost.php
@@ -58,7 +58,7 @@ class Endpoint_Traffic_Boost extends Base_Endpoint {
 	 *
 	 * @since 3.19.0
 	 *
-	 * @return string The endpoint name.
+	 * @return string The endpoint's name.
 	 */
 	public static function get_endpoint_name(): string {
 		return 'traffic-boost';
@@ -69,7 +69,7 @@ class Endpoint_Traffic_Boost extends Base_Endpoint {
 	 *
 	 * @since 3.19.0
 	 *
-	 * @return string The feature name.
+	 * @return string The feature's name.
 	 */
 	public function get_pch_feature_name(): string {
 		return 'traffic_boost';

--- a/src/rest-api/content-helper/trait-content-helper-feature.php
+++ b/src/rest-api/content-helper/trait-content-helper-feature.php
@@ -27,7 +27,7 @@ trait Content_Helper_Feature {
 	 *
 	 * @since 3.17.0
 	 *
-	 * @return string The feature name.
+	 * @return string The feature's name.
 	 */
 	abstract public function get_pch_feature_name(): string;
 

--- a/src/rest-api/settings/class-endpoint-dashboard-widget-settings.php
+++ b/src/rest-api/settings/class-endpoint-dashboard-widget-settings.php
@@ -19,7 +19,7 @@ namespace Parsely\REST_API\Settings;
  */
 class Endpoint_Dashboard_Widget_Settings extends Base_Settings_Endpoint {
 	/**
-	 * Returns the endpoint name.
+	 * Returns the endpoint's name.
 	 *
 	 * @since 3.17.0
 	 *

--- a/src/rest-api/settings/class-endpoint-editor-sidebar-settings.php
+++ b/src/rest-api/settings/class-endpoint-editor-sidebar-settings.php
@@ -19,7 +19,7 @@ namespace Parsely\REST_API\Settings;
  */
 class Endpoint_Editor_Sidebar_Settings extends Base_Settings_Endpoint {
 	/**
-	 * Returns the endpoint name.
+	 * Returns the endpoint's name.
 	 *
 	 * @since 3.17.0
 	 *

--- a/src/rest-api/stats/class-endpoint-post.php
+++ b/src/rest-api/stats/class-endpoint-post.php
@@ -83,11 +83,11 @@ class Endpoint_Post extends Base_Endpoint {
 	}
 
 	/**
-	 * Returns the endpoint name.
+	 * Returns the endpoint's name.
 	 *
 	 * @since 3.17.0
 	 *
-	 * @return string The endpoint name.
+	 * @return string The endpoint's name.
 	 */
 	public static function get_endpoint_name(): string {
 		return 'post';

--- a/src/rest-api/stats/class-endpoint-posts.php
+++ b/src/rest-api/stats/class-endpoint-posts.php
@@ -83,7 +83,7 @@ class Endpoint_Posts extends Base_Endpoint {
 	}
 
 	/**
-	 * Returns the endpoint name.
+	 * Returns the endpoint's name.
 	 *
 	 * @since 3.17.0
 	 *

--- a/src/rest-api/stats/class-endpoint-related.php
+++ b/src/rest-api/stats/class-endpoint-related.php
@@ -49,7 +49,7 @@ class Endpoint_Related extends Base_Endpoint {
 	}
 
 	/**
-	 * Returns the endpoint name.
+	 * Returns the endpoint's name.
 	 *
 	 * @since 3.17.0
 	 *

--- a/tests/Integration/RestAPI/BaseAPIControllerTest.php
+++ b/tests/Integration/RestAPI/BaseAPIControllerTest.php
@@ -244,11 +244,11 @@ class BaseAPIControllerTest extends TestCase {
 		// Create a mocked endpoint.
 		$endpoint = new class( $this->test_controller ) extends Base_Endpoint {
 			/**
-			 * Get the endpoint name.
+			 * Get the endpoint's name.
 			 *
 			 * @since 3.17.0
 			 *
-			 * @return string The endpoint name.
+			 * @return string The endpoint's name.
 			 */
 			public static function get_endpoint_name(): string {
 				return 'test-endpoint';

--- a/tests/Integration/RestAPI/BaseEndpointTest.php
+++ b/tests/Integration/RestAPI/BaseEndpointTest.php
@@ -114,7 +114,7 @@ class BaseEndpointTest extends TestCase {
 		$this->test_endpoint = new class($this->api_controller) extends Base_Endpoint {
 
 			/**
-			 * Gets the endpoint name.
+			 * Gets the endpoint's name.
 			 *
 			 * @since 3.17.0
 			 *

--- a/tests/Integration/Services/BaseAPIServiceTestCase.php
+++ b/tests/Integration/Services/BaseAPIServiceTestCase.php
@@ -38,7 +38,8 @@ abstract class BaseAPIServiceTestCase extends TestCase {
 	/**
 	 * Provides data for test_endpoint_is_registered().
 	 *
-	 * Should return an array of arrays, each containing the endpoint name and class.
+	 * Should return an array of arrays, each containing the endpoint's name and
+	 * class.
 	 *
 	 * @since 3.17.0
 	 *

--- a/tests/Integration/Services/ContentAPI/ContentApiServiceTestCase.php
+++ b/tests/Integration/Services/ContentAPI/ContentApiServiceTestCase.php
@@ -62,7 +62,7 @@ class ContentApiServiceTestCase extends BaseAPIServiceTestCase {
 	/**
 	 * Provides data for test_endpoint_is_registered().
 	 *
-	 * Should return an array of arrays, each containing the endpoint name and
+	 * Should return an array of arrays, each containing the endpoint's name and
 	 * class.
 	 *
 	 * @since 3.17.0
@@ -114,8 +114,8 @@ class ContentApiServiceTestCase extends BaseAPIServiceTestCase {
 	 * @covers \Parsely\Services\Base_API_Service::get_endpoint
 	 * @uses \Parsely\Services\Cached_Service_Endpoint::get_uncached_endpoint
 	 *
-	 * @param string       $endpoint The endpoint name to check.
-	 * @param class-string $class_name The endpoint class to check.
+	 * @param string       $endpoint The endpoint's name to check.
+	 * @param class-string $class_name The endpoint's expected class.
 	 */
 	public function test_endpoint_is_registered( string $endpoint, string $class_name ): void {
 		// Check that the endpoint exists and is an instance of the expected class.

--- a/tests/Integration/Services/SuggestionsAPI/SuggestionsApiServiceTestCase.php
+++ b/tests/Integration/Services/SuggestionsAPI/SuggestionsApiServiceTestCase.php
@@ -59,7 +59,7 @@ class SuggestionsApiServiceTestCase extends BaseAPIServiceTestCase {
 	/**
 	 * Provides data for test_endpoint_is_registered().
 	 *
-	 * Should return an array of arrays, each containing the endpoint name and
+	 * Should return an array of arrays, each containing the endpoint's name and
 	 * class.
 	 *
 	 * @since 3.17.0
@@ -103,8 +103,8 @@ class SuggestionsApiServiceTestCase extends BaseAPIServiceTestCase {
 	 * @dataProvider data_registered_endpoints
 	 * @covers \Parsely\Services\Base_API_Service::get_endpoint
 	 *
-	 * @param string       $endpoint The endpoint name to check.
-	 * @param class-string $class_name The endpoint class to check.
+	 * @param string       $endpoint The endpoint's name to check.
+	 * @param class-string $class_name The endpoint's expected class.
 	 */
 	public function test_endpoint_is_registered( string $endpoint, string $class_name ): void {
 		// Check that the endpoint exists and is an instance of the expected class.

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import { type Page } from '@playwright/test';
  */
 import { Admin } from '@wordpress/e2e-test-utils-playwright';
 
-export const PLUGIN_VERSION = '3.19.2';
+export const PLUGIN_VERSION = '3.19.3';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.19.2
+ * Version:           3.19.3
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -49,7 +49,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION             = '3.19.2';
+const PARSELY_VERSION             = '3.19.3';
 const PARSELY_FILE                = __FILE__;
 const PARSELY_DATA_SCHEMA_VERSION = '1';
 const PARSELY_CACHE_GROUP         = 'wp-parsely';


### PR DESCRIPTION
This PR merges the `develop` branch into the `trunk` branch in order to release wp-parsely 3.19.3.