### PR TITLE
Release wp-parsely 3.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Inherit site-wide suggestion defaults per setting ([#4556](https://github.com/Parsely/wp-parsely/pull/4556))
 
-
 ## [3.24.0](https://github.com/Parsely/wp-parsely/compare/3.23.7...3.24.0) - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.24.1](https://github.com/Parsely/wp-parsely/compare/3.24.0...3.24.1) - 2026-08-26
+
+### Fixed
+
+- Inherit site-wide suggestion defaults per setting ([#4556](https://github.com/Parsely/wp-parsely/pull/4556))
+
+
 ## [3.24.0](https://github.com/Parsely/wp-parsely/compare/3.23.7...3.24.0) - 2026-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse.ly
 
-Stable tag: 3.24.0  
+Stable tag: 3.24.1  
 Requires at least: 6.1  
 Tested up to: 6.9  
 Requires PHP: 7.4  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-parsely",
-	"version": "3.24.0",
+	"version": "3.24.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-parsely",
-			"version": "3.24.0",
+			"version": "3.24.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/js-cookie": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-parsely",
-	"version": "3.24.0",
+	"version": "3.24.1",
 	"private": true,
 	"description": "The Parse.ly plugin facilitates real-time and historical analytics to your content through a platform designed and built for digital publishing.",
 	"author": "parsely, hbbtstar, jblz, mikeyarce, GaryJ, parsely_mike, acicovic, mehmoodak, vaurdan",

--- a/src/rest-api/settings/class-base-settings-endpoint.php
+++ b/src/rest-api/settings/class-base-settings-endpoint.php
@@ -373,7 +373,7 @@ abstract class Base_Settings_Endpoint extends Base_Endpoint {
 		foreach ( $this->get_inheritable_keys() as $composite_key ) {
 			$keys = explode( '.', $composite_key );
 
-			if ( $this->has_path_value( $stored, $keys ) ||
+			if ( $this->is_stored_override( $stored, $composite_key ) ||
 				$this->get_path_value( $settings, $keys ) !== $this->get_default( $keys )
 			) {
 				continue;
@@ -383,6 +383,24 @@ abstract class Base_Settings_Endpoint extends Base_Endpoint {
 		}
 
 		return $settings;
+	}
+
+	/**
+	 * Returns whether the user set the passed setting.
+	 *
+	 * A value that sanitization rejects resolves to the setting's default on
+	 * read, so treating it as set would pin the user to that default.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @param array<string, mixed> $stored        The settings as they are stored.
+	 * @param string               $composite_key The setting's composite key.
+	 * @return bool
+	 */
+	protected function is_stored_override( array $stored, string $composite_key ): bool {
+		$value = $this->get_path_value( $stored, explode( '.', $composite_key ) );
+
+		return null !== $value && $this->sanitize_subvalue( $composite_key, $value ) === $value;
 	}
 
 	/**
@@ -670,19 +688,6 @@ abstract class Base_Settings_Endpoint extends Base_Endpoint {
 		}
 
 		return $current;
-	}
-
-	/**
-	 * Returns whether the passed path holds a value.
-	 *
-	 * @since 3.24.1
-	 *
-	 * @param array<string, mixed> $settings The settings to look in.
-	 * @param array<string>        $keys     The path to the setting.
-	 * @return bool
-	 */
-	protected function has_path_value( array $settings, array $keys ): bool {
-		return null !== $this->get_path_value( $settings, $keys );
 	}
 
 	/**

--- a/src/rest-api/settings/class-base-settings-endpoint.php
+++ b/src/rest-api/settings/class-base-settings-endpoint.php
@@ -27,6 +27,16 @@ use WP_Error;
  */
 abstract class Base_Settings_Endpoint extends Base_Endpoint {
 	/**
+	 * The format that stored settings are expected to be in. Recorded per user,
+	 * and bumped whenever stored values need converting.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @var int
+	 */
+	protected const STORED_FORMAT_VERSION = 1;
+
+	/**
 	 * The meta entry's default value. Initialized in the constructor.
 	 *
 	 * @since 3.13.0
@@ -76,6 +86,35 @@ abstract class Base_Settings_Endpoint extends Base_Endpoint {
 	 * @return array<string, Subvalue_Spec>
 	 */
 	abstract protected function get_subvalues_specs(): array;
+
+	/**
+	 * Returns the composite keys of the settings that inherit their default.
+	 *
+	 * These are stored only once the user deviates from the default, so that a
+	 * later change to it still reaches users who never set them.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @return array<string> The composite keys.
+	 */
+	protected function get_inheritable_keys(): array {
+		return array();
+	}
+
+	/**
+	 * Returns the defaults that inheritable settings had before they became
+	 * inheritable, keyed by composite key.
+	 *
+	 * A stored value matching one of these was written when the setting had no
+	 * configurable default, so it cannot be told apart from an untouched one.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @return array<string, mixed> The defaults, as composite key => value pairs.
+	 */
+	protected function get_legacy_defaults(): array {
+		return array();
+	}
 
 	/**
 	 * Constructor.
@@ -175,15 +214,14 @@ abstract class Base_Settings_Endpoint extends Base_Endpoint {
 	 * @since 3.17.0
 	 * @since 3.24.0 The stored value is resolved against the current
 	 *               specifications.
+	 * @since 3.24.1 A stored value predating the current format is normalized
+	 *               and stored anew.
 	 *
 	 * @return WP_REST_Response The response object.
 	 */
 	public function get_settings(): WP_REST_Response {
-		$meta_key = $this->get_meta_key();
-		$settings = get_user_meta( $this->current_user_id, $meta_key, true );
-
 		return new WP_REST_Response(
-			$this->sanitize_value( is_array( $settings ) ? $settings : array() ),
+			$this->sanitize_value( $this->get_stored_settings() ),
 			200
 		);
 	}
@@ -193,7 +231,12 @@ abstract class Base_Settings_Endpoint extends Base_Endpoint {
 	 *
 	 * Updates the settings for the current user.
 	 *
+	 * Settings absent from the request keep their current value, rather than
+	 * being reset to their default.
+	 *
 	 * @since 3.17.0
+	 * @since 3.24.1 The request is merged into the current settings, and
+	 *               inheritable settings are stored only once set.
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error The response object.
@@ -209,18 +252,21 @@ abstract class Base_Settings_Endpoint extends Base_Endpoint {
 			);
 		}
 
-		$sanitized_value = $this->sanitize_value( $meta_value );
+		$stored_settings  = $this->get_stored_settings();
+		$current_settings = $this->sanitize_value( $stored_settings );
+		$sanitized_value  = $this->sanitize_value(
+			$this->merge_settings( $meta_value, $current_settings )
+		);
 
 		// If the current settings are the same as the new settings, return early.
-		$current_settings = $this->get_settings();
-		if ( $current_settings->get_data() === $sanitized_value ) {
-			return $current_settings;
+		if ( $current_settings === $sanitized_value ) {
+			return new WP_REST_Response( $current_settings, 200 );
 		}
 
 		$update_meta = update_user_meta(
 			$this->current_user_id,
 			$this->get_meta_key(),
-			$sanitized_value
+			$this->strip_inherited_values( $sanitized_value, $stored_settings )
 		);
 
 		if ( false === $update_meta ) {
@@ -230,7 +276,142 @@ abstract class Base_Settings_Endpoint extends Base_Endpoint {
 			);
 		}
 
+		$this->record_stored_format();
+
 		return new WP_REST_Response( $sanitized_value, 200 );
+	}
+
+	/**
+	 * Returns the current user's stored settings, normalizing them first if
+	 * they were stored in an earlier format.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @return array<string, mixed> The stored settings.
+	 */
+	protected function get_stored_settings(): array {
+		$settings = get_user_meta( $this->current_user_id, $this->get_meta_key(), true );
+		$settings = is_array( $settings ) ? $settings : array();
+
+		return $this->needs_normalizing( $settings )
+			? $this->normalize_stored_settings( $settings )
+			: $settings;
+	}
+
+	/**
+	 * Returns whether the passed stored settings need normalizing before use.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @param array<string, mixed> $settings The stored settings.
+	 * @return bool
+	 */
+	protected function needs_normalizing( array $settings ): bool {
+		if ( 0 === count( $settings ) || 0 === count( $this->get_inheritable_keys() ) ) {
+			return false;
+		}
+
+		$format = get_user_meta( $this->current_user_id, $this->get_format_meta_key(), true );
+
+		return static::STORED_FORMAT_VERSION !== ( is_numeric( $format ) ? (int) $format : 0 );
+	}
+
+	/**
+	 * Drops the stored inheritable settings that cannot be told apart from an
+	 * untouched default, and stores the result.
+	 *
+	 * A value matching the setting's current default was stored by a full-tree
+	 * save; one matching its legacy default was stored when the setting had no
+	 * configurable default. Neither expresses a choice.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @param array<string, mixed> $settings The stored settings.
+	 * @return array<string, mixed> The normalized settings.
+	 */
+	protected function normalize_stored_settings( array $settings ): array {
+		$legacy_defaults = $this->get_legacy_defaults();
+
+		foreach ( $this->get_inheritable_keys() as $composite_key ) {
+			$keys  = explode( '.', $composite_key );
+			$value = $this->get_path_value( $settings, $keys );
+
+			if ( null === $value ) {
+				continue;
+			}
+
+			$defaults = array( $this->get_default( $keys ) );
+			if ( array_key_exists( $composite_key, $legacy_defaults ) ) {
+				$defaults[] = $legacy_defaults[ $composite_key ];
+			}
+
+			if ( in_array( $value, $defaults, true ) ) {
+				$this->unset_path_value( $settings, $keys );
+			}
+		}
+
+		update_user_meta( $this->current_user_id, $this->get_meta_key(), $settings );
+		$this->record_stored_format();
+
+		return $settings;
+	}
+
+	/**
+	 * Removes the inheritable settings that the user has not set, so that they
+	 * keep following their default.
+	 *
+	 * A setting counts as set once it is stored, so that a choice is not undone
+	 * by a later change to the default that happens to match it.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @param array<string, mixed> $settings The settings about to be stored.
+	 * @param array<string, mixed> $stored   The settings as they are stored.
+	 * @return array<string, mixed> The settings to store.
+	 */
+	protected function strip_inherited_values( array $settings, array $stored ): array {
+		foreach ( $this->get_inheritable_keys() as $composite_key ) {
+			$keys = explode( '.', $composite_key );
+
+			if ( $this->has_path_value( $stored, $keys ) ||
+				$this->get_path_value( $settings, $keys ) !== $this->get_default( $keys )
+			) {
+				continue;
+			}
+
+			$this->unset_path_value( $settings, $keys );
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Records that the current user's settings are stored in the current
+	 * format.
+	 *
+	 * @since 3.24.1
+	 */
+	protected function record_stored_format(): void {
+		if ( 0 === count( $this->get_inheritable_keys() ) ) {
+			return;
+		}
+
+		update_user_meta(
+			$this->current_user_id,
+			$this->get_format_meta_key(),
+			static::STORED_FORMAT_VERSION
+		);
+	}
+
+	/**
+	 * Returns the key of the meta entry holding the stored format's version.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @return string The meta entry's key.
+	 */
+	protected function get_format_meta_key(): string {
+		return $this->get_meta_key() . '_format';
 	}
 
 	/**
@@ -296,6 +477,58 @@ abstract class Base_Settings_Endpoint extends Base_Endpoint {
 		}
 
 		return $sanitized_value;
+	}
+
+	/**
+	 * Merges the passed settings into the current ones.
+	 *
+	 * Recursion follows the specifications, so that a setting holding a list of
+	 * values is replaced rather than merged into.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @param array<string, mixed> $settings   The settings to merge in.
+	 * @param array<string, mixed> $current    The settings to merge into.
+	 * @param string               $parent_key The parent key for the current level of the settings.
+	 * @return array<string, mixed> The merged settings.
+	 */
+	protected function merge_settings(
+		array $settings,
+		array $current,
+		string $parent_key = ''
+	): array {
+		/**
+		 * Current level's specifications.
+		 *
+		 * @var array<string, Subvalue_Spec> $current_specs
+		 */
+		$current_specs = ( '' === $parent_key ) ? $this->get_subvalues_specs() : $this->get_nested_specs( $parent_key );
+
+		foreach ( $current_specs as $key => $spec ) {
+			if ( ! array_key_exists( $key, $settings ) ) {
+				continue;
+			}
+
+			$value = $settings[ $key ];
+
+			/**
+			 * Spec for the current key.
+			 *
+			 * @var array{default: mixed, values?: array<mixed>} $spec
+			 */
+			if ( is_array( $value ) && isset( $spec['values'] ) ) {
+				$current_value   = $current[ $key ] ?? null;
+				$current[ $key ] = $this->merge_settings(
+					$value,
+					is_array( $current_value ) ? $current_value : array(),
+					'' === $parent_key ? $key : $parent_key . '.' . $key
+				);
+			} else {
+				$current[ $key ] = $value;
+			}
+		}
+
+		return $current;
 	}
 
 	/**
@@ -414,5 +647,69 @@ abstract class Base_Settings_Endpoint extends Base_Endpoint {
 		}
 
 		return $specs;
+	}
+
+	/**
+	 * Returns the value held at the passed path.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @param array<string, mixed> $settings The settings to look in.
+	 * @param array<string>        $keys     The path to the setting.
+	 * @return mixed The value, or null if the path holds none.
+	 */
+	protected function get_path_value( array $settings, array $keys ) {
+		$current = $settings;
+
+		foreach ( $keys as $key ) {
+			if ( ! is_array( $current ) || ! array_key_exists( $key, $current ) ) {
+				return null;
+			}
+
+			$current = $current[ $key ];
+		}
+
+		return $current;
+	}
+
+	/**
+	 * Returns whether the passed path holds a value.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @param array<string, mixed> $settings The settings to look in.
+	 * @param array<string>        $keys     The path to the setting.
+	 * @return bool
+	 */
+	protected function has_path_value( array $settings, array $keys ): bool {
+		return null !== $this->get_path_value( $settings, $keys );
+	}
+
+	/**
+	 * Removes the value held at the passed path.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @param array<string, mixed> $settings The settings to remove from.
+	 * @param array<string>        $keys     The path to the setting.
+	 */
+	protected function unset_path_value( array &$settings, array $keys ): void {
+		$last_key = array_pop( $keys );
+
+		if ( null === $last_key ) {
+			return;
+		}
+
+		$current = &$settings;
+
+		foreach ( $keys as $key ) {
+			if ( ! isset( $current[ $key ] ) || ! is_array( $current[ $key ] ) ) {
+				return;
+			}
+
+			$current = &$current[ $key ];
+		}
+
+		unset( $current[ $last_key ] );
 	}
 }

--- a/src/rest-api/settings/class-endpoint-editor-sidebar-settings.php
+++ b/src/rest-api/settings/class-endpoint-editor-sidebar-settings.php
@@ -175,6 +175,47 @@ class Endpoint_Editor_Sidebar_Settings extends Base_Settings_Endpoint {
 	}
 
 	/**
+	 * Returns the composite keys of the settings that inherit their default.
+	 *
+	 * These are the settings whose default the plugin's settings page makes
+	 * configurable.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @return array<string> The composite keys.
+	 */
+	protected function get_inheritable_keys(): array {
+		return array(
+			'ExcerptSuggestions.Length',
+			'ExcerptSuggestions.Persona',
+			'ExcerptSuggestions.Tone',
+			'TitleSuggestions.Persona',
+			'TitleSuggestions.Tone',
+		);
+	}
+
+	/**
+	 * Returns the defaults that the inheritable settings had before 3.24.0 made
+	 * them configurable.
+	 *
+	 * Spelled out rather than taken from Suggestion_Defaults, whose constants
+	 * describe the present rather than the past. `Length` is absent, as it did
+	 * not exist before it became configurable.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @return array<string, mixed> The defaults, as composite key => value pairs.
+	 */
+	protected function get_legacy_defaults(): array {
+		return array(
+			'ExcerptSuggestions.Persona' => 'journalist',
+			'ExcerptSuggestions.Tone'    => 'neutral',
+			'TitleSuggestions.Persona'   => 'journalist',
+			'TitleSuggestions.Tone'      => 'neutral',
+		);
+	}
+
+	/**
 	 * Sanitizes the passed subvalue.
 	 *
 	 * Extends the parent implementation with a range check for the desired

--- a/tests/Integration/RestAPI/Settings/EndpointEditorSidebarSettingsTest.php
+++ b/tests/Integration/RestAPI/Settings/EndpointEditorSidebarSettingsTest.php
@@ -814,6 +814,74 @@ class EndpointEditorSidebarSettingsTest extends BaseSettingsEndpointTest {
 	}
 
 	/**
+	 * Verifies that a stored value which sanitization rejects does not count as
+	 * a setting the user has set.
+	 *
+	 * Such a value is resolved to the setting's default on read, and the sidebar
+	 * sends that default straight back.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @covers \Parsely\REST_API\Settings\Base_Settings_Endpoint::is_stored_override
+	 * @covers \Parsely\REST_API\Settings\Base_Settings_Endpoint::strip_inherited_values
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_length
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_persona
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_tone
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_feature_options
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_personas
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_tones
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\REST_API\Base_API_Controller::__construct
+	 * @uses \Parsely\REST_API\Base_API_Controller::get_parsely
+	 * @uses \Parsely\REST_API\Base_API_Controller::init
+	 * @uses \Parsely\REST_API\Base_Endpoint::__construct
+	 * @uses \Parsely\REST_API\Base_Endpoint::init
+	 * @uses \Parsely\REST_API\Base_Endpoint::is_available_to_current_user
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::__construct
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_default
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_settings
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_stored_settings
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_valid_values
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::init
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::merge_settings
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::register_routes
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::sanitize_value
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::set_settings
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_endpoint_name
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_inheritable_keys
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_legacy_defaults
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_meta_key
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_subvalues_specs
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::sanitize_subvalue
+	 */
+	public function test_a_rejected_stored_value_is_not_treated_as_set(): void {
+		$this->set_current_user_to_admin();
+		$this->set_suggestion_defaults( array( 'default_length' => 220 ) );
+
+		// An out-of-range length, which get_settings() repairs to the site's.
+		update_user_meta(
+			get_current_user_id(),
+			'parsely_content_helper_settings_editor_sidebar',
+			array( 'ExcerptSuggestions' => array( 'Length' => 99999 ) )
+		);
+
+		$endpoint = $this->get_initialized_endpoint();
+		$settings = $this->get_endpoint_settings( $endpoint );
+		assert( is_array( $settings['ExcerptSuggestions'] ) );
+		self::assertSame( 220, $settings['ExcerptSuggestions']['Length'] );
+
+		// The author saves an unrelated setting, sending the repaired value back.
+		$settings['InitialTabName'] = 'performance';
+		$this->send_endpoint_put_request( $endpoint, $settings );
+
+		$this->set_suggestion_defaults( array( 'default_length' => 90 ) );
+		$value = $this->get_endpoint_settings( $this->get_initialized_endpoint() );
+
+		assert( is_array( $value['ExcerptSuggestions'] ) );
+		self::assertSame( 90, $value['ExcerptSuggestions']['Length'] );
+	}
+
+	/**
 	 * Stores the passed site-wide generation defaults.
 	 *
 	 * @since 3.24.1

--- a/tests/Integration/RestAPI/Settings/EndpointEditorSidebarSettingsTest.php
+++ b/tests/Integration/RestAPI/Settings/EndpointEditorSidebarSettingsTest.php
@@ -13,6 +13,8 @@ namespace Parsely\Tests\Integration\RestAPI\Settings;
 use Parsely\Content_Helper\Suggestion_Defaults;
 use Parsely\REST_API\Content_Helper\Content_Helper_Controller;
 use Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * Integration tests for the Endpoint_Editor_Sidebar_Settings class.
@@ -377,12 +379,17 @@ class EndpointEditorSidebarSettingsTest extends BaseSettingsEndpointTest {
 	 * Verifies that a stored value saved before a setting existed is resolved
 	 * against the current specifications, rather than returned as it stands.
 	 *
-	 * Users who saved settings before 3.24.0 have no `Length`, and their
-	 * `ExcerptSuggestions` still carries the `Open` setting that was removed.
+	 * Users who saved settings before 3.24.0 have no `Length`, their
+	 * `ExcerptSuggestions` still carries the `Open` setting that was removed,
+	 * and their tone and persona hold the defaults of the day.
 	 *
 	 * @since 3.24.0
+	 * @since 3.24.1 The stored legacy tone and persona take the site's defaults.
 	 *
 	 * @covers \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_settings
+	 * @covers \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_stored_settings
+	 * @covers \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_inheritable_keys
+	 * @covers \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_legacy_defaults
 	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_length
 	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_persona
 	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_tone
@@ -431,12 +438,11 @@ class EndpointEditorSidebarSettingsTest extends BaseSettingsEndpointTest {
 
 		assert( is_array( $value ) && is_array( $value['ExcerptSuggestions'] ) );
 
-		// The site's length reaches the user, rather than the shipped default.
+		// The site's defaults reach the user: the stored tone and persona are
+		// the defaults of the day, so they express no choice to preserve.
 		self::assertSame( 220, $value['ExcerptSuggestions']['Length'] );
-
-		// The user's own choices stand.
-		self::assertSame( 'journalist', $value['ExcerptSuggestions']['Persona'] );
-		self::assertSame( 'neutral', $value['ExcerptSuggestions']['Tone'] );
+		self::assertSame( 'techAnalyst', $value['ExcerptSuggestions']['Persona'] );
+		self::assertSame( 'analytical', $value['ExcerptSuggestions']['Tone'] );
 
 		// The removed setting is dropped.
 		self::assertArrayNotHasKey( 'Open', $value['ExcerptSuggestions'] );
@@ -509,6 +515,398 @@ class EndpointEditorSidebarSettingsTest extends BaseSettingsEndpointTest {
 			Suggestion_Defaults::DEFAULT_LENGTH,
 			$value['ExcerptSuggestions']['Length']
 		);
+	}
+
+	/**
+	 * Verifies that a site-wide default keeps reaching a setting that the user
+	 * has never set, even after saving other settings.
+	 *
+	 * The Editor Sidebar sends the whole settings tree on every change, so the
+	 * defaults it was served come back as if they had been chosen.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @covers \Parsely\REST_API\Settings\Base_Settings_Endpoint::set_settings
+	 * @covers \Parsely\REST_API\Settings\Base_Settings_Endpoint::strip_inherited_values
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_length
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_persona
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_tone
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_feature_options
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_personas
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_tones
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\REST_API\Base_API_Controller::__construct
+	 * @uses \Parsely\REST_API\Base_API_Controller::get_parsely
+	 * @uses \Parsely\REST_API\Base_API_Controller::init
+	 * @uses \Parsely\REST_API\Base_Endpoint::__construct
+	 * @uses \Parsely\REST_API\Base_Endpoint::init
+	 * @uses \Parsely\REST_API\Base_Endpoint::is_available_to_current_user
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::__construct
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_default
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_settings
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_stored_settings
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_valid_values
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::init
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::merge_settings
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::register_routes
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::sanitize_value
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_endpoint_name
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_inheritable_keys
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_meta_key
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_subvalues_specs
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::sanitize_subvalue
+	 */
+	public function test_an_unset_setting_keeps_following_the_site_default(): void {
+		$this->set_current_user_to_admin();
+		$this->set_suggestion_defaults(
+			array(
+				'default_persona' => 'techAnalyst',
+				'default_tone'    => 'analytical',
+			),
+			array(
+				'default_persona' => 'businessAnalyst',
+				'default_tone'    => 'serious',
+			)
+		);
+
+		// Save an unrelated setting, sending the whole tree as the sidebar does.
+		$endpoint = $this->get_initialized_endpoint();
+		$settings = $this->get_endpoint_settings( $endpoint );
+
+		$settings['InitialTabName'] = 'performance';
+		$this->send_endpoint_put_request( $endpoint, $settings );
+
+		// The tab is stored, but the defaults that came along with it are not.
+		$stored         = $this->get_stored_settings();
+		$stored_excerpt = $stored['ExcerptSuggestions'] ?? array();
+		$stored_title   = $stored['TitleSuggestions'] ?? array();
+		assert( is_array( $stored_excerpt ) && is_array( $stored_title ) );
+
+		self::assertSame( 'performance', $stored['InitialTabName'] ?? null );
+		self::assertArrayNotHasKey( 'Persona', $stored_excerpt );
+		self::assertArrayNotHasKey( 'Tone', $stored_excerpt );
+		self::assertArrayNotHasKey( 'Persona', $stored_title );
+		self::assertArrayNotHasKey( 'Tone', $stored_title );
+
+		$this->set_suggestion_defaults(
+			array(
+				'default_persona' => 'journalist',
+				'default_tone'    => 'humorous',
+			),
+			array(
+				'default_persona' => 'politicalAnalyst',
+				'default_tone'    => 'skeptical',
+			)
+		);
+		$value = $this->get_endpoint_settings( $this->get_initialized_endpoint() );
+
+		assert( is_array( $value['ExcerptSuggestions'] ) && is_array( $value['TitleSuggestions'] ) );
+		self::assertSame( 'journalist', $value['ExcerptSuggestions']['Persona'] );
+		self::assertSame( 'humorous', $value['ExcerptSuggestions']['Tone'] );
+		self::assertSame( 'politicalAnalyst', $value['TitleSuggestions']['Persona'] );
+		self::assertSame( 'skeptical', $value['TitleSuggestions']['Tone'] );
+		self::assertSame( 'performance', $value['InitialTabName'] );
+	}
+
+	/**
+	 * Verifies that a setting the user has set is not moved by a later change
+	 * to the site-wide default, including one that moves onto their value.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @covers \Parsely\REST_API\Settings\Base_Settings_Endpoint::set_settings
+	 * @covers \Parsely\REST_API\Settings\Base_Settings_Endpoint::strip_inherited_values
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_length
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_persona
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_tone
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_feature_options
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_personas
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_tones
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\REST_API\Base_API_Controller::__construct
+	 * @uses \Parsely\REST_API\Base_API_Controller::get_parsely
+	 * @uses \Parsely\REST_API\Base_API_Controller::init
+	 * @uses \Parsely\REST_API\Base_Endpoint::__construct
+	 * @uses \Parsely\REST_API\Base_Endpoint::init
+	 * @uses \Parsely\REST_API\Base_Endpoint::is_available_to_current_user
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::__construct
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_default
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_settings
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_stored_settings
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_valid_values
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::init
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::merge_settings
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::register_routes
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::sanitize_value
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_endpoint_name
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_inheritable_keys
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_meta_key
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_subvalues_specs
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::sanitize_subvalue
+	 */
+	public function test_a_set_setting_is_not_moved_by_the_site_default(): void {
+		$this->set_current_user_to_admin();
+		$this->set_suggestion_defaults( array( 'default_tone' => 'analytical' ) );
+
+		$endpoint = $this->get_initialized_endpoint();
+		$settings = $this->get_endpoint_settings( $endpoint );
+		assert( is_array( $settings['ExcerptSuggestions'] ) );
+
+		$settings['ExcerptSuggestions']['Tone'] = 'formal';
+		$this->send_endpoint_put_request( $endpoint, $settings );
+
+		// The site's default moves onto the user's choice, and they then save
+		// an unrelated setting. Their choice must not dissolve into the default.
+		$this->set_suggestion_defaults( array( 'default_tone' => 'formal' ) );
+		$endpoint = $this->get_initialized_endpoint();
+		$settings = $this->get_endpoint_settings( $endpoint );
+
+		$settings['InitialTabName'] = 'performance';
+		$this->send_endpoint_put_request( $endpoint, $settings );
+
+		$this->set_suggestion_defaults( array( 'default_tone' => 'humorous' ) );
+		$value = $this->get_endpoint_settings( $this->get_initialized_endpoint() );
+
+		assert( is_array( $value['ExcerptSuggestions'] ) );
+		self::assertSame( 'formal', $value['ExcerptSuggestions']['Tone'] );
+	}
+
+	/**
+	 * Verifies that settings absent from a PUT request keep their value, rather
+	 * than being reset to their default.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @covers \Parsely\REST_API\Settings\Base_Settings_Endpoint::merge_settings
+	 * @covers \Parsely\REST_API\Settings\Base_Settings_Endpoint::set_settings
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_length
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_persona
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_tone
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_feature_options
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_personas
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_tones
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\REST_API\Base_API_Controller::__construct
+	 * @uses \Parsely\REST_API\Base_API_Controller::get_parsely
+	 * @uses \Parsely\REST_API\Base_API_Controller::init
+	 * @uses \Parsely\REST_API\Base_Endpoint::__construct
+	 * @uses \Parsely\REST_API\Base_Endpoint::init
+	 * @uses \Parsely\REST_API\Base_Endpoint::is_available_to_current_user
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::__construct
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_default
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_nested_specs
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_settings
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_stored_settings
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_valid_values
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::init
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::register_routes
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::sanitize_value
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::strip_inherited_values
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_endpoint_name
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_inheritable_keys
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_meta_key
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_subvalues_specs
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::sanitize_subvalue
+	 */
+	public function test_settings_absent_from_a_put_request_keep_their_value(): void {
+		$this->set_current_user_to_admin();
+		update_user_meta(
+			get_current_user_id(),
+			'parsely_content_helper_settings_editor_sidebar',
+			array(
+				'PerformanceStats' => array( 'VisibleDataPoints' => array( 'views' ) ),
+				'RelatedPosts'     => array( 'Period' => '30d' ),
+				'SmartLinking'     => array( 'MaxLinks' => 25 ),
+			)
+		);
+
+		$value = $this->send_endpoint_put_request(
+			$this->get_initialized_endpoint(),
+			array( 'InitialTabName' => 'performance' )
+		);
+
+		assert(
+			is_array( $value['PerformanceStats'] ) &&
+			is_array( $value['RelatedPosts'] ) &&
+			is_array( $value['SmartLinking'] )
+		);
+
+		self::assertSame( 'performance', $value['InitialTabName'] );
+		self::assertSame( '30d', $value['RelatedPosts']['Period'] );
+		self::assertSame( 25, $value['SmartLinking']['MaxLinks'] );
+
+		// A setting holding a list is replaced rather than merged into.
+		self::assertSame( array( 'views' ), $value['PerformanceStats']['VisibleDataPoints'] );
+	}
+
+	/**
+	 * Verifies that stored settings are normalized only once, so that a choice
+	 * matching a later site-wide default is not mistaken for an untouched one.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @covers \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_stored_settings
+	 * @covers \Parsely\REST_API\Settings\Base_Settings_Endpoint::normalize_stored_settings
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_length
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_persona
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_default_tone
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_feature_options
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_personas
+	 * @uses \Parsely\Content_Helper\Suggestion_Defaults::get_tones
+	 * @uses \Parsely\Parsely::get_options
+	 * @uses \Parsely\REST_API\Base_API_Controller::__construct
+	 * @uses \Parsely\REST_API\Base_API_Controller::get_parsely
+	 * @uses \Parsely\REST_API\Base_API_Controller::init
+	 * @uses \Parsely\REST_API\Base_Endpoint::__construct
+	 * @uses \Parsely\REST_API\Base_Endpoint::init
+	 * @uses \Parsely\REST_API\Base_Endpoint::is_available_to_current_user
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::__construct
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_default
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_settings
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::get_valid_values
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::init
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::register_routes
+	 * @uses \Parsely\REST_API\Settings\Base_Settings_Endpoint::sanitize_value
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_endpoint_name
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_inheritable_keys
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_legacy_defaults
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_meta_key
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::get_subvalues_specs
+	 * @uses \Parsely\REST_API\Settings\Endpoint_Editor_Sidebar_Settings::sanitize_subvalue
+	 */
+	public function test_stored_settings_are_normalized_only_once(): void {
+		$this->set_current_user_to_admin();
+		$this->set_suggestion_defaults(
+			array(
+				'default_persona' => 'techAnalyst',
+				'default_tone'    => 'analytical',
+			)
+		);
+
+		// A pre-3.24.0 value holding a real choice alongside a legacy default.
+		update_user_meta(
+			get_current_user_id(),
+			'parsely_content_helper_settings_editor_sidebar',
+			array(
+				'ExcerptSuggestions' => array(
+					'Persona' => 'journalist',
+					'Tone'    => 'formal',
+				),
+			)
+		);
+
+		$value = $this->get_endpoint_settings( $this->get_initialized_endpoint() );
+		assert( is_array( $value['ExcerptSuggestions'] ) );
+
+		self::assertSame( 'formal', $value['ExcerptSuggestions']['Tone'] );
+		self::assertSame( 'techAnalyst', $value['ExcerptSuggestions']['Persona'] );
+
+		// Normalizing again would drop the choice, as it now matches the site's
+		// default. A later change to that default must still not move the user.
+		$this->set_suggestion_defaults( array( 'default_tone' => 'formal' ) );
+		$this->get_endpoint_settings( $this->get_initialized_endpoint() );
+
+		$this->set_suggestion_defaults( array( 'default_tone' => 'humorous' ) );
+		$value = $this->get_endpoint_settings( $this->get_initialized_endpoint() );
+
+		assert( is_array( $value['ExcerptSuggestions'] ) );
+		self::assertSame( 'formal', $value['ExcerptSuggestions']['Tone'] );
+	}
+
+	/**
+	 * Stores the passed site-wide generation defaults.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @param array<string, mixed> $excerpt_options The Excerpt Suggestions options.
+	 * @param array<string, mixed> $title_options   The Title Suggestions options.
+	 */
+	private function set_suggestion_defaults(
+		array $excerpt_options,
+		array $title_options = array()
+	): void {
+		$options                   = self::DEFAULT_OPTIONS;
+		$options['content_helper'] = array(
+			'excerpt_suggestions' => $excerpt_options,
+			'title_suggestions'   => $title_options,
+		);
+
+		update_option( \Parsely\Parsely::OPTIONS_KEY, $options );
+	}
+
+	/**
+	 * Returns an endpoint built against the site's current options, as a real
+	 * request would, with the current user set.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @return Endpoint_Editor_Sidebar_Settings The endpoint.
+	 */
+	private function get_initialized_endpoint(): Endpoint_Editor_Sidebar_Settings {
+		$endpoint = new Endpoint_Editor_Sidebar_Settings( $this->api_controller );
+		$endpoint->init();
+
+		return $endpoint;
+	}
+
+	/**
+	 * Returns the settings that the passed endpoint responds with.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @param Endpoint_Editor_Sidebar_Settings $endpoint The endpoint to query.
+	 * @return array<string, mixed> The settings.
+	 */
+	private function get_endpoint_settings(
+		Endpoint_Editor_Sidebar_Settings $endpoint
+	): array {
+		$value = $endpoint->get_settings()->get_data();
+		assert( is_array( $value ) );
+
+		return $value;
+	}
+
+	/**
+	 * Sends a PUT request to the passed endpoint.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @param Endpoint_Editor_Sidebar_Settings $endpoint The endpoint to send to.
+	 * @param array<string, mixed>             $data     The settings to send.
+	 * @return array<string, mixed> The settings the endpoint responds with.
+	 */
+	private function send_endpoint_put_request(
+		Endpoint_Editor_Sidebar_Settings $endpoint,
+		array $data
+	): array {
+		$request = new WP_REST_Request( 'PUT', '/' );
+		$request->set_body( $this->wp_json_encode( $data ) );
+		$request->set_header( 'content-type', 'application/json' );
+
+		$response = $endpoint->set_settings( $request );
+		self::assertInstanceOf( WP_REST_Response::class, $response );
+
+		$value = $response->get_data();
+		assert( is_array( $value ) );
+
+		return $value;
+	}
+
+	/**
+	 * Returns the current user's stored settings, as they are stored.
+	 *
+	 * @since 3.24.1
+	 *
+	 * @return array<string, mixed> The stored settings.
+	 */
+	private function get_stored_settings(): array {
+		$settings = get_user_meta(
+			get_current_user_id(),
+			'parsely_content_helper_settings_editor_sidebar',
+			true
+		);
+
+		return is_array( $settings ) ? $settings : array();
 	}
 
 	/**

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,7 +8,7 @@ import { type Page } from '@playwright/test';
  */
 import { Admin } from '@wordpress/e2e-test-utils-playwright';
 
-export const PLUGIN_VERSION = '3.24.0';
+export const PLUGIN_VERSION = '3.24.1';
 export const VALID_SITE_ID = 'demoaccount.parsely.com';
 export const INVALID_SITE_ID = 'invalid.parsely.com';
 export const VALID_API_SECRET = 'valid_api_secret';

--- a/wp-parsely.php
+++ b/wp-parsely.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Parse.ly
  * Plugin URI:        https://docs.parse.ly/wordpress
  * Description:       This plugin makes it a snap to add Parse.ly tracking code and metadata to your WordPress blog.
- * Version:           3.24.0
+ * Version:           3.24.1
  * Author:            Parse.ly
  * Author URI:        https://www.parse.ly
  * Text Domain:       wp-parsely
@@ -50,7 +50,7 @@ if ( class_exists( Parsely::class ) ) {
 	return;
 }
 
-const PARSELY_VERSION             = '3.24.0';
+const PARSELY_VERSION             = '3.24.1';
 const PARSELY_FILE                = __FILE__;
 const PARSELY_DATA_SCHEMA_VERSION = '1';
 const PARSELY_CACHE_GROUP         = 'wp-parsely';


### PR DESCRIPTION
This PR merges the `develop` branch into the `trunk` branch in order to release wp-parsely 3.24.1.