### PR TITLE
Release wp-parsely 3.20.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.20.6](https://github.com/Parsely/wp-parsely/compare/3.20.5...3.20.6) - 2025-07-22
+
+### Dependency Updates
+
+- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.20.6+label%3ADeps).
+
 ## [3.20.5](https://github.com/Parsely/wp-parsely/compare/3.20.4...3.20.5) - 2025-07-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.20.5  
+Stable tag: 3.20.6  
 Requires at least: 6.0  
 Tested up to: 6.8  
 Requires PHP: 7.4  

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"@types/lodash.debounce": "^4.0.9",
 				"@types/react-router": "^5.1.20",
 				"@types/wordpress__block-editor": "^11.5.17",
-				"@types/wordpress__blocks": "^12.5.17",
+				"@types/wordpress__blocks": "^12.5.18",
 				"@types/wordpress__edit-post": "^8.4.2",
 				"@types/wordpress__wordcount": "^2.4.5",
 				"@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -6320,10 +6320,11 @@
 			}
 		},
 		"node_modules/@types/wordpress__blocks": {
-			"version": "12.5.17",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-12.5.17.tgz",
-			"integrity": "sha512-4IyMaHai+g4x3ItG0pVhpct9bpksUDjSgkHSbk7BYGdzYMIJrEPBJcxkIC2og2OTEdJqpSTb6vYiEFdLM/ADcQ==",
+			"version": "12.5.18",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-12.5.18.tgz",
+			"integrity": "sha512-KDugvZn2fEd1mIyYSE4j0QS4vkXOyz1r4akFrnUyJBoIBVQNqDopqXW2qX7kIrTXk9MydWZpdReNDg2Me02s4g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/react": "^18",
 				"@wordpress/components": "^27.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"@types/js-cookie": "^3.0.6",
 				"@types/lodash.debounce": "^4.0.9",
 				"@types/react-router": "^5.1.20",
-				"@types/wordpress__block-editor": "^11.5.16",
+				"@types/wordpress__block-editor": "^11.5.17",
 				"@types/wordpress__blocks": "^12.5.17",
 				"@types/wordpress__edit-post": "^8.4.2",
 				"@types/wordpress__wordcount": "^2.4.5",
@@ -5909,9 +5909,9 @@
 			}
 		},
 		"node_modules/@types/wordpress__block-editor": {
-			"version": "11.5.16",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__block-editor/-/wordpress__block-editor-11.5.16.tgz",
-			"integrity": "sha512-E/HU2zRiw09QvS1To0e1Noi61+klIIfQAwGK7zp+EWcuBoHHNsayXLjBmVGW6C/P2aPeHmqm2duVomPHMEFQcg==",
+			"version": "11.5.17",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__block-editor/-/wordpress__block-editor-11.5.17.tgz",
+			"integrity": "sha512-wn9BjAiTO8qJAXzg7JB8UllgmPEt9BNDcA7/nvwh8PObY1CnJCjWxih/usk95HnhQ5FNk4kT0FrymgzQX9wkPA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.20.5",
+	"version": "3.20.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.20.5",
+			"version": "3.20.6",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11487,6 +11487,20 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -13583,6 +13597,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/duplexer": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -13819,14 +13848,11 @@
 			}
 		},
 		"node_modules/es-define-property": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"get-intrinsic": "^1.2.4"
-			},
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -13903,9 +13929,9 @@
 			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13916,15 +13942,16 @@
 			}
 		},
 		"node_modules/es-set-tostringtag": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-			"integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"get-intrinsic": "^1.2.4",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
 				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.1"
+				"hasown": "^2.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -15587,14 +15614,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.12"
 			},
 			"engines": {
@@ -15781,17 +15810,22 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
 				"function-bind": "^1.1.2",
-				"has-proto": "^1.0.1",
-				"has-symbols": "^1.0.3",
-				"hasown": "^2.0.0"
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -15831,6 +15865,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/get-stdin": {
@@ -16069,13 +16117,13 @@
 			}
 		},
 		"node_modules/gopd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"get-intrinsic": "^1.1.3"
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -16210,9 +16258,9 @@
 			}
 		},
 		"node_modules/has-symbols": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -19466,6 +19514,16 @@
 			"integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/mathml-tag-names": {
 			"version": "2.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@playwright/test": "^1.53.2",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@testing-library/react": "^16.3.0",
-				"@types/jest": "^29.5.14",
+				"@types/jest": "^30.0.0",
 				"@types/js-cookie": "^3.0.6",
 				"@types/lodash.debounce": "^4.0.9",
 				"@types/react-router": "^5.1.20",
@@ -126,15 +126,15 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.26.2",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-			"integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.25.9",
+				"@babel/helper-validator-identifier": "^7.27.1",
 				"js-tokens": "^4.0.0",
-				"picocolors": "^1.0.0"
+				"picocolors": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -472,9 +472,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-			"integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3170,6 +3170,16 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/@jest/diff-sequences": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+			"integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
 		"node_modules/@jest/environment": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -3231,6 +3241,16 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/@jest/get-type": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.0.1.tgz",
+			"integrity": "sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
 		"node_modules/@jest/globals": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -3245,6 +3265,30 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/pattern": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/pattern/node_modules/jest-regex-util": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/reporters": {
@@ -5295,14 +5339,67 @@
 			}
 		},
 		"node_modules/@types/jest": {
-			"version": "29.5.14",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
-			"integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+			"version": "30.0.0",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+			"integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"expect": "^29.0.0",
-				"pretty-format": "^29.0.0"
+				"expect": "^30.0.0",
+				"pretty-format": "^30.0.0"
 			}
