### PR TITLE
Fix `_parsely_canonical_url` storing an `http` scheme on `https` sites

### DIFF
--- a/src/rest-api/stats/trait-post-data.php
+++ b/src/rest-api/stats/trait-post-data.php
@@ -146,13 +146,13 @@ trait Post_Data_Trait {
 			$post_id  = Utils::get_post_id_by_url( $item['url'] );
 			$post_url = Parsely::get_url_with_itm_source( $item['url'], null );
 
+			if ( Utils::parsely_is_https_supported() ) {
+				$post_url = str_replace( 'http://', 'https://', $post_url );
+			}
+
 			// If we have a post ID, update the post canonical URL.
 			if ( 0 !== $post_id ) {
 				Parsely::set_canonical_url( $post_id, $post_url );
-			}
-
-			if ( Utils::parsely_is_https_supported() ) {
-				$post_url = str_replace( 'http://', 'https://', $post_url );
 			}
 
 			$data['rawUrl']  = $post_url;

--- a/tests/Integration/RestAPI/Stats/EndpointStatsPostTest.php
+++ b/tests/Integration/RestAPI/Stats/EndpointStatsPostTest.php
@@ -649,4 +649,199 @@ class EndpointStatsPostTest extends BaseEndpointTest {
 			$response_data['data']
 		);
 	}
