### PR TITLE
Release wp-parsely 3.20.2 with correct README version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change feature name from "Traffic Boost" to "Engagement Boost" ([#3482](https://github.com/Parsely/wp-parsely/pull/3482))
 
-
 ## [3.20.1](https://github.com/Parsely/wp-parsely/compare/3.20.0...3.20.1) - 2025-06-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Parse.ly
 
-Stable tag: 3.20.1
-Requires at least: 6.0
-Tested up to: 6.8
-Requires PHP: 7.4
-License: GPLv2 or later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
-Tags: analytics, statistics, stats, content marketing, parsely, parsley, parse.ly
+Stable tag: 3.20.2  
+Requires at least: 6.0  
+Tested up to: 6.8  
+Requires PHP: 7.4  
+License: GPLv2 or later  
+License URI: https://www.gnu.org/licenses/gpl-2.0.html  
+Tags: analytics, statistics, stats, content marketing, parsely, parsley, parse.ly  
 Contributors: parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan
 
 The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.


### PR DESCRIPTION
This PR merges the `develop` branch into the `trunk` branch in order to release wp-parsely 3.20.2. Fixes a README metadata mistake added in https://github.com/Parsely/wp-parsely/pull/3485.