### PR TITLE
Revert "build(deps-dev): bump @wordpress/api-fetch from 7.29.0 to 7.35.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"@types/wordpress__edit-post": "^8.4.2",
 				"@types/wordpress__wordcount": "^2.4.5",
 				"@typescript-eslint/eslint-plugin": "^6.21.0",
-				"@wordpress/api-fetch": "7.35",
+				"@wordpress/api-fetch": "7.29",
 				"@wordpress/babel-preset-default": "^7.42.0",
 				"@wordpress/block-editor": "^15.6.0",
 				"@wordpress/blocks": "^15.8.0",
@@ -8011,14 +8011,15 @@
 			}
 		},
 		"node_modules/@wordpress/api-fetch": {
-			"version": "7.35.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.35.0.tgz",
-			"integrity": "sha512-jWIhNUVYkUOsVLvGodBhzLe4DR+gCNmh7sm91Vce/79M+DXMtEFLc8jHJ5kXKudnPPTzy29KF1ZzZJ9rm9sqRQ==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.29.0.tgz",
+			"integrity": "sha512-5Z3qtbMCqbvpqHufIxI85T3sloCN5c/10BKd9hzdllEpTONhUAWf42jsVyBYsXh2ZHvq0FekQhs2RdE30cLKAA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.8.0",
-				"@wordpress/url": "^4.35.0"
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^6.2.0",
+				"@wordpress/url": "^4.29.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8158,6 +8159,21 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/api-fetch": {
+			"version": "7.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.33.0.tgz",
+			"integrity": "sha512-1hUMnX7t+PFBgNNZIITOY8w9J3/ZcVm3sT2gxURPaz1B1BE7LwLwQQyqUWi6hl4Z0eh5qUcEG5HJOUZTGLmVwA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.6.0",
+				"@wordpress/url": "^4.33.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/base-styles": {
 			"version": "6.9.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.9.0.tgz",
@@ -8267,6 +8283,21 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/api-fetch": {
+			"version": "7.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.33.0.tgz",
+			"integrity": "sha512-1hUMnX7t+PFBgNNZIITOY8w9J3/ZcVm3sT2gxURPaz1B1BE7LwLwQQyqUWi6hl4Z0eh5qUcEG5HJOUZTGLmVwA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.6.0",
+				"@wordpress/url": "^4.33.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/base-styles": {
@@ -8627,6 +8658,21 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/@wordpress/api-fetch": {
+			"version": "7.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.33.0.tgz",
+			"integrity": "sha512-1hUMnX7t+PFBgNNZIITOY8w9J3/ZcVm3sT2gxURPaz1B1BE7LwLwQQyqUWi6hl4Z0eh5qUcEG5HJOUZTGLmVwA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.6.0",
+				"@wordpress/url": "^4.33.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/undo-manager": {
@@ -9202,6 +9248,21 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/edit-post/node_modules/@wordpress/api-fetch": {
+			"version": "7.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.33.0.tgz",
+			"integrity": "sha512-1hUMnX7t+PFBgNNZIITOY8w9J3/ZcVm3sT2gxURPaz1B1BE7LwLwQQyqUWi6hl4Z0eh5qUcEG5HJOUZTGLmVwA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.6.0",
+				"@wordpress/url": "^4.33.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/edit-post/node_modules/@wordpress/base-styles": {
 			"version": "6.9.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.9.0.tgz",
@@ -9301,6 +9362,21 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/api-fetch": {
+			"version": "7.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.33.0.tgz",
+			"integrity": "sha512-1hUMnX7t+PFBgNNZIITOY8w9J3/ZcVm3sT2gxURPaz1B1BE7LwLwQQyqUWi6hl4Z0eh5qUcEG5HJOUZTGLmVwA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.6.0",
+				"@wordpress/url": "^4.33.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/editor/node_modules/@wordpress/base-styles": {
@@ -9769,6 +9845,21 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/api-fetch": {
+			"version": "7.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.33.0.tgz",
+			"integrity": "sha512-1hUMnX7t+PFBgNNZIITOY8w9J3/ZcVm3sT2gxURPaz1B1BE7LwLwQQyqUWi6hl4Z0eh5qUcEG5HJOUZTGLmVwA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.6.0",
+				"@wordpress/url": "^4.33.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/fields/node_modules/@wordpress/base-styles": {
 			"version": "6.9.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.9.0.tgz",
@@ -10063,6 +10154,21 @@
 				"@wordpress/element": "^6.33.0",
 				"@wordpress/i18n": "^6.6.0",
 				"@wordpress/private-apis": "^1.33.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-utils/node_modules/@wordpress/api-fetch": {
+			"version": "7.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.33.0.tgz",
+			"integrity": "sha512-1hUMnX7t+PFBgNNZIITOY8w9J3/ZcVm3sT2gxURPaz1B1BE7LwLwQQyqUWi6hl4Z0eh5qUcEG5HJOUZTGLmVwA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.6.0",
+				"@wordpress/url": "^4.33.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10835,6 +10941,21 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/api-fetch": {
+			"version": "7.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.33.0.tgz",
+			"integrity": "sha512-1hUMnX7t+PFBgNNZIITOY8w9J3/ZcVm3sT2gxURPaz1B1BE7LwLwQQyqUWi6hl4Z0eh5qUcEG5HJOUZTGLmVwA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.6.0",
+				"@wordpress/url": "^4.33.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/shortcode": {
 			"version": "4.35.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.35.0.tgz",
@@ -10968,6 +11089,21 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/upload-media/node_modules/@wordpress/api-fetch": {
+			"version": "7.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.33.0.tgz",
+			"integrity": "sha512-1hUMnX7t+PFBgNNZIITOY8w9J3/ZcVm3sT2gxURPaz1B1BE7LwLwQQyqUWi6hl4Z0eh5qUcEG5HJOUZTGLmVwA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.6.0",
+				"@wordpress/url": "^4.33.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/url": {
 			"version": "4.35.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.35.0.tgz",
@@ -11039,6 +11175,21 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/widgets/node_modules/@wordpress/api-fetch": {
+			"version": "7.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.33.0.tgz",
+			"integrity": "sha512-1hUMnX7t+PFBgNNZIITOY8w9J3/ZcVm3sT2gxURPaz1B1BE7LwLwQQyqUWi6hl4Z0eh5qUcEG5HJOUZTGLmVwA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/i18n": "^6.6.0",
+				"@wordpress/url": "^4.33.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/widgets/node_modules/@wordpress/base-styles": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"@types/wordpress__edit-post": "^8.4.2",
 		"@types/wordpress__wordcount": "^2.4.5",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",
-		"@wordpress/api-fetch": "7.35",
+		"@wordpress/api-fetch": "7.29",
 		"@wordpress/babel-preset-default": "^7.42.0",
 		"@wordpress/block-editor": "^15.6.0",
 		"@wordpress/blocks": "^15.8.0",

--- a/src/content-helper/common/providers/base-provider.tsx
+++ b/src/content-helper/common/providers/base-provider.tsx
@@ -143,7 +143,7 @@ export abstract class BaseProvider {
 	 *
 	 * @return {Promise<ContentHelperAPIResponse<any>>} The fetched data.
 	 */
-	protected async fetch<T>( options: APIFetchOptions<true>, id?: string ): Promise<T> {
+	protected async fetch<T>( options: APIFetchOptions, id?: string ): Promise<T> {
 		const { abortController, abortId } = this.getOrCreateController( id );
 		options.signal = abortController.signal;
 


### PR DESCRIPTION
Reverts Parsely/wp-parsely#3816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Downgraded WordPress API dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->