### PR TITLE
Settings page: Fix Headline Testing documentation link

### DIFF
--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -544,7 +544,7 @@ final class Settings_Page {
 			__( 'Headline Testing', 'wp-parsely' ),
 			function (): void {
 				echo '<p>' . esc_html__( 'Configure Parse.ly Headline Testing to automatically test different headline variations and optimize for engagement.', 'wp-parsely' ) . '</p>';
-				echo '<p><a href="https://docs.parse.ly/install-headline-testing/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Learn more about Headline Testing', 'wp-parsely' ) . '</a></p>';
+				echo '<p><a href="https://docs.parse.ly/dashboard/optimization-menu/headline-testing-tab/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Learn more about Headline Testing', 'wp-parsely' ) . '</a></p>';
 			},
 			Parsely::MENU_SLUG
 		);


### PR DESCRIPTION
## Description
With this PR, we're fixing the Headline Testing documentation link to a page that gives better information about the feature.

## Motivation and context
Provide the best possible documentation.

## How has this been tested?
No functionality changes, manually tested that the link opens to the correct page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Learn more about Headline Testing” link in the Headline Testing section of the settings to point to the new Parse.ly dashboard path, replacing the outdated documentation URL.
  * Ensures users are directed to current guidance without altering any settings, functionality, or layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->