### PR TITLE
Update "Stable tag" to "3.20.2", fix README whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change feature name from "Traffic Boost" to "Engagement Boost" ([#3482](https://github.com/Parsely/wp-parsely/pull/3482))
 
-
 ## [3.20.1](https://github.com/Parsely/wp-parsely/compare/3.20.0...3.20.1) - 2025-06-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Parse.ly
 
-Stable tag: 3.20.1
-Requires at least: 6.0
-Tested up to: 6.8
-Requires PHP: 7.4
-License: GPLv2 or later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
-Tags: analytics, statistics, stats, content marketing, parsely, parsley, parse.ly
+Stable tag: 3.20.2  
+Requires at least: 6.0  
+Tested up to: 6.8  
+Requires PHP: 7.4  
+License: GPLv2 or later  
+License URI: https://www.gnu.org/licenses/gpl-2.0.html  
+Tags: analytics, statistics, stats, content marketing, parsely, parsley, parse.ly  
 Contributors: parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan
 
 The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.


### PR DESCRIPTION
## Description

Related to the recent release PRs #3485, #3484, #3483, #3482. I made a change in README.md which automatically removed some trailing spaces. These appear to be consequential trailing spaces, so I've re-added them and manually updated the "Stable Version" to `3.20.2`.

I also saw an error related to the two newlines in `CHANGELOG.md`, not sure where that came from, but also removed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to improve formatting and reflect the renaming of "Traffic Boost" to "Engagement Boost."
  - Updated the stable version tag in the documentation to 3.20.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->