### PR TITLE
README.md: Update "Tested up to" to 6.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Stable tag: 3.22.0  
 Requires at least: 6.0  
-Tested up to: 6.8  
+Tested up to: 6.9  
 Requires PHP: 7.4  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  


### PR DESCRIPTION
## Description
This PR updates the "Tested up to" field of `README.md` to `6.9`.

## Motivation and Context
Keep our `README.md` updated with the latest information.

## How Has This Been Tested?
- Current tests pass. Our integration tests are running against WP [latest/trunk](https://github.com/Parsely/wp-parsely/blob/1a867b3065c83a22fbd2ad64fab10ca66d5ddf3c/.github/workflows/integration-tests.yml#L33-L43) and our E2E tests against latest stable through `wp-env`.
- No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated compatibility information to indicate testing support for version 6.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->