### PR TITLE
Add remaining per-post permission checks in Content Intelligence

### DIFF
--- a/src/UI/class-row-actions.php
+++ b/src/UI/class-row-actions.php
@@ -137,7 +137,8 @@ final class Row_Actions {
 	public function row_actions_add_engagement_boost_link( array $actions, WP_Post $post ): array {
 		if ( ! Permissions::current_user_can_use_pch_feature(
 			'traffic_boost',
-			$this->parsely->get_options()['content_helper']
+			$this->parsely->get_options()['content_helper'],
+			$post->ID
 		) ) {
 			return $actions;
 		}

--- a/src/rest-api/content-helper/class-endpoint-smart-linking.php
+++ b/src/rest-api/content-helper/class-endpoint-smart-linking.php
@@ -533,7 +533,8 @@ class Endpoint_Smart_Linking extends Base_Endpoint {
 			if ( $post_id > 0 ) {
 				$post = get_post( $post_id );
 
-				if ( null !== $post ) {
+				// URLs resolve by slug, irrespective of the post's status.
+				if ( null !== $post && current_user_can( 'read_post', $post_id ) ) {
 					$post_type_obj  = get_post_type_object( $post->post_type );
 					$post_type_name = $post_type_obj instanceof \WP_Post_Type ? $post_type_obj->labels->singular_name : '';
 

--- a/src/rest-api/content-helper/class-endpoint-traffic-boost.php
+++ b/src/rest-api/content-helper/class-endpoint-traffic-boost.php
@@ -624,7 +624,7 @@ class Endpoint_Traffic_Boost extends Base_Endpoint {
 	 * @since 3.19.0
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 * @return WP_REST_Response The response object.
+	 * @return WP_REST_Response|WP_Error The response object.
 	 */
 	public function discard_suggestion( WP_REST_Request $request ) {
 		/**
@@ -633,6 +633,13 @@ class Endpoint_Traffic_Boost extends Base_Endpoint {
 		 * @var Inbound_Smart_Link $inbound_link
 		 */
 		$inbound_link = $request->get_param( 'inbound_link' );
+
+		$source_post_access = $this->validate_source_post_access(
+			$inbound_link->source_post_id
+		);
+		if ( is_wp_error( $source_post_access ) ) {
+			return $source_post_access;
+		}
 
 		$deleted = $inbound_link->delete();
 

--- a/tests/Integration/RestAPI/ContentHelper/EndpointSmartLinkingAuthorizationTest.php
+++ b/tests/Integration/RestAPI/ContentHelper/EndpointSmartLinkingAuthorizationTest.php
@@ -20,6 +20,7 @@ use Parsely\REST_API\Content_Helper\Content_Helper_Controller;
 use Parsely\REST_API\Content_Helper\Endpoint_Smart_Linking;
 use Parsely\Tests\Integration\TestCase;
 use WP_Error;
+use WP_Post;
 use WP_REST_Request;
 
 /**
@@ -51,6 +52,27 @@ class EndpointSmartLinkingAuthorizationTest extends TestCase {
 	 * @var int
 	 */
 	private int $other_users_post_id;
+
+	/**
+	 * A private post owned by another user.
+	 *
+	 * @var int
+	 */
+	private int $other_users_private_post_id;
+
+	/**
+	 * A scheduled post owned by another user.
+	 *
+	 * @var int
+	 */
+	private int $other_users_scheduled_post_id;
+
+	/**
+	 * A private post owned by the current user.
+	 *
+	 * @var int
+	 */
+	private int $own_private_post_id;
 
 	/**
 	 * Sets up the test environment.
@@ -102,7 +124,76 @@ class EndpointSmartLinkingAuthorizationTest extends TestCase {
 		);
 		$this->other_users_post_id = $other_users_post_id;
 
+		// Non-public posts get a slug generated from their title, which makes
+		// them addressable by URL. Drafts and pending posts do not.
+		$this->other_users_private_post_id = $this->create_post(
+			array(
+				'post_author' => $other_user_id,
+				'post_status' => 'private',
+				'post_title'  => 'Private by other',
+			)
+		);
+
+		$this->other_users_scheduled_post_id = $this->create_post(
+			array(
+				'post_author' => $other_user_id,
+				'post_status' => 'future',
+				'post_date'   => '2099-01-01 00:00:00',
+				'post_title'  => 'Scheduled by other',
+			)
+		);
+
+		$this->own_private_post_id = $this->create_post(
+			array(
+				'post_author' => $author_user_id,
+				'post_status' => 'private',
+				'post_title'  => 'Private by author',
+			)
+		);
+
 		wp_set_current_user( $author_user_id );
+	}
+
+	/**
+	 * Creates a post and returns its ID.
+	 *
+	 * @since 3.23.7
+	 *
+	 * @param array<string, mixed> $args The post's fields.
+	 * @return int The new post's ID.
+	 */
+	private function create_post( array $args ): int {
+		/** @var int */
+		return self::factory()->post->create( $args );
+	}
+
+	/**
+	 * Returns the post IDs that get_post_meta_for_urls() describes for the
+	 * given posts' URLs.
+	 *
+	 * @since 3.23.7
+	 *
+	 * @param int ...$post_ids The posts to request meta for.
+	 * @return array<int> The post IDs present in the response.
+	 */
+	private function get_post_meta_ids( int ...$post_ids ): array {
+		$urls = array();
+
+		foreach ( $post_ids as $post_id ) {
+			$post = get_post( $post_id );
+			self::assertInstanceOf( WP_Post::class, $post );
+			self::assertNotSame( '', $post->post_name, 'Fixture is wrong: the post has no slug.' );
+
+			$urls[] = home_url( '/' . $post->post_name . '/' );
+		}
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'urls', $urls );
+
+		/** @var array{data: array<array{id: int}>} $data */
+		$data = $this->endpoint->get_post_meta_for_urls( $request )->get_data();
+
+		return array_column( $data['data'], 'id' );
 	}
 
 	/**
@@ -188,6 +279,74 @@ class EndpointSmartLinkingAuthorizationTest extends TestCase {
 				$this->get_request( $this->other_users_post_id )
 			),
 			'An Editor should retain Smart Linking access to another user\'s post.'
+		);
+	}
+
+	/**
+	 * Verifies that get_post_meta_for_urls() does not describe another user's
+	 * non-public posts.
+	 *
+	 * The route takes URLs rather than post IDs, so the permission callback's
+	 * per-post check cannot cover it. URLs resolve by slug irrespective of post
+	 * status, which makes private and scheduled posts addressable.
+	 *
+	 * @since 3.23.7
+	 *
+	 * @covers \Parsely\REST_API\Content_Helper\Endpoint_Smart_Linking::get_post_meta_for_urls
+	 * @uses \Parsely\Utils\Utils::get_post_id_by_url
+	 */
+	public function test_post_meta_omits_another_users_non_public_posts(): void {
+		self::assertFalse(
+			current_user_can( 'read_post', $this->other_users_private_post_id ),
+			'Fixture is wrong: the user can read the other user\'s private post.'
+		);
+
+		self::assertSame(
+			array(),
+			$this->get_post_meta_ids(
+				$this->other_users_private_post_id,
+				$this->other_users_scheduled_post_id
+			),
+			'Meta for another user\'s non-public posts was disclosed.'
+		);
+	}
+
+	/**
+	 * Verifies that get_post_meta_for_urls() still describes the posts the user
+	 * can read.
+	 *
+	 * Guards against the read_post check being too restrictive: linking to
+	 * other users' published posts is the feature's purpose.
+	 *
+	 * @since 3.23.7
+	 *
+	 * @covers \Parsely\REST_API\Content_Helper\Endpoint_Smart_Linking::get_post_meta_for_urls
+	 * @uses \Parsely\Utils\Utils::get_post_id_by_url
+	 */
+	public function test_post_meta_includes_readable_posts(): void {
+		self::assertSame(
+			array( $this->other_users_post_id, $this->own_private_post_id ),
+			$this->get_post_meta_ids( $this->other_users_post_id, $this->own_private_post_id ),
+			'Meta for readable posts should be returned.'
+		);
+	}
+
+	/**
+	 * Verifies that an Editor still gets meta for another user's non-public
+	 * posts, which the read_private_posts capability allows.
+	 *
+	 * @since 3.23.7
+	 *
+	 * @covers \Parsely\REST_API\Content_Helper\Endpoint_Smart_Linking::get_post_meta_for_urls
+	 * @uses \Parsely\Utils\Utils::get_post_id_by_url
+	 */
+	public function test_post_meta_includes_another_users_private_post_for_editor(): void {
+		TestCase::set_current_user_to( 'sl_meta_editor', 'editor' );
+
+		self::assertSame(
+			array( $this->other_users_private_post_id ),
+			$this->get_post_meta_ids( $this->other_users_private_post_id ),
+			'An Editor should still get meta for another user\'s private post.'
 		);
 	}
 }

--- a/tests/Integration/RestAPI/ContentHelper/EndpointTrafficBoostAuthorizationTest.php
+++ b/tests/Integration/RestAPI/ContentHelper/EndpointTrafficBoostAuthorizationTest.php
@@ -677,6 +677,127 @@ class EndpointTrafficBoostAuthorizationTest extends TestCase {
 	}
 
 	/**
+	 * Verifies that discard_suggestion does not delete the record of a link
+	 * that is applied to a source post the current user cannot edit.
+	 *
+	 * Deleting the record leaves the applied link's anchor in the source post
+	 * with nothing left to remove it by, so the check belongs here too.
+	 *
+	 * @since 3.23.7
+	 *
+	 * @covers \Parsely\REST_API\Content_Helper\Endpoint_Traffic_Boost::discard_suggestion
+	 * @uses \Parsely\Models\Inbound_Smart_Link
+	 * @uses \Parsely\Models\Smart_Link
+	 * @uses \Parsely\Permissions::current_user_can_use_pch_feature
+	 * @uses \Parsely\REST_API\Content_Helper\Endpoint_Traffic_Boost::validate_smart_link_id
+	 */
+	public function test_discard_suggestion_denies_inaccessible_source_post(): void {
+		$smart_link_id = $this->seed_applied_link( $this->private_post_id );
+
+		self::assertWPError(
+			$this->endpoint->discard_suggestion( $this->get_discard_request( $smart_link_id ) ),
+			'Discarding a link applied to an inaccessible source post should be denied.'
+		);
+
+		self::assertInstanceOf(
+			WP_Post::class,
+			get_post( $smart_link_id ),
+			'The Smart Link record should have survived the denied discard.'
+		);
+	}
+
+	/**
+	 * Verifies that discard_suggestion still works on a source post the user
+	 * owns.
+	 *
+	 * Guards against the authorization check being too restrictive.
+	 *
+	 * @since 3.23.7
+	 *
+	 * @covers \Parsely\REST_API\Content_Helper\Endpoint_Traffic_Boost::discard_suggestion
+	 * @uses \Parsely\Models\Inbound_Smart_Link
+	 * @uses \Parsely\Models\Smart_Link
+	 * @uses \Parsely\Permissions::current_user_can_use_pch_feature
+	 * @uses \Parsely\REST_API\Content_Helper\Endpoint_Traffic_Boost::validate_smart_link_id
+	 */
+	public function test_discard_suggestion_succeeds_on_own_source_post(): void {
+		$smart_link_id = $this->seed_applied_link( $this->own_post_id );
+
+		self::assertInstanceOf(
+			WP_REST_Response::class,
+			$this->endpoint->discard_suggestion( $this->get_discard_request( $smart_link_id ) ),
+			'Discarding a link applied to an editable source post should succeed.'
+		);
+
+		self::assertNull(
+			get_post( $smart_link_id ),
+			'The Smart Link record should have been deleted.'
+		);
+	}
+
+	/**
+	 * Builds a discard request for the given Smart Link.
+	 *
+	 * @since 3.23.7
+	 *
+	 * @param int $smart_link_id The Smart Link's ID.
+	 * @return WP_REST_Request The request object.
+	 */
+	private function get_discard_request( int $smart_link_id ): WP_REST_Request {
+		$request = new WP_REST_Request( 'DELETE' );
+		$request->set_param( 'post_id', $this->destination_post_id );
+
+		// Mirrors the route's validate_callback, which sets the `inbound_link`
+		// param.
+		$this->endpoint->validate_smart_link_id( $smart_link_id, $request );
+
+		return $request;
+	}
+
+	/**
+	 * Seeds a Smart Link applied to the given source post, as the post's owner
+	 * would have.
+	 *
+	 * @since 3.23.7
+	 *
+	 * @param int $source_post_id The source post to apply the link to.
+	 * @return int The Smart Link's ID.
+	 */
+	private function seed_applied_link( int $source_post_id ): int {
+		$post = get_post( $source_post_id );
+		self::assertInstanceOf( WP_Post::class, $post );
+
+		$current_user_id = get_current_user_id();
+		wp_set_current_user( (int) $post->post_author );
+
+		$link = new Inbound_Smart_Link(
+			(string) get_permalink( $this->destination_post_id ),
+			'Destination post',
+			self::LINK_TEXT,
+			0,
+			$source_post_id
+		);
+		$link->set_destination_post_id( $this->destination_post_id );
+		$link->set_status( Smart_Link_Status::PENDING );
+		$link->set_context( 'traffic_boost' );
+		$link->save();
+		$link->apply();
+
+		wp_set_current_user( $current_user_id );
+
+		self::assertStringContainsString(
+			'data-smartlink',
+			$this->get_stored_content( $source_post_id ),
+			'Fixture is wrong: the link was not applied to the source post.'
+		);
+
+		/** @var array{smart_link_id: int} $link_data */
+		$link_data = $link->to_array();
+
+		return $link_data['smart_link_id'];
+	}
+
+	/**
 	 * Asserts that the full generate/accept flow succeeds for the given source
 	 * post, and that the smart link is persisted to it.
 	 *

--- a/tests/Integration/UI/RowActionsTest.php
+++ b/tests/Integration/UI/RowActionsTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Parsely\Tests\Integration\UI;
 
 use Parsely\Parsely;
+use Parsely\Permissions;
 use Parsely\Tests\Integration\TestCase;
 use Parsely\UI\Row_Actions;
 
@@ -153,6 +154,131 @@ final class RowActionsTest extends TestCase {
 		self::assertSame(
 			'<a href="' . $url . '" aria-label="' . $aria_label . '">Parse.ly&nbsp;Stats</a>',
 			$actions['find_in_parsely']
+		);
+	}
+
+	/**
+	 * Verifies that the Engagement Boost action is not offered for a post the
+	 * user cannot edit.
+	 *
+	 * The action links to a dashboard view whose REST calls are authorized per
+	 * post, so offering it here would only lead to a denied request.
+	 *
+	 * @since 3.23.7
+	 *
+	 * @covers \Parsely\UI\Row_Actions::row_actions_add_engagement_boost_link
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Permissions::current_user_can_use_pch_feature
+	 * @uses \Parsely\Permissions::get_user_roles_with_edit_posts_cap
+	 * @uses \Parsely\UI\Row_Actions::generate_aria_label_for_post
+	 * @uses \Parsely\UI\Row_Actions::generate_link_to_engagement_boost
+	 *
+	 * @group ui
+	 */
+	public function test_engagement_boost_action_is_gated_per_post(): void {
+		$this->set_engagement_boost_options();
+
+		$other_user_id = self::create_test_user( 'ra_other_user', 'administrator' );
+		$author_id     = self::create_test_user( 'ra_author', 'author' );
+
+		/** @var int $other_users_post_id */
+		$other_users_post_id = self::factory()->post->create(
+			array(
+				'post_author' => $other_user_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		/** @var int $own_post_id */
+		$own_post_id = self::factory()->post->create(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		wp_set_current_user( $author_id );
+
+		self::assertArrayNotHasKey(
+			'engagement_boost',
+			self::$row_actions->row_actions_add_engagement_boost_link(
+				array(),
+				$this->get_post( $other_users_post_id )
+			),
+			'An Author should not be offered Engagement Boost for another user\'s post.'
+		);
+
+		self::assertArrayHasKey(
+			'engagement_boost',
+			self::$row_actions->row_actions_add_engagement_boost_link(
+				array(),
+				$this->get_post( $own_post_id )
+			),
+			'An Author should be offered Engagement Boost for their own post.'
+		);
+	}
+
+	/**
+	 * Verifies that an Editor is still offered the Engagement Boost action for
+	 * another user's post, which the edit_others_posts capability allows.
+	 *
+	 * @since 3.23.7
+	 *
+	 * @covers \Parsely\UI\Row_Actions::row_actions_add_engagement_boost_link
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\Parsely::post_has_trackable_status
+	 * @uses \Parsely\Permissions::current_user_can_use_pch_feature
+	 * @uses \Parsely\Permissions::get_user_roles_with_edit_posts_cap
+	 * @uses \Parsely\UI\Row_Actions::generate_aria_label_for_post
+	 * @uses \Parsely\UI\Row_Actions::generate_link_to_engagement_boost
+	 *
+	 * @group ui
+	 */
+	public function test_engagement_boost_action_is_offered_to_editor(): void {
+		$this->set_engagement_boost_options();
+
+		$other_user_id = self::create_test_user( 'ra_eb_other_user', 'administrator' );
+
+		/** @var int $other_users_post_id */
+		$other_users_post_id = self::factory()->post->create(
+			array(
+				'post_author' => $other_user_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		self::set_current_user_to( 'ra_editor', 'editor' );
+
+		self::assertArrayHasKey(
+			'engagement_boost',
+			self::$row_actions->row_actions_add_engagement_boost_link(
+				array(),
+				$this->get_post( $other_users_post_id )
+			),
+			'An Editor should be offered Engagement Boost for another user\'s post.'
+		);
+	}
+
+	/**
+	 * Enables Engagement Boost for every role having the edit_posts capability.
+	 *
+	 * @since 3.23.7
+	 */
+	private function set_engagement_boost_options(): void {
+		self::set_options(
+			array(
+				'apikey'         => 'somekey',
+				'content_helper' => array(
+					'ai_features_enabled' => true,
+					'traffic_boost'       => array(
+						'enabled'            => true,
+						'allowed_user_roles' => array_keys(
+							Permissions::get_user_roles_with_edit_posts_cap()
+						),
+					),
+				),
+			)
 		);
 	}
 }


### PR DESCRIPTION
Fixes #4532

## Description

Three per-post authorization gaps left over after #4526.

`get_post_meta_for_urls()` is reached by URL rather than post ID, so the permission callback's per-post check never applies to it. Because `Utils::get_post_id_by_url()` resolves posts by slug without filtering status, the route described `private` and scheduled posts, and drafts that were once published. It now skips posts failing `current_user_can( 'read_post', $post_id )`.

`read_post` rather than `edit_post`, because this is a read path and linking to other users' published posts is the feature's purpose — `edit_post` would have emptied the response for Authors. Core's meta-cap mapping gives the right answer per status on its own: public posts fall to `read`, your own posts to `read`, others' private posts to `read_private_posts`, and others' non-public posts through to `edit_post`. It's also what `WP_REST_Posts_Controller` uses to gate post visibility.

`discard_suggestion()` gets the `validate_source_post_access()` guard its three siblings already have. It resolves its source post from a stored Smart Link, so the permission callback can't see it, and `validate_smart_link_id()` constrains only `destination_post_id`. The guard rather than a `PENDING` restriction: it's purely additive, so it can't alter behaviour for anyone who already has source-post access, and it makes all five mutating handlers consistent. `discard_suggestions()` (plural) needed nothing — `delete_pending_suggestions()` already filters on `PENDING`.

The Engagement Boost row action now passes `$post->ID`, the same omission #4526 fixed elsewhere.

## Motivation and context

The first is the substantive one: an Author could read titles, author names, dates and IDs of other users' private and scheduled posts. The second let an Author delete the record of a link applied to a post they cannot edit, leaving the anchor with nothing to remove it by — narrow, since an authorized user must have applied the link first, but it is a cross-user write. The third is a dead link rather than access, as the view's REST calls are already refused.

Authors are again the only role affected. Editors and Administrators hold `edit_others_posts` and `read_private_posts`, so nothing changes for them. One user-visible change worth noting for release notes: Authors will no longer see the Engagement Boost row action on posts they cannot edit.

## How has this been tested?

7 new integration tests across the two authorization test classes and `RowActionsTest`, covering both non-public statuses that are addressable by slug, and each denial paired with a positive case so an over-broad check fails the suite. Confirmed failing on `develop` and passing here.

Also verified end-to-end through `rest_get_server()->dispatch()` rather than direct handler calls, since the permission callback and `validate_callback` ordering only apply on a real dispatch. Authors get nothing for others' private, scheduled and reverted-draft posts while still getting published and their own private posts; Editors still get all of them. `discard-suggestion` returns 403 with the record intact for a foreign source post, and still succeeds on an own source post.

Integration suite run single-site and with `WP_MULTISITE=1`: 520 tests in both, with failure counts unchanged from `develop` (45 and 31 — the pre-existing `example.org` vs test-environment `home_url()` mismatches). Unit suite, PHPCS `--severity=1`, PHPStan level 9 and `composer lint` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission checks for Engagement Boost actions on individual posts.
  * Prevented access to metadata for posts users cannot read.
  * Prevented unauthorized deletion of Smart Links while allowing permitted users to discard suggestions.

* **Tests**
  * Added coverage for private, scheduled, and cross-user post access.
  * Added tests verifying post-specific action visibility and Smart Link deletion permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->