### PR TITLE
Update "Content Helper" to "Content Intelligence" on settings page

### DIFF
--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -438,7 +438,7 @@ final class Settings_Page {
 
 		add_settings_section(
 			$section_key,
-			__( 'Content Helper', 'wp-parsely' ),
+			__( 'Content Intelligence', 'wp-parsely' ),
 			'__return_null',
 			Parsely::MENU_SLUG
 		);

--- a/tests/e2e/specs/activation-flow.spec.ts
+++ b/tests/e2e/specs/activation-flow.spec.ts
@@ -57,7 +57,7 @@ test.describe( 'Activation flow', (): void => {
 		// Initialize locators.
 		const basicTab = page.getByRole( 'link', { name: 'Basic' } );
 		const basicSection = page.locator( '.basic-section' );
-		const contentHelperTab = page.getByRole( 'link', { name: 'Content Helper' } );
+		const contentHelperTab = page.getByRole( 'link', { name: 'Content Intelligence' } );
 		const contentHelperSection = page.locator( '.content-helper-section' );
 		const recrawlTab = page.getByRole( 'link', { name: 'Recrawl' } );
 		const recrawlSection = page.locator( '.recrawl-section' );


### PR DESCRIPTION
## Description

Update the "Content Helper" tab on the settings page to "Content Intelligence":

![Screenshot 2025-06-25 at 10 52 01 AM](https://github.com/user-attachments/assets/b0121f8a-7fe2-47b5-b033-1409e315f275)

## Motivation and context

Clarified terminology.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the settings section label from "Content Helper" to "Content Intelligence" for improved clarity.

- **Tests**
  - Adjusted end-to-end tests to reflect the updated label in the settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->