+
+	/**
+	 * Verifies that the canonical URL saved to post meta uses the https scheme
+	 * when the site supports https, even when the Parse.ly API returns an
+	 * http URL.
+	 *
+	 * @since 3.24.0
+	 *
+	 * @covers \Parsely\REST_API\Stats\Endpoint_Post::get_post_details
+	 * @uses \Parsely\Parsely::api_secret_is_set
+	 * @uses \Parsely\Parsely::get_api_secret
+	 * @uses \Parsely\Parsely::get_canonical_url
+	 * @uses \Parsely\Parsely::get_dash_url
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::get_site_id
+	 * @uses \Parsely\Parsely::get_url_with_itm_source
+	 * @uses \Parsely\Parsely::set_canonical_url
+	 * @uses \Parsely\Parsely::set_default_content_helper_settings_values
+	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
+	 * @uses \Parsely\Parsely::site_id_is_set
+	 * @uses \Parsely\Permissions::build_pch_permissions_settings_array
+	 * @uses \Parsely\Permissions::get_user_roles_with_edit_posts_cap
+	 * @uses \Parsely\REST_API\Base_API_Controller::__construct
+	 * @uses \Parsely\REST_API\Base_API_Controller::get_full_namespace
+	 * @uses \Parsely\REST_API\Base_API_Controller::get_parsely
+	 * @uses \Parsely\REST_API\Base_API_Controller::prefix_route
+	 * @uses \Parsely\REST_API\Base_Endpoint::__construct
+	 * @uses \Parsely\REST_API\Base_Endpoint::apply_capability_filters
+	 * @uses \Parsely\REST_API\Base_Endpoint::get_default_access_capability
+	 * @uses \Parsely\REST_API\Base_Endpoint::get_full_endpoint
+	 * @uses \Parsely\REST_API\Base_Endpoint::init
+	 * @uses \Parsely\REST_API\Base_Endpoint::is_available_to_current_user
+	 * @uses \Parsely\REST_API\Base_Endpoint::register_rest_route
+	 * @uses \Parsely\REST_API\Base_Endpoint::validate_site_id_and_secret
+	 * @uses \Parsely\REST_API\REST_API_Controller::get_namespace
+	 * @uses \Parsely\REST_API\REST_API_Controller::get_version
+	 * @uses \Parsely\REST_API\Stats\Endpoint_Post::__construct
+	 * @uses \Parsely\REST_API\Stats\Endpoint_Post::get_endpoint_name
+	 * @uses \Parsely\REST_API\Stats\Endpoint_Post::register_routes
+	 * @uses \Parsely\REST_API\Stats\Post_Data_Trait::extract_post_data
+	 * @uses \Parsely\REST_API\Stats\Post_Data_Trait::get_itm_source_param_args
+	 * @uses \Parsely\REST_API\Stats\Post_Data_Trait::set_itm_source_from_request
+	 * @uses \Parsely\REST_API\Stats\Related_Posts_Trait::get_related_posts_param_args
+	 * @uses \Parsely\REST_API\Stats\Stats_Controller::get_route_prefix
+	 * @uses \Parsely\REST_API\Use_Post_ID_Parameter_Trait::register_rest_route_with_post_id
+	 * @uses \Parsely\REST_API\Use_Post_ID_Parameter_Trait::validate_post_id
+	 * @uses \Parsely\Utils\Utils::convert_endpoint_to_filter_key
+	 * @uses \Parsely\Utils\Utils::get_formatted_duration
+	 * @uses \Parsely\Utils\Utils::get_post_id_by_url
+	 * @uses \Parsely\Utils\Utils::parsely_is_https_supported
+	 */
+	public function test_get_details_stores_canonical_url_with_https_scheme(): void {
+		$test_post_id = $this->create_test_post();
+		$route        = $this->get_endpoint()->get_full_endpoint( '/' . $test_post_id . '/details' );
+
+		TestCase::set_options(
+			array(
+				'apikey'     => 'example.com',
+				'api_secret' => 'test-secret',
+			)
+		);
+		$this->set_current_user_to_admin();
+
+		// Make the site https, so that Utils::parsely_is_https_supported()
+		// returns true.
+		$https_filter = function (): string {
+			return 'https://example.org';
+		};
+		add_filter( 'option_home', $https_filter );
+		add_filter( 'option_siteurl', $https_filter );
+
+		// Return an http URL from the API, as happens for sites that Parse.ly
+		// first crawled before an https migration.
+		add_filter(
+			'pre_http_request',
+			$http_request_filter = function () use ( $test_post_id ): array {
+				return array(
+					'body' => '
+						{"data":[{
+							"metrics": { "views": 1 },
+							"url": "http://example.org/?p=' . $test_post_id . '"
+						}]}
+					',
+				);
+			}
+		);
+
+		rest_get_server()->dispatch( new WP_REST_Request( 'GET', $route ) );
+
+		$stored_canonical_url = get_post_meta( $test_post_id, '_parsely_canonical_url', true );
+
+		remove_filter( 'pre_http_request', $http_request_filter );
+		remove_filter( 'option_siteurl', $https_filter );
+		remove_filter( 'option_home', $https_filter );
+
+		self::assertIsString( $stored_canonical_url );
+		self::assertStringStartsWith( 'https://', $stored_canonical_url );
+	}
+
+	/**
+	 * Verifies that the canonical URL saved to post meta keeps the http scheme
+	 * when the site does not support https.
+	 *
+	 * @since 3.24.0
+	 *
+	 * @covers \Parsely\REST_API\Stats\Endpoint_Post::get_post_details
+	 * @uses \Parsely\Parsely::api_secret_is_set
+	 * @uses \Parsely\Parsely::get_api_secret
+	 * @uses \Parsely\Parsely::get_canonical_url
+	 * @uses \Parsely\Parsely::get_dash_url
+	 * @uses \Parsely\Parsely::get_managed_credentials
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::get_site_id
+	 * @uses \Parsely\Parsely::get_url_with_itm_source
+	 * @uses \Parsely\Parsely::set_canonical_url
+	 * @uses \Parsely\Parsely::set_default_content_helper_settings_values
+	 * @uses \Parsely\Parsely::set_default_full_metadata_in_non_posts
+	 * @uses \Parsely\Parsely::site_id_is_set
+	 * @uses \Parsely\Permissions::build_pch_permissions_settings_array
+	 * @uses \Parsely\Permissions::get_user_roles_with_edit_posts_cap
+	 * @uses \Parsely\REST_API\Base_API_Controller::__construct
+	 * @uses \Parsely\REST_API\Base_API_Controller::get_full_namespace
+	 * @uses \Parsely\REST_API\Base_API_Controller::get_parsely
+	 * @uses \Parsely\REST_API\Base_API_Controller::prefix_route
+	 * @uses \Parsely\REST_API\Base_Endpoint::__construct
+	 * @uses \Parsely\REST_API\Base_Endpoint::apply_capability_filters
+	 * @uses \Parsely\REST_API\Base_Endpoint::get_default_access_capability
+	 * @uses \Parsely\REST_API\Base_Endpoint::get_full_endpoint
+	 * @uses \Parsely\REST_API\Base_Endpoint::init
+	 * @uses \Parsely\REST_API\Base_Endpoint::is_available_to_current_user
+	 * @uses \Parsely\REST_API\Base_Endpoint::register_rest_route
+	 * @uses \Parsely\REST_API\Base_Endpoint::validate_site_id_and_secret
+	 * @uses \Parsely\REST_API\REST_API_Controller::get_namespace
+	 * @uses \Parsely\REST_API\REST_API_Controller::get_version
+	 * @uses \Parsely\REST_API\Stats\Endpoint_Post::__construct
+	 * @uses \Parsely\REST_API\Stats\Endpoint_Post::get_endpoint_name
+	 * @uses \Parsely\REST_API\Stats\Endpoint_Post::register_routes
+	 * @uses \Parsely\REST_API\Stats\Post_Data_Trait::extract_post_data
+	 * @uses \Parsely\REST_API\Stats\Post_Data_Trait::get_itm_source_param_args
+	 * @uses \Parsely\REST_API\Stats\Post_Data_Trait::set_itm_source_from_request
+	 * @uses \Parsely\REST_API\Stats\Related_Posts_Trait::get_related_posts_param_args
+	 * @uses \Parsely\REST_API\Stats\Stats_Controller::get_route_prefix
+	 * @uses \Parsely\REST_API\Use_Post_ID_Parameter_Trait::register_rest_route_with_post_id
+	 * @uses \Parsely\REST_API\Use_Post_ID_Parameter_Trait::validate_post_id
+	 * @uses \Parsely\Utils\Utils::convert_endpoint_to_filter_key
+	 * @uses \Parsely\Utils\Utils::get_formatted_duration
+	 * @uses \Parsely\Utils\Utils::get_post_id_by_url
+	 * @uses \Parsely\Utils\Utils::parsely_is_https_supported
+	 */
+	public function test_get_details_keeps_http_canonical_url_without_https_support(): void {
+		$test_post_id = $this->create_test_post();
+		$route        = $this->get_endpoint()->get_full_endpoint( '/' . $test_post_id . '/details' );
+
+		TestCase::set_options(
+			array(
+				'apikey'     => 'example.com',
+				'api_secret' => 'test-secret',
+			)
+		);
+		$this->set_current_user_to_admin();
+
+		// Make the site http-only, so that Utils::parsely_is_https_supported()
+		// returns false and no scheme rewriting should occur.
+		$http_filter = function (): string {
+			return 'http://example.org';
+		};
+		add_filter( 'option_home', $http_filter );
+		add_filter( 'option_siteurl', $http_filter );
+
+		add_filter(
+			'pre_http_request',
+			$http_request_filter = function () use ( $test_post_id ): array {
+				return array(
+					'body' => '
+						{"data":[{
+							"metrics": { "views": 1 },
+							"url": "http://example.org/?p=' . $test_post_id . '"
+						}]}
+					',
+				);
+			}
+		);
+
+		rest_get_server()->dispatch( new WP_REST_Request( 'GET', $route ) );
+
+		$stored_canonical_url = get_post_meta( $test_post_id, '_parsely_canonical_url', true );
+
+		remove_filter( 'pre_http_request', $http_request_filter );
+		remove_filter( 'option_siteurl', $http_filter );
+		remove_filter( 'option_home', $http_filter );
+
+		self::assertIsString( $stored_canonical_url );
+		self::assertStringStartsWith( 'http://', $stored_canonical_url );
+	}
 }


