### PR TITLE
Release wp-parsely 3.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.20.3](https://github.com/Parsely/wp-parsely/compare/3.20.2...3.20.3) - 2025-06-25
+
+### Fixed
+
+- Update "Stable tag" to "3.20.2", fix README whitespace ([#3486](https://github.com/Parsely/wp-parsely/pull/3486))
+
+
 ## [3.20.2](https://github.com/Parsely/wp-parsely/compare/3.20.1...3.20.2) - 2025-06-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.20.3](https://github.com/Parsely/wp-parsely/compare/3.20.2...3.20.3) - 2025-06-25
 
+### Changed
+
+- Update "Content Helper" to "Content Intelligence" on settings page ([#3489](github.com/Parsely/wp-parsely/pull/3489))
+
 ### Fixed
 
 - Update "Stable tag" to "3.20.2", fix README whitespace ([#3486](https://github.com/Parsely/wp-parsely/pull/3486))
-
 
 ## [3.20.2](https://github.com/Parsely/wp-parsely/compare/3.20.1...3.20.2) - 2025-06-24
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.20.2  
+Stable tag: 3.20.3  
 Requires at least: 6.0  
 Tested up to: 6.8  
 Requires PHP: 7.4  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.20.2",
+	"version": "3.20.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.20.2",
+			"version": "3.20.3",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.20.2",
+	"version": "3.20.3",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -438,7 +438,7 @@ final class Settings_Page {
 
 		add_settings_section(
 			$section_key,
-			__( 'Content Helper', 'wp-parsely' ),
+			__( 'Content Intelligence', 'wp-parsely' ),
 			'__return_null',
 			Parsely::MENU_SLUG
 		);

--- a/tests/e2e/specs/activation-flow.spec.ts
+++ b/tests/e2e/specs/activation-flow.spec.ts
@@ -57,7 +57,7 @@ test.describe( 'Activation flow', (): void => {
 		// Initialize locators.
 		const basicTab = page.getByRole( 'link', { name: 'Basic' } );
 		const basicSection = page.locator( '.basic-section' );
-		const contentHelperTab = page.getByRole( 'link', { name: 'Content Helper' } );
+		const contentHelperTab = page.getByRole( 'link', { name: 'Content Intelligence' } );
 		const contentHelperSection = page.locator( '.content-helper-section' );
 		const recrawlTab = page.getByRole( 'link', { name: 'Recrawl' } );
 		const recrawlSection = page.locator( '.recrawl-section' );

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import { type Page } from '@playwright/test';
  */
 import { Admin } from '@wordpress/e2e-test-utils-playwright';
 
-export const PLUGIN_VERSION = '3.20.2';
+export const PLUGIN_VERSION = '3.20.3';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.20.2
+ * Version:           3.20.3
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -49,7 +49,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION             = '3.20.2';
+const PARSELY_VERSION             = '3.20.3';
 const PARSELY_FILE                = __FILE__;
 const PARSELY_DATA_SCHEMA_VERSION = '1';
 const PARSELY_CACHE_GROUP         = 'wp-parsely';


### PR DESCRIPTION
This PR merges the `develop` branch into the `trunk` branch in order to release wp-parsely 3.20.3.