### PR TITLE
bump-version.yml: Use PHP 8.4

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -27,10 +27,10 @@ jobs:
             exit 1
           fi
 
-      - name: Setup PHP 8.1
+      - name: Setup PHP 8.4
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.4'
           extensions: mbstring, json
 
       - name: Checkout ${{ github.ref_name }} branch
@@ -73,10 +73,10 @@ jobs:
       CURRENT_VERSION: ${{ needs.validate_version.outputs.current_version }}
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Setup PHP 8.1
+      - name: Setup PHP 8.4
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.4'
           extensions: mbstring, json
 
       - name: Configure Git


### PR DESCRIPTION
## Description
With this PR, we're replacing PHP 8.1 with PHP 8.4 in our `bump-version.yml` workflow.

## Motivation and context
PHP 8.1 is nearing EOL (end of 2025).

## How has this been tested?
The workflow should work with the new PHP version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration to use PHP 8.4 across relevant workflow steps.
  * Aligns build environment with the latest PHP version for improved compatibility and long-term support.
  * No changes to user-facing features or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->