### PR DESCRIPTION
## Description

While digging into an `http://` URL that had turned up in `_parsely_canonical_url` on an https-only site, we traced it back to the order of two blocks in `Post_Data_Trait::extract_post_data()`.

This moves the https normalization above the `set_canonical_url()` call, so the URL that gets saved is the same normalized one already used for the response fields. It is a straight statement reorder, with no change to logic.

## Motivation and context

In `src/rest-api/stats/trait-post-data.php`, `$post_url` comes from `$item['url']`, which is whatever the Parse.ly API returned. That is often `http://` for sites Parse.ly first crawled before an https migration. The meta was being written first, with the normalization running just after:

```php
$post_url = Parsely::get_url_with_itm_source( $item['url'], null );

// Saves the raw value.
if ( 0 !== $post_id ) {
    Parsely::set_canonical_url( $post_id, $post_url );
}

// Only updates the local variable, which the response fields below use.
if ( Utils::parsely_is_https_supported() ) {
    $post_url = str_replace( 'http://', 'https://', $post_url );
}
```

So `rawUrl`, `dashUrl`, `id` and `url` all came out correct, and only the saved value kept the original scheme.

Two things stop it from correcting itself:

The stored value sticks. `get_canonical_url_from_post()` prefers the meta and only falls back to `get_permalink()` when it is empty, so once an `http` value is written it keeps winning over the correct permalink.

