### PR TITLE
Release wp-parsely 3.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.21.1](https://github.com/Parsely/wp-parsely/compare/3.21.0...3.21.1) - 2025-10-13
+
+### Fixed
+
+- Settings page: Fix Headline Testing documentation link ([#3753](https://github.com/Parsely/wp-parsely/pull/3753))
+
+
 ## [3.21.0](https://github.com/Parsely/wp-parsely/compare/3.20.8...3.21.0) - 2025-10-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Settings page: Fix Headline Testing documentation link ([#3753](https://github.com/Parsely/wp-parsely/pull/3753))
 
-
 ## [3.21.0](https://github.com/Parsely/wp-parsely/compare/3.20.8...3.21.0) - 2025-10-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.21.0  
+Stable tag: 3.21.1  
 Requires at least: 6.0  
 Tested up to: 6.8  
 Requires PHP: 7.4  

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -54,6 +54,10 @@ composer testwp -- --filter SettingsPageTest
 
 # Run all multisite integration tests.
 composer testwp-ms
+
+# Run with coverage.
+composer coveragewp
+composer coveragewp -- --filter SettingsPageTest
 ```
 
 ### Troubleshooting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.21.0",
+	"version": "3.21.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.21.0",
+			"version": "3.21.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.21.0",
+	"version": "3.21.1",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/src/UI/class-settings-page.php
+++ b/src/UI/class-settings-page.php
@@ -544,7 +544,7 @@ final class Settings_Page {
 			__( 'Headline Testing', 'wp-parsely' ),
 			function (): void {
 				echo '<p>' . esc_html__( 'Configure Parse.ly Headline Testing to automatically test different headline variations and optimize for engagement.', 'wp-parsely' ) . '</p>';
-				echo '<p><a href="https://docs.parse.ly/install-headline-testing/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Learn more about Headline Testing', 'wp-parsely' ) . '</a></p>';
+				echo '<p><a href="https://docs.parse.ly/dashboard/optimization-menu/headline-testing-tab/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Learn more about Headline Testing', 'wp-parsely' ) . '</a></p>';
 			},
 			Parsely::MENU_SLUG
 		);

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import { type Page } from '@playwright/test';
  */
 import { Admin } from '@wordpress/e2e-test-utils-playwright';
 
-export const PLUGIN_VERSION = '3.21.0';
+export const PLUGIN_VERSION = '3.21.1';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.21.0
+ * Version:           3.21.1
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -50,7 +50,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION             = '3.21.0';
+const PARSELY_VERSION             = '3.21.1';
 const PARSELY_FILE                = __FILE__;
 const PARSELY_DATA_SCHEMA_VERSION = '1';
 const PARSELY_CACHE_GROUP         = 'wp-parsely';


### PR DESCRIPTION
This PR merges the `develop` branch into the `trunk` branch in order to release wp-parsely 3.21.1.