### PR TITLE
Downgrade api-fetch package to 7.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"@types/wordpress__edit-post": "^8.4.2",
 				"@types/wordpress__wordcount": "^2.4.5",
 				"@typescript-eslint/eslint-plugin": "^6.21.0",
-				"@wordpress/api-fetch": "^7.30.0",
+				"@wordpress/api-fetch": "7.29",
 				"@wordpress/babel-preset-default": "^7.42.0",
 				"@wordpress/block-editor": "^15.3.0",
 				"@wordpress/blocks": "^15.3.0",
@@ -7967,15 +7967,15 @@
 			}
 		},
 		"node_modules/@wordpress/api-fetch": {
-			"version": "7.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.30.0.tgz",
-			"integrity": "sha512-KwI+ENWAd350Y5qd/Ok1bbSplDP4HFf9E/yh8QnRkhtsx4xAmFP5prNkPXktqK00NGPU8rRcTKzMdtrgQ2M/pA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.29.0.tgz",
+			"integrity": "sha512-5Z3qtbMCqbvpqHufIxI85T3sloCN5c/10BKd9hzdllEpTONhUAWf42jsVyBYsXh2ZHvq0FekQhs2RdE30cLKAA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^6.3.0",
-				"@wordpress/url": "^4.30.0"
+				"@wordpress/i18n": "^6.2.0",
+				"@wordpress/url": "^4.29.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8121,6 +8121,22 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/api-fetch": {
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.30.0.tgz",
+			"integrity": "sha512-KwI+ENWAd350Y5qd/Ok1bbSplDP4HFf9E/yh8QnRkhtsx4xAmFP5prNkPXktqK00NGPU8rRcTKzMdtrgQ2M/pA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.3.0",
+				"@wordpress/url": "^4.30.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/keycodes": {
 			"version": "4.30.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.30.0.tgz",
@@ -8220,6 +8236,22 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/api-fetch": {
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.30.0.tgz",
+			"integrity": "sha512-KwI+ENWAd350Y5qd/Ok1bbSplDP4HFf9E/yh8QnRkhtsx4xAmFP5prNkPXktqK00NGPU8rRcTKzMdtrgQ2M/pA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.3.0",
+				"@wordpress/url": "^4.30.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/keycodes": {
@@ -8558,6 +8590,22 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/@wordpress/api-fetch": {
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.30.0.tgz",
+			"integrity": "sha512-KwI+ENWAd350Y5qd/Ok1bbSplDP4HFf9E/yh8QnRkhtsx4xAmFP5prNkPXktqK00NGPU8rRcTKzMdtrgQ2M/pA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.3.0",
+				"@wordpress/url": "^4.30.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/undo-manager": {
@@ -9152,6 +9200,22 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/edit-post/node_modules/@wordpress/api-fetch": {
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.30.0.tgz",
+			"integrity": "sha512-KwI+ENWAd350Y5qd/Ok1bbSplDP4HFf9E/yh8QnRkhtsx4xAmFP5prNkPXktqK00NGPU8rRcTKzMdtrgQ2M/pA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.3.0",
+				"@wordpress/url": "^4.30.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/edit-post/node_modules/@wordpress/keycodes": {
 			"version": "4.30.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.30.0.tgz",
@@ -9240,6 +9304,22 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/api-fetch": {
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.30.0.tgz",
+			"integrity": "sha512-KwI+ENWAd350Y5qd/Ok1bbSplDP4HFf9E/yh8QnRkhtsx4xAmFP5prNkPXktqK00NGPU8rRcTKzMdtrgQ2M/pA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.3.0",
+				"@wordpress/url": "^4.30.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/editor/node_modules/@wordpress/keycodes": {
@@ -9702,6 +9782,22 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/api-fetch": {
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.30.0.tgz",
+			"integrity": "sha512-KwI+ENWAd350Y5qd/Ok1bbSplDP4HFf9E/yh8QnRkhtsx4xAmFP5prNkPXktqK00NGPU8rRcTKzMdtrgQ2M/pA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.3.0",
+				"@wordpress/url": "^4.30.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/fields/node_modules/@wordpress/warning": {
 			"version": "3.30.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.30.0.tgz",
@@ -9985,6 +10081,22 @@
 				"@wordpress/element": "^6.30.0",
 				"@wordpress/i18n": "^6.3.0",
 				"@wordpress/private-apis": "^1.30.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-utils/node_modules/@wordpress/api-fetch": {
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.30.0.tgz",
+			"integrity": "sha512-KwI+ENWAd350Y5qd/Ok1bbSplDP4HFf9E/yh8QnRkhtsx4xAmFP5prNkPXktqK00NGPU8rRcTKzMdtrgQ2M/pA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.3.0",
+				"@wordpress/url": "^4.30.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10733,6 +10845,22 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/api-fetch": {
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.30.0.tgz",
+			"integrity": "sha512-KwI+ENWAd350Y5qd/Ok1bbSplDP4HFf9E/yh8QnRkhtsx4xAmFP5prNkPXktqK00NGPU8rRcTKzMdtrgQ2M/pA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.3.0",
+				"@wordpress/url": "^4.30.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/shortcode": {
 			"version": "4.30.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.30.0.tgz",
@@ -10872,6 +11000,22 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/upload-media/node_modules/@wordpress/api-fetch": {
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.30.0.tgz",
+			"integrity": "sha512-KwI+ENWAd350Y5qd/Ok1bbSplDP4HFf9E/yh8QnRkhtsx4xAmFP5prNkPXktqK00NGPU8rRcTKzMdtrgQ2M/pA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.3.0",
+				"@wordpress/url": "^4.30.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/url": {
 			"version": "4.30.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.30.0.tgz",
@@ -10945,6 +11089,22 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/widgets/node_modules/@wordpress/api-fetch": {
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.30.0.tgz",
+			"integrity": "sha512-KwI+ENWAd350Y5qd/Ok1bbSplDP4HFf9E/yh8QnRkhtsx4xAmFP5prNkPXktqK00NGPU8rRcTKzMdtrgQ2M/pA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.3.0",
+				"@wordpress/url": "^4.30.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/wordcount": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"@types/wordpress__edit-post": "^8.4.2",
 		"@types/wordpress__wordcount": "^2.4.5",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",
-		"@wordpress/api-fetch": "^7.30.0",
+		"@wordpress/api-fetch": "7.29",
 		"@wordpress/babel-preset-default": "^7.42.0",
 		"@wordpress/block-editor": "^15.3.0",
 		"@wordpress/blocks": "^15.3.0",

--- a/src/content-helper/common/providers/base-provider.tsx
+++ b/src/content-helper/common/providers/base-provider.tsx
@@ -137,21 +137,18 @@ export abstract class BaseProvider {
 	 * AbortController signal.
 	 *
 	 * @since 3.15.0
-	 * @since 3.20.7 Using APIFetchOptions<true> to avoid a type error when building on GitHub.
 	 *
 	 * @param {APIFetchOptions} options The options to pass to apiFetch.
 	 * @param {string?}         id      The (optional) ID of the request.
 	 *
 	 * @return {Promise<ContentHelperAPIResponse<any>>} The fetched data.
 	 */
-	protected async fetch<T>( options: APIFetchOptions<true>, id?: string ): Promise<T> {
+	protected async fetch<T>( options: APIFetchOptions, id?: string ): Promise<T> {
 		const { abortController, abortId } = this.getOrCreateController( id );
 		options.signal = abortController.signal;
 
 		try {
-			const response = await apiFetch<ContentHelperAPIResponse<T>>(
-				options as APIFetchOptions<true>
-			);
+			const response = await apiFetch<ContentHelperAPIResponse<T>>( options );
 
 			// Validate API side errors.
 			if ( response.error ) {


### PR DESCRIPTION
## Description
We're having [build issues on the develop branch](https://github.com/Parsely/wp-parsely/pull/3661) after updating `@wordpress/api-fetch` from `7.29` to `7.30`. With this PR we're downgrading to `7.29` in an attempt to avoid the issue introduced due to the stricter typing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned a development dependency to an exact version to ensure consistent, reproducible builds.

* **Refactor**
  * Streamlined internal request typing to simplify options handling and reduce type assertions. No changes to behavior or UI are expected.

No user-facing changes in this release; improvements focus on development stability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->