Nothing further down catches it either. `set_canonical_url()` runs the value through `sanitize_url( $canonical_url, array( 'http', 'https' ) )`, which allows `http`, and `get_canonical_url()` only swaps the host for the Site ID without looking at the scheme. From there it reaches `canonical_url` in the REST metadata endpoint and the Smart Links suggestion payloads, so those can end up carrying an `http` canonical for an https page.

It is also written when the stats sidebar loads rather than on save, which makes it hard to attribute. We found it on a post that had not been edited for five days.

### A note on scope

`Utils::get_post_id_by_url( $item['url'] )` still uses the original, unnormalized URL. It works as it is, and changing it could affect post matching, so it seemed better left alone.

A broader fix would be to normalize inside `set_canonical_url()`, which would also cover the two callers in `src/Models/class-smart-link.php` (lines 670 and 699) that take a caller-supplied URL and look to have the same exposure. That changes the behavior of a public static method, so we left it as your call. Happy to switch if you would prefer it.

Either way, meta already written by affected versions will not fix itself, because of the precedence above. Normalizing on read in `get_canonical_url_from_post()`, or a small migration, would clear those out. Happy to add either if useful.

## How has this been tested?

There are two new tests in `EndpointStatsPostTest.php`, one for each side of the `Utils::parsely_is_https_supported()` condition. Both mock `pre_http_request` to return an `http://` URL for a test post, dispatch the endpoint, and check the saved `_parsely_canonical_url`. They assert on the scheme rather than the whole URL, to stay clear of the Site ID host swap in `get_canonical_url()`.

- `test_get_details_stores_canonical_url_with_https_scheme` forces `home_url()` and `site_url()` to https, and expects the saved value to be `https://`.
- `test_get_details_keeps_http_canonical_url_without_https_support` leaves the site http-only, and expects the saved value to stay `http://`.

The second test guards the http-only path, which this change should leave exactly as it was.

Run against the unfixed code, the https test fails and the http-only one still passes:

```
✔ Get details keeps http canonical url without https support
✘ Get details stores canonical url with https scheme
  Failed asserting that 'http://example.com/?p=4' starts with "https://".
```

With the fix, both pass. So the only behavior that changes is the https case.

The tests are in the first commit and the fix in the second, which does mean the first commit is red on its own. Happy to squash or reorder if you would rather it were not.

Everything run locally against `wp-env`, on PHP 8.3 with WordPress 7.0.2:

- `composer testwp`: 497 tests, 1509 assertions, no failures. The 3 skips are the usual multisite ones on a single-site run.
- `composer cs`: clean.
- `php lint.php`: clean.
- `vendor/bin/phpstan analyse`: 21 errors, but all of them are already there on `develop` with these changes stashed, so none are introduced here. They look to be an artifact of running the analysis on PHP 8.3 while the project targets 7.4, and phpstan does not appear to run in CI. Glad to look at them separately if that would be useful.

`CanonicalURLsTest.php` also still passes untouched, which is what we would expect given `set_canonical_url()` itself is unchanged.

Thanks for taking a look.

## Screenshots (if appropriate)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Canonical post URLs in statistics are now correctly saved with HTTPS when the site supports secure connections.
  * HTTP-only sites continue to preserve HTTP canonical URLs.

* **Tests**
  * Added coverage verifying canonical URL persistence for both HTTPS-enabled and HTTP-only sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->