### PR TITLE
Try to fix develop build error

### DIFF
--- a/src/content-helper/common/providers/base-provider.tsx
+++ b/src/content-helper/common/providers/base-provider.tsx
@@ -148,7 +148,7 @@ export abstract class BaseProvider {
 		options.signal = abortController.signal;
 
 		try {
-			const response = await apiFetch<ContentHelperAPIResponse<T>, true>( options );
+			const response = await apiFetch<ContentHelperAPIResponse<T>>( options as APIFetchOptions<true> );
 
 			// Validate API side errors.
 			if ( response.error ) {

--- a/src/content-helper/common/providers/base-provider.tsx
+++ b/src/content-helper/common/providers/base-provider.tsx
@@ -148,7 +148,7 @@ export abstract class BaseProvider {
 		options.signal = abortController.signal;
 
 		try {
-			const response = await apiFetch<ContentHelperAPIResponse<T>>( options );
+			const response = await apiFetch<ContentHelperAPIResponse<T>, true>( options );
 
 			// Validate API side errors.
 			if ( response.error ) {


### PR DESCRIPTION
After merging `https://github.com/Parsely/wp-parsely/pull/3816` we started getting build errors on `develop`	(see https://github.com/Parsely/wp-parsely/actions/runs/19479384043/job/55747325249). This is a fix attempting to solve the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tightened internal API typing for fetch calls to improve type safety.
  * No changes to behavior, error handling, or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->