### PR TITLE
Release wp-parsely 3.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.21.2](https://github.com/Parsely/wp-parsely/compare/3.21.1...3.21.2) - 2025-12-02
+
+### Dependency Updates
+
+- The list of all dependency updates for this release is available [here](https://github.com/Parsely/wp-parsely/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.21.2+label%3ADeps).
+
 ## [3.21.1](https://github.com/Parsely/wp-parsely/compare/3.21.0...3.21.1) - 2025-10-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.21.1  
+Stable tag: 3.21.2  
 Requires at least: 6.0  
 Tested up to: 6.8  
 Requires PHP: 7.4  

--- a/package-lock.json
+++ b/package-lock.json
@@ -3119,6 +3119,20 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
 		"node_modules/@istanbuljs/schema": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -9411,6 +9425,20 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/@wordpress/env/node_modules/js-yaml": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
 		"node_modules/@wordpress/env/node_modules/minimatch": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -12434,6 +12462,23 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/callsites": {
@@ -15946,40 +15991,40 @@
 			"license": "MIT"
 		},
 		"node_modules/express": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-			"integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+			"integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.20.3",
-				"content-disposition": "0.5.4",
+				"body-parser": "~1.20.3",
+				"content-disposition": "~0.5.4",
 				"content-type": "~1.0.4",
-				"cookie": "0.7.1",
-				"cookie-signature": "1.0.6",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
 				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"finalhandler": "1.3.1",
-				"fresh": "0.5.2",
-				"http-errors": "2.0.0",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
 				"merge-descriptors": "1.0.3",
 				"methods": "~1.1.2",
-				"on-finished": "2.4.1",
+				"on-finished": "~2.4.1",
 				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.12",
+				"path-to-regexp": "~0.1.12",
 				"proxy-addr": "~2.0.7",
-				"qs": "6.13.0",
+				"qs": "~6.14.0",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
-				"send": "0.19.0",
-				"serve-static": "1.16.2",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
 				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
+				"statuses": "~2.0.1",
 				"type-is": "~1.6.18",
 				"utils-merge": "1.0.1",
 				"vary": "~1.1.2"
@@ -16025,6 +16070,22 @@
 			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/express/node_modules/qs": {
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/extract-zip": {
 			"version": "1.7.0",
@@ -19599,20 +19660,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
-		},
 		"node_modules/jsbn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
@@ -20991,9 +21038,9 @@
 			}
 		},
 		"node_modules/node-forge": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-			"integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+			"integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
 			"dev": true,
 			"license": "(BSD-3-Clause OR GPL-2.0)",
 			"engines": {
@@ -21283,9 +21330,9 @@
 			"license": "MIT"
 		},
 		"node_modules/object-inspect": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-			"integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -25039,16 +25086,73 @@
 			}
 		},
 		"node_modules/side-channel": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
 				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.4",
-				"object-inspect": "^1.13.1"
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.21.1",
+	"version": "3.21.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.21.1",
+			"version": "3.21.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -90,10 +90,16 @@
 		"@wordpress/scripts": "Don't upgrade to v28 or greater until the plugin requires WordPress 6.6. See https://github.com/WordPress/gutenberg/pull/62265/files"
 	},
 	"overrides": {
+		"express": "^4.22.0",
+		"js-yaml@^3": "3.14.2",
+		"node-forge": "^1.3.2",
 		"puppeteer-core": "^23.1.0"
 	},
 	"overridesComments": {
-		"puppeteer-core": "Remove once we have upgraded @wordpress/scripts to v29 or greater. See https://github.com/WordPress/gutenberg/pull/64597"
+		"express": "Security update to v4.22.0 or later. Keep until @wordpress/scripts gets upgraded.",
+		"js-yaml@^3": "Security update to v3.14.2. Keep until @wordpress/scripts gets upgraded.",
+		"node-forge": "Security update to v1.3.2 or later. Keep until @wordpress/scripts gets upgraded.",
+		"puppeteer-core": "Security update to v23.1.0 or later. Keep until @wordpress/scripts gets upgraded."
 	},
 	"scripts": {
 		"build": "wp-scripts build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.21.1",
+	"version": "3.21.2",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import { type Page } from '@playwright/test';
  */
 import { Admin } from '@wordpress/e2e-test-utils-playwright';
 
-export const PLUGIN_VERSION = '3.21.1';
+export const PLUGIN_VERSION = '3.21.2';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.21.1
+ * Version:           3.21.2
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -50,7 +50,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION             = '3.21.1';
+const PARSELY_VERSION             = '3.21.2';
 const PARSELY_FILE                = __FILE__;
 const PARSELY_DATA_SCHEMA_VERSION = '1';
 const PARSELY_CACHE_GROUP         = 'wp-parsely';


### PR DESCRIPTION
This PR merges the `develop` branch into the `trunk` branch in order to release wp-parsely 3.21.2.