+		},
+		"node_modules/@types/jest/node_modules/@jest/expect-utils": {
+			"version": "30.0.4",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.4.tgz",
+			"integrity": "sha512-EgXecHDNfANeqOkcak0DxsoVI4qkDUsR7n/Lr2vtmTBjwLPBnnPOF71S11Q8IObWzxm2QgQoY6f9hzrRD3gHRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/@jest/schemas": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.1.tgz",
+			"integrity": "sha512-+g/1TKjFuGrf1Hh0QPCv0gISwBxJ+MQSNXmG9zjHy7BmFhtoJ9fdNhWJp3qUKRi93AOZHXtdxZgJ1vAtz6z65w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/@jest/types": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.1.tgz",
+			"integrity": "sha512-HGwoYRVF0QSKJu1ZQX0o5ZrUrrhj0aOOFA8hXrumD7SIzjouevhawbTjmXdwOmURdGluU9DM/XvGm3NyFoiQjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.0.1",
+				"@jest/schemas": "30.0.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/@sinclair/typebox": {
+			"version": "0.34.37",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.37.tgz",
+			"integrity": "sha512-2TRuQVgQYfy+EzHRTIvkhv2ADEouJ2xNS/Vq+W5EuuewBdOrvATvljZTxHWZSTYr2sTjTHpGvucaGAt67S2akw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/jest/node_modules/ansi-styles": {
 			"version": "5.2.0",
@@ -5317,19 +5414,152 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/@types/jest/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+		"node_modules/@types/jest/node_modules/ci-info": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+			"integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@types/jest/node_modules/expect": {
+			"version": "30.0.4",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.0.4.tgz",
+			"integrity": "sha512-dDLGjnP2cKbEppxVICxI/Uf4YemmGMPNy0QytCbfafbpYk9AFQsxb8Uyrxii0RPK7FWgLGlSem+07WirwS3cFQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
+				"@jest/expect-utils": "30.0.4",
+				"@jest/get-type": "30.0.1",
+				"jest-matcher-utils": "30.0.4",
+				"jest-message-util": "30.0.2",
+				"jest-mock": "30.0.2",
+				"jest-util": "30.0.2"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/jest-diff": {
+			"version": "30.0.4",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.4.tgz",
+			"integrity": "sha512-TSjceIf6797jyd+R64NXqicttROD+Qf98fex7CowmlSn7f8+En0da1Dglwr1AXxDtVizoxXYZBlUQwNhoOXkNw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/diff-sequences": "30.0.1",
+				"@jest/get-type": "30.0.1",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/jest-matcher-utils": {
+			"version": "30.0.4",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.4.tgz",
+			"integrity": "sha512-ubCewJ54YzeAZ2JeHHGVoU+eDIpQFsfPQs0xURPWoNiO42LGJ+QGgfSf+hFIRplkZDkhH5MOvuxHKXRTUU3dUQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.0.1",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.0.4",
+				"pretty-format": "30.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/jest-message-util": {
+			"version": "30.0.2",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.2.tgz",
+			"integrity": "sha512-vXywcxmr0SsKXF/bAD7t7nMamRvPuJkras00gqYeB1V0WllxZrbZ0paRr3XqpFU2sYYjD0qAaG2fRyn/CGZ0aw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.0.1",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.0.2",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/jest-mock": {
+			"version": "30.0.2",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.2.tgz",
+			"integrity": "sha512-PnZOHmqup/9cT/y+pXIVbbi8ID6U1XHRmbvR7MvUy4SLqhCbwpkmXhLbsWbGewHrV5x/1bF7YDjs+x24/QSvFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.0.1",
+				"@types/node": "*",
+				"jest-util": "30.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/jest-util": {
+			"version": "30.0.2",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.2.tgz",
+			"integrity": "sha512-8IyqfKS4MqprBuUpZNlFB5l+WFehc8bfCe1HSZFHzft2mOuND8Cvi9r1musli+u6F3TqanCZ/Ik4H4pXUolZIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.0.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/picomatch": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@types/jest/node_modules/pretty-format": {
+			"version": "30.0.2",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.2.tgz",
+			"integrity": "sha512-yC5/EBSOrTtqhCKfLHqoUIAXVRZnukHPwWBJWR7h84Q3Be1DRQZLncwcfLoPA5RPQ65qfiCMqgYwdUuQ//eVpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.1",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@types/js-cookie": {
@@ -20825,9 +21055,9 @@
 			"license": "MIT"
 		},
 		"node_modules/picocolors": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-			"integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
 			"dev": true,
 			"license": "ISC"
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -11250,16 +11250,6 @@
 				"npm": "1.2.8000 || >= 1.4.16"
 			}
 		},
-		"node_modules/body-parser/node_modules/bytes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/body-parser/node_modules/debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -11429,9 +11419,9 @@
 			}
 		},
 		"node_modules/bytes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12129,18 +12119,18 @@
 			}
 		},
 		"node_modules/compression": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-			"integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+			"integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"accepts": "~1.3.5",
