### PR TITLE
Attempt to fix develop branch build error

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -52,7 +52,7 @@ jobs:
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.1.0
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,7 +28,7 @@ jobs:
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.1.0
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/src/content-helper/common/providers/base-provider.tsx
+++ b/src/content-helper/common/providers/base-provider.tsx
@@ -137,6 +137,7 @@ export abstract class BaseProvider {
 	 * AbortController signal.
 	 *
 	 * @since 3.15.0
+	 * @since 3.20.7 Using APIFetchOptions<true> to avoid a type error when building on GitHub.
 	 *
 	 * @param {APIFetchOptions} options The options to pass to apiFetch.
 	 * @param {string?}         id      The (optional) ID of the request.
@@ -148,7 +149,9 @@ export abstract class BaseProvider {
 		options.signal = abortController.signal;
 
 		try {
-			const response = await apiFetch<ContentHelperAPIResponse<T>>( options );
+			const response = await apiFetch<ContentHelperAPIResponse<T>>(
+				options as APIFetchOptions<true>
+			);
 
 			// Validate API side errors.
 			if ( response.error ) {


### PR DESCRIPTION
## Description
When we updated api-fetch to 7.30, we started getting this error when `npm run build` was being called. From [here](https://github.com/Parsely/wp-parsely/actions/runs/17496613957/job/49698966480?pr=3657):

```
ERROR in /home/runner/work/wp-parsely/wp-parsely/src/content-helper/common/providers/base-provider.tsx(151,66)
      TS2345: Argument of type 'APIFetchOptions<boolean>' is not assignable to parameter of type 'APIFetchOptions<true>'.
  Type 'boolean' is not assignable to type 'true'.
```

We fixed the error with https://github.com/Parsely/wp-parsely/pull/3657/commits/0a6834be266fc5bbafb1c1e7b859ee2d770e57a1, but then `develop` plugin builds [started failing](https://github.com/Parsely/wp-parsely/actions/runs/17496792102/job/49699939342). This doesn't happen for the PRs themselves. We're getting the error only after merging into `develop`

This PR is an attempt to fix this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI workflows to use the latest Node.js setup action across build and test pipelines.
- Documentation
  - Added a @since note to the fetch method describing the use of APIFetchOptions<true>.
- Style
  - Minor type annotation adjustment in fetch call to align with generic options (no runtime behavior change).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->