### PR TITLE
Fix integration test errors on PHP 8.5

### DIFF
--- a/tests/Integration/ContentHelper/ContentHelperPostListStatsTest.php
+++ b/tests/Integration/ContentHelper/ContentHelperPostListStatsTest.php
@@ -1297,7 +1297,7 @@ final class ContentHelperPostListStatsTest extends ContentHelperFeatureTest {
 
 		// Replace the original API with the mock, using reflection.
 		$api_reflection = new ReflectionProperty( $obj, 'content_api' );
-		$api_reflection->setAccessible( true );
+		self::make_accessible( $api_reflection );
 		$api_reflection->setValue( $obj, $api );
 
 		return $obj->get_parsely_stats_response();

--- a/tests/Integration/HeadlineTestingScriptsTest.php
+++ b/tests/Integration/HeadlineTestingScriptsTest.php
@@ -31,16 +31,6 @@ final class HeadlineTestingScriptsTest extends TestCase {
 	private static $headline_testing;
 
 	/**
-	 * One-line script string used in assertions.
-	 *
-	 * @since 3.21.0
-	 *
-	 * @var string $one_line_script_string Holds the one-line script string.
-	 */
-	private static $one_line_script_string = 'src="https://experiments.parsely.com/vip-experiments.js?apiKey=demoaccount.parsely.com&amp;ver='
-		. PARSELY_VERSION . '" id="parsely-headline-testing-one-line-js"';
-
-	/**
 	 * Advanced script string used in assertions.
 	 *
 	 * @since 3.21.0
@@ -262,7 +252,7 @@ final class HeadlineTestingScriptsTest extends TestCase {
 		$output = (string) ob_get_clean();
 
 		// Markup should contain the one-line script and not the advanced script.
-		self::assertStringContainsString( self::$one_line_script_string, $output );
+		$this->assert_one_line_script_in_output( $output );
 		self::assertStringNotContainsString( self::$advanced_script_string, $output );
 	}
 
@@ -307,10 +297,7 @@ final class HeadlineTestingScriptsTest extends TestCase {
 		$output = (string) ob_get_clean();
 
 		// Markup should contain the one-line script with the option's attribute.
-		self::assertStringContainsString(
-			self::$one_line_script_string . ' data-enable-live-updates="true"',
-			$output
-		);
+		$this->assert_one_line_script_in_output( $output, array( 'data-enable-live-updates' => 'true' ) );
 		self::assertStringNotContainsString( self::$advanced_script_string, $output );
 	}
 
@@ -410,7 +397,7 @@ final class HeadlineTestingScriptsTest extends TestCase {
 
 		// Markup should contain the advanced script and not the one-line script.
 		self::assertStringContainsString( self::$advanced_script_string, $output );
-		self::assertStringNotContainsString( self::$one_line_script_string, $output );
+		$this->assert_one_line_script_not_in_output( $output );
 	}
 
 	/**
@@ -460,7 +447,7 @@ final class HeadlineTestingScriptsTest extends TestCase {
 		// Markup should contain the advanced script with the option's config.
 		self::assertStringContainsString( self::$advanced_script_string, $output );
 		self::assertStringContainsString( 'enableLiveUpdates: true', $output );
-		self::assertStringNotContainsString( self::$one_line_script_string, $output );
+		$this->assert_one_line_script_not_in_output( $output );
 	}
 
 	/**
@@ -483,5 +470,43 @@ final class HeadlineTestingScriptsTest extends TestCase {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Asserts that the one-line headline testing script tag is present in the
+	 * given HTML output.
+	 *
+	 * Uses a regex with lookaheads to verify each attribute independently,
+	 * making the assertion robust against WordPress changes to attribute order
+	 * or HTML entity encoding variants (e.g. &amp; vs &#038;).
+	 *
+	 * @since 3.22.1
+	 *
+	 * @param string               $output      The HTML output to search.
+	 * @param array<string,string> $extra_attrs Optional extra attributes to assert on the tag.
+	 */
+	private function assert_one_line_script_in_output( string $output, array $extra_attrs = array() ): void {
+		$version    = preg_quote( PARSELY_VERSION, '~' );
+		$lookaheads = '(?=[^>]*\bid="parsely-headline-testing-one-line-js")'
+			. '(?=[^>]*\bsrc="https://experiments\.parsely\.com/vip-experiments\.js'
+			. '\?apiKey=demoaccount\.parsely\.com(?:&amp;|&#038;)ver=' . $version . '")';
+
+		foreach ( $extra_attrs as $attr => $value ) {
+			$lookaheads .= '(?=[^>]*\b' . preg_quote( $attr, '~' ) . '="' . preg_quote( $value, '~' ) . '")';
+		}
+
+		self::assertMatchesRegularExpression( '~<script' . $lookaheads . '~', $output );
+	}
+
+	/**
+	 * Asserts that the one-line headline testing script tag is not present in
+	 * the given HTML output.
+	 *
+	 * @since 3.22.1
+	 *
+	 * @param string $output The HTML output to search.
+	 */
+	private function assert_one_line_script_not_in_output( string $output ): void {
+		self::assertStringNotContainsString( 'id="parsely-headline-testing-one-line-js"', $output );
 	}
 }

--- a/tests/Integration/Integrations/IntegrationsTest.php
+++ b/tests/Integration/Integrations/IntegrationsTest.php
@@ -43,7 +43,7 @@ final class IntegrationsTest extends TestCase {
 
 		// Use Reflection to look inside the collection.
 		$reflector_property = ( new ReflectionClass( $integrations ) )->getProperty( 'integrations' );
-		$reflector_property->setAccessible( true );
+		self::make_accessible( $reflector_property );
 		/**
 		 * Variable.
 		 *

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -653,7 +653,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 		$reflector = new ReflectionClass( $class_name );
 		$property  = $reflector->getProperty( $property_name );
 
-		$property->setAccessible( true );
+		self::make_accessible( $property );
 
 		return $property;
 	}
@@ -669,7 +669,7 @@ abstract class TestCase extends WPIntegrationTestCase {
 		$reflector = new ReflectionClass( $class_name );
 		$method    = $reflector->getMethod( $method );
 
-		$method->setAccessible( true );
+		self::make_accessible( $method );
 
 		return $method;
 	}

--- a/tests/Traits/TestsReflection.php
+++ b/tests/Traits/TestsReflection.php
@@ -20,6 +20,8 @@ trait TestsReflection {
 	 * 8.1, where setAccessible() is required. It is a no-op since PHP 8.1
 	 * and deprecated since PHP 8.5.
 	 *
+	 * @since 3.22.1
+	 *
 	 * @param ReflectionMethod|ReflectionProperty $reflection The reflection object.
 	 */
 	public static function make_accessible( object $reflection ): void {

--- a/tests/Traits/TestsReflection.php
+++ b/tests/Traits/TestsReflection.php
@@ -16,6 +16,19 @@ use ReflectionProperty;
 
 trait TestsReflection {
 	/**
+	 * Makes a ReflectionMethod or ReflectionProperty accessible on PHP below
+	 * 8.1, where setAccessible() is required. It is a no-op since PHP 8.1
+	 * and deprecated since PHP 8.5.
+	 *
+	 * @param ReflectionMethod|ReflectionProperty $reflection The reflection object.
+	 */
+	public static function make_accessible( object $reflection ): void {
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflection->setAccessible( true );
+		}
+	}
+
+	/**
 	 * Gets a method from a class. This should be used when trying to access a
 	 * private method for testing.
 	 *
@@ -26,7 +39,7 @@ trait TestsReflection {
 	 */
 	public static function get_method( string $method_name, $class_name = Parsely::class ): \ReflectionMethod {
 		$method = ( new \ReflectionClass( $class_name ) )->getMethod( $method_name );
-		$method->setAccessible( true );
+		self::make_accessible( $method );
 
 		return $method;
 	}
@@ -44,7 +57,7 @@ trait TestsReflection {
 	 */
 	public static function get_property( string $property_name, $class_name = Parsely::class ) {
 		$property = ( new \ReflectionClass( $class_name ) )->getProperty( $property_name );
-		$property->setAccessible( true );
+		self::make_accessible( $property );
 
 		return $property;
 	}
@@ -52,9 +65,6 @@ trait TestsReflection {
 	/**
 	 * Overrides the value of a private property on a given object. This is
 	 * useful when mocking the internals of a class.
-	 *
-	 * Note that the property will no longer be private after setAccessible is
-	 * called.
 	 *
 	 * @since 3.17.0 Changed the method signature.
 	 *
@@ -66,16 +76,13 @@ trait TestsReflection {
 	 */
 	public static function set_private_property( $obj, string $property_name, $value ): void {
 		$property = ( new \ReflectionClass( $obj ) )->getProperty( $property_name );
-		$property->setAccessible( true );
+		self::make_accessible( $property );
 		$property->setValue( $obj, $value );
 	}
 
 	/**
 	 * Overrides the value of a protected property on a given object. This is
 	 * useful when mocking the internals of a class.
-	 *
-	 * Note that the property will no longer be protected after setAccessible is
-	 * called.
 	 *
 	 * @since 3.17.0
 	 *
@@ -88,7 +95,7 @@ trait TestsReflection {
 	public static function set_protected_property( $obj, string $property_name, $value ): void {
 		$reflection = new \ReflectionClass( $obj );
 		$property   = $reflection->getProperty( $property_name );
-		$property->setAccessible( true );
+		self::make_accessible( $property );
 		$property->setValue( $obj, $value );
 	}
 }

--- a/tests/Unit/Integrations/IntegrationsTest.php
+++ b/tests/Unit/Integrations/IntegrationsTest.php
@@ -12,6 +12,7 @@ namespace Parsely\Tests\Unit\Integrations;
 use Parsely\Integrations\Integration;
 use Parsely\Integrations\Integrations;
 use Parsely\Parsely;
+use Parsely\Tests\Traits\TestsReflection;
 use ReflectionClass;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
@@ -19,6 +20,8 @@ use Yoast\WPTestUtils\BrainMonkey\TestCase;
  * Unit Tests for the Integrations collection.
  */
 final class IntegrationsTest extends TestCase {
+	use TestsReflection;
+
 	/**
 	 * Internal variable.
 	 *
@@ -49,7 +52,7 @@ final class IntegrationsTest extends TestCase {
 		// Use Reflection to look inside the collection.
 		$reflector          = new ReflectionClass( $integrations );
 		$reflector_property = $reflector->getProperty( 'integrations' );
-		$reflector_property->setAccessible( true );
+		self::make_accessible( $reflector_property );
 		/**
 		 * Variable.
 		 *


### PR DESCRIPTION
## Description
With this PR, we're fixing integration test errors on PHP 8.5.

## Motivation and context
Failing integration tests were inhibiting our workflow

## How has this been tested?
Integration tests now pass on PHP 8.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test utilities with centralized reflection helper methods for enhanced code consistency.

* **Refactor**
  * Consolidated reflection property accessibility handling across test suite for better maintainability and reduced code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->