### PR TITLE
Add blank lines to render lists correctly in plugin listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The wp-parsely plugin is packed with features that allow for a seamless integrat
 #### Automated integration
 
 The plugin automatically inserts the Parse.ly metadata and JavaScript in all published pages and posts (Custom Post Types are supported). It also provides a settings page to customize your integration, with options including:
+
 - Output Parse.ly metadata as [JSON-LD](https://docs.parse.ly/metadata-jsonld/) or [repeated meta tags](https://docs.parse.ly/metatags/).
 - Choose whether logged-in users should be tracked.
 - Define how to track every Post Type (as Post, Non-Post or no tracking).
@@ -37,6 +38,7 @@ The plugin automatically inserts the Parse.ly metadata and JavaScript in all pub
 #### Parse.ly Content Intelligence
 
 [Content Intelligence](https://docs.parse.ly/plugin-content-intelligence/) is a set of content insight tools including:
+
 - The [Parse.ly Dashboard Widget](https://docs.parse.ly/plugin-content-intelligence/#h-dashboard) - Displays the site's top posts in the WordPress Dashboard.
 - The [Parse.ly Stats Column](https://docs.parse.ly/plugin-content-intelligence/#h-posts) - Displays published post performance for the last 7 days in Post Lists.
 - The [Engagement Boost](https://docs.wpvip.com/parse-ly/parsely-features/engagement-boost/) feature - Helps you increase page views and engagement by strategically placing links to key content within high-performing articles on your site.
@@ -54,6 +56,7 @@ The plugin includes a [Recommendations Block](https://docs.parse.ly/recommendati
 #### Advanced integrations support
 
 While the plugin works out of the box for basic integrations, it offers a host of features that easily allow for advanced integration scenarios:
+
 - Support for [Google Tag Manager, AMP, Google Web Stories and Cloudflare](https://docs.parse.ly/plugin-common-questions/#h-is-wp-parsely-compatible-with-amp-or-google-web-stories) is included.
 - The plugin exposes the `wpParselyOnLoad` and `wpParselyOnReady` JavaScript hooks that allow for advanced integrations requiring JavaScript, such as [Dynamic Tracking](https://docs.parse.ly/plugin-dynamic-tracking/).
 - Support for WordPress [network/multisite](https://docs.parse.ly/plugin-common-questions/#h-is-wp-parsely-compatible-with-wordpress-network-multisite) and [decoupled/headless](https://docs.parse.ly/decoupled-set-up/) (GraphQL and WP Rest API) setups is included.


### PR DESCRIPTION
## Description

This PR adds some blank lines to fix how lists are rendered in the [plugin directory listing](https://wordpress.org/plugins/wp-parsely/) for Parse.ly.

## Motivation and context

In the absence of blank lines around the list, the lists are rendered like regular paragraphs and not converted to `<ul>`. 
<img width="753" height="187" alt="Screenshot 2026-04-21 at 6 36 38 PM" src="https://github.com/user-attachments/assets/e4e9da5c-0b4b-4f86-ac5f-07db481cf156" />

This also means that nested lists become flattened.
<img width="783" height="480" alt="Screenshot 2026-04-21 at 6 37 37 PM" src="https://github.com/user-attachments/assets/8ac1e614-27d3-4d62-9200-49f285cae9ad" />

Lists with blank lines padding the list render correctly.
<img width="312" height="144" alt="Screenshot 2026-04-21 at 6 38 05 PM" src="https://github.com/user-attachments/assets/e2a5ddef-6431-4d2a-ba76-85a0e7e7d7b3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting in the README.md feature sections with enhanced spacing for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->