### PR TITLE
.phpcs.xml.dist: Update minimum_supported_wp_version to 6.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -41,7 +41,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.2"/>
+	<config name="minimum_supported_wp_version" value="6.0"/>
 
 	<!-- Rules: WordPress VIP - see
 		https://github.com/Automattic/VIP-Coding-Standards -->


### PR DESCRIPTION
## Description
Our `README.md` currently lists WordPress 6.0 as the minimum version, but this wasn't reflected in our `.phpcs.xml.dist` file. With this PR, we're updating it so the information is synced and we don't get potentially incorrect information when linting our code.

## How has this been tested?
CS Checks still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coding standards configuration to target WordPress 6.0, aligning automated sniffs with current platform expectations and deprecations.
  * This may change linting outcomes for future contributions by flagging outdated patterns earlier.
  * No functional or runtime changes; end-users will not see any differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->