-				"bytes": "3.0.0",
-				"compressible": "~2.0.16",
+				"bytes": "3.1.2",
+				"compressible": "~2.0.18",
 				"debug": "2.6.9",
-				"on-headers": "~1.0.2",
-				"safe-buffer": "5.1.2",
+				"negotiator": "~0.6.4",
+				"on-headers": "~1.1.0",
+				"safe-buffer": "5.2.1",
 				"vary": "~1.1.2"
 			},
 			"engines": {
@@ -12164,12 +12154,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/compression/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+		"node_modules/compression/node_modules/negotiator": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+			"integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
 		"node_modules/compute-scroll-into-view": {
 			"version": "1.0.20",
@@ -20482,9 +20475,9 @@
 			}
 		},
 		"node_modules/on-headers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+			"integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -22326,16 +22319,6 @@
 				"iconv-lite": "0.4.24",
 				"unpipe": "1.0.0"
 			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/raw-body/node_modules/bytes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"lodash.debounce": "^4.0.8"
 			},
 			"devDependencies": {
-				"@playwright/test": "^1.53.2",
+				"@playwright/test": "^1.54.1",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@testing-library/react": "^16.3.0",
 				"@types/jest": "^30.0.0",
@@ -3641,12 +3641,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.53.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.2.tgz",
-			"integrity": "sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw==",
+			"version": "1.54.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.1.tgz",
+			"integrity": "sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.53.2"
+				"playwright": "1.54.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -21131,12 +21132,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.53.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.2.tgz",
-			"integrity": "sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==",
+			"version": "1.54.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
+			"integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.53.2"
+				"playwright-core": "1.54.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -21149,10 +21151,11 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.53.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
-			"integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
+			"version": "1.54.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
+			"integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
 			},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.20.5",
+	"version": "3.20.6",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"@types/lodash.debounce": "^4.0.9",
 		"@types/react-router": "^5.1.20",
 		"@types/wordpress__block-editor": "^11.5.17",
-		"@types/wordpress__blocks": "^12.5.17",
+		"@types/wordpress__blocks": "^12.5.18",
 		"@types/wordpress__edit-post": "^8.4.2",
 		"@types/wordpress__wordcount": "^2.4.5",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"@playwright/test": "^1.53.2",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/react": "^16.3.0",
-		"@types/jest": "^29.5.14",
+		"@types/jest": "^30.0.0",
 		"@types/js-cookie": "^3.0.6",
 		"@types/lodash.debounce": "^4.0.9",
 		"@types/react-router": "^5.1.20",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@types/js-cookie": "^3.0.6",
 		"@types/lodash.debounce": "^4.0.9",
 		"@types/react-router": "^5.1.20",
-		"@types/wordpress__block-editor": "^11.5.16",
+		"@types/wordpress__block-editor": "^11.5.17",
 		"@types/wordpress__blocks": "^12.5.17",
 		"@types/wordpress__edit-post": "^8.4.2",
 		"@types/wordpress__wordcount": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"lodash.debounce": "^4.0.8"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.53.2",
+		"@playwright/test": "^1.54.1",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/react": "^16.3.0",
 		"@types/jest": "^30.0.0",

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import { type Page } from '@playwright/test';
  */
 import { Admin } from '@wordpress/e2e-test-utils-playwright';
 
-export const PLUGIN_VERSION = '3.20.5';
+export const PLUGIN_VERSION = '3.20.6';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.20.5
+ * Version:           3.20.6
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -49,7 +49,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION             = '3.20.5';
+const PARSELY_VERSION             = '3.20.6';
 const PARSELY_FILE                = __FILE__;
 const PARSELY_DATA_SCHEMA_VERSION = '1';
 const PARSELY_CACHE_GROUP         = 'wp-parsely';


### PR DESCRIPTION
This PR merges the `develop` branch into the `trunk` branch in order to release wp-parsely 3.20.6.