### PR TITLE
Revert "build(deps-dev): bump @wordpress/api-fetch from 7.29.0 to 7.32.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"@types/wordpress__edit-post": "^8.4.2",
 				"@types/wordpress__wordcount": "^2.4.5",
 				"@typescript-eslint/eslint-plugin": "^6.21.0",
-				"@wordpress/api-fetch": "7.32",
+				"@wordpress/api-fetch": "7.29",
 				"@wordpress/babel-preset-default": "^7.42.0",
 				"@wordpress/block-editor": "^15.5.0",
 				"@wordpress/blocks": "^15.5.0",
@@ -7967,15 +7967,15 @@
 			}
 		},
 		"node_modules/@wordpress/api-fetch": {
-			"version": "7.32.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.32.0.tgz",
-			"integrity": "sha512-kTufX1lhb7AG7J3KMoDOKO9IKWVwWemf/TqaqiRYNC06uxXPl/VPBJC6AzInirsNw0BZknssje+g7Fc6WbrBFA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.29.0.tgz",
+			"integrity": "sha512-5Z3qtbMCqbvpqHufIxI85T3sloCN5c/10BKd9hzdllEpTONhUAWf42jsVyBYsXh2ZHvq0FekQhs2RdE30cLKAA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^6.5.0",
-				"@wordpress/url": "^4.32.0"
+				"@wordpress/i18n": "^6.2.0",
+				"@wordpress/url": "^4.29.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8066,7 +8066,7 @@
 				"@emotion/styled": "^11.6.0",
 				"@react-spring/web": "^9.4.5",
 				"@wordpress/a11y": "^4.32.0",
-				"@wordpress/api-fetch": "7.32",
+				"@wordpress/api-fetch": "^7.32.0",
 				"@wordpress/blob": "^4.32.0",
 				"@wordpress/block-serialization-default-parser": "^5.32.0",
 				"@wordpress/blocks": "^15.5.0",
@@ -8121,6 +8121,22 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/api-fetch": {
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.32.0.tgz",
+			"integrity": "sha512-kTufX1lhb7AG7J3KMoDOKO9IKWVwWemf/TqaqiRYNC06uxXPl/VPBJC6AzInirsNw0BZknssje+g7Fc6WbrBFA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.5.0",
+				"@wordpress/url": "^4.32.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/keycodes": {
 			"version": "4.32.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.32.0.tgz",
@@ -8171,7 +8187,7 @@
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
 				"@wordpress/a11y": "^4.32.0",
-				"@wordpress/api-fetch": "7.32",
+				"@wordpress/api-fetch": "^7.32.0",
 				"@wordpress/autop": "^4.32.0",
 				"@wordpress/blob": "^4.32.0",
 				"@wordpress/block-editor": "^15.5.0",
@@ -8220,6 +8236,22 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/api-fetch": {
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.32.0.tgz",
+			"integrity": "sha512-kTufX1lhb7AG7J3KMoDOKO9IKWVwWemf/TqaqiRYNC06uxXPl/VPBJC6AzInirsNw0BZknssje+g7Fc6WbrBFA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.5.0",
+				"@wordpress/url": "^4.32.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/keycodes": {
@@ -8529,7 +8561,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "7.32",
+				"@wordpress/api-fetch": "^7.32.0",
 				"@wordpress/block-editor": "^15.5.0",
 				"@wordpress/blocks": "^15.5.0",
 				"@wordpress/compose": "^7.32.0",
@@ -8558,6 +8590,22 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/@wordpress/api-fetch": {
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.32.0.tgz",
+			"integrity": "sha512-kTufX1lhb7AG7J3KMoDOKO9IKWVwWemf/TqaqiRYNC06uxXPl/VPBJC6AzInirsNw0BZknssje+g7Fc6WbrBFA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.5.0",
+				"@wordpress/url": "^4.32.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/undo-manager": {
@@ -9115,7 +9163,7 @@
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
 				"@wordpress/a11y": "^4.32.0",
-				"@wordpress/api-fetch": "7.32",
+				"@wordpress/api-fetch": "^7.32.0",
 				"@wordpress/block-editor": "^15.5.0",
 				"@wordpress/block-library": "^9.32.0",
 				"@wordpress/blocks": "^15.5.0",
@@ -9154,6 +9202,22 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/edit-post/node_modules/@wordpress/api-fetch": {
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.32.0.tgz",
+			"integrity": "sha512-kTufX1lhb7AG7J3KMoDOKO9IKWVwWemf/TqaqiRYNC06uxXPl/VPBJC6AzInirsNw0BZknssje+g7Fc6WbrBFA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.5.0",
+				"@wordpress/url": "^4.32.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/edit-post/node_modules/@wordpress/keycodes": {
 			"version": "4.32.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.32.0.tgz",
@@ -9189,7 +9253,7 @@
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
 				"@wordpress/a11y": "^4.32.0",
-				"@wordpress/api-fetch": "7.32",
+				"@wordpress/api-fetch": "^7.32.0",
 				"@wordpress/blob": "^4.32.0",
 				"@wordpress/block-editor": "^15.5.0",
 				"@wordpress/blocks": "^15.5.0",
@@ -9242,6 +9306,22 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/api-fetch": {
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.32.0.tgz",
+			"integrity": "sha512-kTufX1lhb7AG7J3KMoDOKO9IKWVwWemf/TqaqiRYNC06uxXPl/VPBJC6AzInirsNw0BZknssje+g7Fc6WbrBFA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.5.0",
+				"@wordpress/url": "^4.32.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/editor/node_modules/@wordpress/keycodes": {
@@ -9668,7 +9748,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "7.32",
+				"@wordpress/api-fetch": "^7.32.0",
 				"@wordpress/blob": "^4.32.0",
 				"@wordpress/block-editor": "^15.5.0",
 				"@wordpress/blocks": "^15.5.0",
@@ -9702,6 +9782,22 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/api-fetch": {
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.32.0.tgz",
+			"integrity": "sha512-kTufX1lhb7AG7J3KMoDOKO9IKWVwWemf/TqaqiRYNC06uxXPl/VPBJC6AzInirsNw0BZknssje+g7Fc6WbrBFA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.5.0",
+				"@wordpress/url": "^4.32.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/fields/node_modules/@wordpress/warning": {
@@ -9982,11 +10078,27 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "7.32",
+				"@wordpress/api-fetch": "^7.32.0",
 				"@wordpress/blob": "^4.32.0",
 				"@wordpress/element": "^6.32.0",
 				"@wordpress/i18n": "^6.5.0",
 				"@wordpress/private-apis": "^1.32.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-utils/node_modules/@wordpress/api-fetch": {
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.32.0.tgz",
+			"integrity": "sha512-kTufX1lhb7AG7J3KMoDOKO9IKWVwWemf/TqaqiRYNC06uxXPl/VPBJC6AzInirsNw0BZknssje+g7Fc6WbrBFA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.5.0",
+				"@wordpress/url": "^4.32.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10716,7 +10828,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "7.32",
+				"@wordpress/api-fetch": "^7.32.0",
 				"@wordpress/blocks": "^15.5.0",
 				"@wordpress/components": "^30.5.0",
 				"@wordpress/compose": "^7.32.0",
@@ -10733,6 +10845,22 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/api-fetch": {
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.32.0.tgz",
+			"integrity": "sha512-kTufX1lhb7AG7J3KMoDOKO9IKWVwWemf/TqaqiRYNC06uxXPl/VPBJC6AzInirsNw0BZknssje+g7Fc6WbrBFA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.5.0",
+				"@wordpress/url": "^4.32.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/shortcode": {
@@ -10854,7 +10982,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "7.32",
+				"@wordpress/api-fetch": "^7.32.0",
 				"@wordpress/blob": "^4.32.0",
 				"@wordpress/compose": "^7.32.0",
 				"@wordpress/data": "^10.32.0",
@@ -10872,6 +11000,22 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/upload-media/node_modules/@wordpress/api-fetch": {
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.32.0.tgz",
+			"integrity": "sha512-kTufX1lhb7AG7J3KMoDOKO9IKWVwWemf/TqaqiRYNC06uxXPl/VPBJC6AzInirsNw0BZknssje+g7Fc6WbrBFA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.5.0",
+				"@wordpress/url": "^4.32.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/url": {
@@ -10927,7 +11071,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "7.32",
+				"@wordpress/api-fetch": "^7.32.0",
 				"@wordpress/block-editor": "^15.5.0",
 				"@wordpress/blocks": "^15.5.0",
 				"@wordpress/components": "^30.5.0",
@@ -10947,6 +11091,22 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/widgets/node_modules/@wordpress/api-fetch": {
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.32.0.tgz",
+			"integrity": "sha512-kTufX1lhb7AG7J3KMoDOKO9IKWVwWemf/TqaqiRYNC06uxXPl/VPBJC6AzInirsNw0BZknssje+g7Fc6WbrBFA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.5.0",
+				"@wordpress/url": "^4.32.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/wordcount": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"@types/wordpress__edit-post": "^8.4.2",
 		"@types/wordpress__wordcount": "^2.4.5",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",
-		"@wordpress/api-fetch": "7.32",
+		"@wordpress/api-fetch": "7.29",
 		"@wordpress/babel-preset-default": "^7.42.0",
 		"@wordpress/block-editor": "^15.5.0",
 		"@wordpress/blocks": "^15.5.0",

--- a/src/content-helper/common/providers/base-provider.tsx
+++ b/src/content-helper/common/providers/base-provider.tsx
@@ -148,7 +148,7 @@ export abstract class BaseProvider {
 		options.signal = abortController.signal;
 
 		try {
-			const response = await apiFetch<ContentHelperAPIResponse<T>>( options as APIFetchOptions<true> );
+			const response = await apiFetch<ContentHelperAPIResponse<T>>( options );
 
 			// Validate API side errors.
 			if ( response.error ) {


### PR DESCRIPTION
Reverts Parsely/wp-parsely#3728, which creates build issues on the `develop` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.
- Refactor
  - Streamlined internal request handling types to reduce complexity without affecting behavior.
- Chores
  - Updated development dependency versions to improve build consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->